### PR TITLE
Check the method argument in parseargs_varsel() instead of select()

### DIFF
--- a/R/varsel.R
+++ b/R/varsel.R
@@ -167,8 +167,6 @@ select <- function(method, p_sel, d_train, family_kl, intercept, nv_max,
       searchpath <- list(vind=vind, p_sel=p_sel)
       return(searchpath)
     }
-  } else {
-    stop(sprintf('Unknown search method: %s.', method))
   }
 }
 
@@ -189,6 +187,8 @@ parseargs_varsel <- function(refmodel, method, relax, intercept, nv_max, nc, ns,
       method <- 'forward'
     else
       method <- 'L1'
+  } else if (!tolower(method) %in% c('forward', 'l1')) {
+    stop(sprintf('Unknown search method: %s.', method))
   }
   
   if (is.null(relax)) {


### PR DESCRIPTION
This avoids some unnecessary work (such as the calls to `.get_traindata()` and `.get_refdist()`) if the method passed is neither "forward" nor "L1", so the call to `varsel()` or `cv_varsel()` will stop immediately rather than after a few seconds (or more for a large model).