### PR TITLE
Fix the error message if an unknown cv_method is specified

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -90,7 +90,7 @@ cv_varsel <- function(fit,  method = NULL, cv_method = NULL,
 		sel_cv <- loo_varsel(refmodel, method, nv_max, ns, nc, nspred, ncpred, relax, intercept, penalty, 
 		                     verbose, opt, nloo = nloo, validate_search = validate_search, seed = seed)
 	} else {
-		stop(sprintf('Unknown cross-validation method: %s.', method))
+               stop(sprintf('Unknown cross-validation method: %s.', cv_method))
 	}
 	
 	# run the selection using the full dataset


### PR DESCRIPTION
I stumbled into this by chance:
```
> cvs <- cv_varsel(fit, cv_method="k-fold")
Error in cv_varsel(fit, cv_method = "k-fold") :
  Unknown cross-validation method: L1.
```