### PR TITLE
standard errors from varsel_stats() for stat='rmse' not reproducible

### DIFF
--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -182,7 +182,7 @@ get_stat <- function(mu, lppd, d_test, family, stat, mu.bs=NULL, lppd.bs=NULL,
       value.se <- sd(value.bootstrap1-value.bootstrap2)
     } else {
       value <- sqrt(mean(weights*(mu-y)^2, na.rm=T))
-      value.bootstrap <- bootstrap((mu-y)^2, function(resid2) sqrt(mean(weights*resid2, na.rm=T)), b=B)
+      value.bootstrap <- bootstrap((mu-y)^2, function(resid2) sqrt(mean(weights*resid2, na.rm=T)), b=B, seed=seed)
       value.se <- sd(value.bootstrap)
     }
     


### PR DESCRIPTION
If varsel_stats() is called with options stat='rmse' and delta=FALSE, the computation of the standard errors via bootstrap would not be exactly reproducible because the random seed is not set.