### PR TITLE
eliminate reference to nonexistent `object`

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -192,7 +192,7 @@ proj_coef_helper <- function(proj, fun) {
         b <- proj$beta
         if(NROW(b) == 0) return(0)
         rownames(b) <- proj$ind_names
-        if(object$proj$intercept) {
+        if(proj$intercept) {
             b <- rbind(proj$alpha, b)
             rownames(b)[1] <- '(Intercept)'
         }


### PR DESCRIPTION
The Gaussian example in README currently does not run because `proj_coef_helper` tries to access `object` which does not exist. With this PR, the example works again.