### PR TITLE
add AUC as option to varsel_stats() 

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -221,6 +221,7 @@ proj_predict <- function(object, xnew, offsetnew = NULL, weightsnew = NULL,
 #'  \item{mse:} {Mean squared error (gaussian family only)}
 #'  \item{rmse:} {Root mean squared error (gaussian family only)}
 #'  \item{acc/pctcorr:} {Classification accuracy (binomial family only)}
+#'  \item{auc:} {Area under the ROC curve (binomial family only)}
 #' }
 #' Default is elpd.
 #' @param type One or more items from 'mean', 'se', 'lower' and 'upper' indicating which of these to

--- a/R/misc.R
+++ b/R/misc.R
@@ -54,15 +54,17 @@ bootstrap <- function(x, fun=mean, b=1000, oobfun=NULL, seed=NULL, ...) {
   rng_state_old <- .Random.seed
   on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
   set.seed(seed)
-  
+
+  seq_x <- seq.int(NROW(x))
+  is_vector <- NCOL(x) == 1
   bsstat <- rep(NA, b)
   oobstat <- rep(NA, b)
   for (i in 1:b) {
-    bsind <- sample(seq_along(x), replace=T)
-    bsstat[i] <- fun(x[bsind], ...)
+    bsind <- sample(seq_x, replace=T)
+    bsstat[i] <- fun(if (is_vector) x[bsind] else x[bsind, ], ...)
     if (!is.null(oobfun)) {
-      oobind <- setdiff(seq_along(x), unique(bsind))
-      oobstat[i] <- oobfun(x[oobind], ...)
+      oobind <- setdiff(seq_x, unique(bsind))
+      oobstat[i] <- oobfun(if (is_vector) x[oobind] else x[oobind, ], ...)
     }
   }
   if (!is.null(oobfun)) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -43,6 +43,33 @@ log_sum_exp <- function(x) {
 	max_x + log(sum(exp(x - max_x)))
 }
 
+auc <- function(x) {
+  resp <- x[, 1]
+  pred <- x[, 2]
+  weights <- x[, 3]
+  n <- nrow(x)
+  ord <- order(pred, decreasing=TRUE)
+  resp <- resp[ord]
+  pred <- pred[ord]
+  weights <- weights[ord]
+  w0 <- w1 <- weights
+  w0[resp == 1] <- 0 # true negative weights
+  w1[resp == 0] <- 0 # true positive weights
+  cum_w0 <- cumsum(w0)
+  cum_w1 <- cumsum(w1)
+
+  ## ignore tied predicted probabilities, keeping only the rightmost one
+  rightmost.prob <- c(diff(pred) != 0, TRUE)
+  fpr <- c(0, cum_w0[rightmost.prob]) / cum_w0[n]
+  tpr <- c(0, cum_w1[rightmost.prob]) / cum_w1[n]
+  delta_fpr <- c(diff(fpr), 0)
+  delta_tpr <- c(diff(tpr), 0)
+
+  ## sum the area of the rectangles that fall completely below the ROC curve
+  ## plus half the area of the rectangles that are cut in two by the curve
+  return(sum(delta_fpr * tpr) + sum(delta_fpr * delta_tpr) / 2)
+}
+
 bootstrap <- function(x, fun=mean, b=1000, oobfun=NULL, seed=NULL, ...) {
   #
   # bootstrap an arbitrary quantity fun that takes the sample x

--- a/R/misc.R
+++ b/R/misc.R
@@ -120,8 +120,8 @@ bootstrap <- function(x, fun=mean, b=1000, oobfun=NULL, seed=NULL, ...) {
   if (!inherits(object, c('vsel', 'cvsel')))
     stop('The object is not a variable selection object. Run variable selection first')
 
-  recognized_stats <- c('elpd', 'mlpd','mse', 'rmse', 'acc', 'pctcorr')
-  binomial_only_stats <- c('acc', 'pctcorr')
+  recognized_stats <- c('elpd', 'mlpd','mse', 'rmse', 'acc', 'pctcorr', 'auc')
+  binomial_only_stats <- c('acc', 'pctcorr', 'auc')
   family <- object$family_kl$family
 
   if (is.null(stats))

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -199,6 +199,24 @@ get_stat <- function(mu, lppd, d_test, family, stat, mu.bs=NULL, lppd.bs=NULL,
       value.se <- weighted.sd(round(mu) == y, weights, na.rm=T) / sqrt(n_notna)
     }
     
+  } else if (stat == 'auc') {
+
+    if (family$family != 'binomial')
+      stop('Statistic ', stat, ' available only for binomial family.')
+    y <- d_test$y
+    auc.data <- cbind(y, mu, weights)[!is.na(mu), ]
+    if (!is.null(mu.bs)) {
+      auc.data.bs <- cbind(y, mu.bs, weights)[!is.na(mu), ]
+      value <- auc(auc.data) - auc(auc.data.bs)
+      value.bootstrap1 <- bootstrap(auc.data, auc, b=B, seed=seed)
+      value.bootstrap2 <- bootstrap(auc.data.bs, auc, b=B, seed=seed)
+      value.se <- sd(value.bootstrap1 - value.bootstrap2)
+    } else {
+      value <- auc(auc.data)
+      value.bootstrap <- bootstrap(auc.data, auc, b=B, seed=seed)
+      value.se <- sd(value.bootstrap)
+    }
+
   } else {
     stop('Unknown statistic: ', stat)
   }

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -204,17 +204,19 @@ get_stat <- function(mu, lppd, d_test, family, stat, mu.bs=NULL, lppd.bs=NULL,
     if (family$family != 'binomial')
       stop('Statistic ', stat, ' available only for binomial family.')
     y <- d_test$y
-    auc.data <- cbind(y, mu, weights)[!is.na(mu), ]
+    auc.data <- cbind(y, mu, weights)
     if (!is.null(mu.bs)) {
-      auc.data.bs <- cbind(y, mu.bs, weights)[!is.na(mu), ]
+      mu.bs[is.na(mu)] <- NA # compute the relative auc using only those points
+      mu[is.na(mu.bs)] <- NA # for which both mu and mu.bs are non-NA
+      auc.data.bs <- cbind(y, mu.bs, weights)
       value <- auc(auc.data) - auc(auc.data.bs)
       value.bootstrap1 <- bootstrap(auc.data, auc, b=B, seed=seed)
       value.bootstrap2 <- bootstrap(auc.data.bs, auc, b=B, seed=seed)
-      value.se <- sd(value.bootstrap1 - value.bootstrap2)
+      value.se <- sd(value.bootstrap1 - value.bootstrap2, na.rm=TRUE)
     } else {
       value <- auc(auc.data)
       value.bootstrap <- bootstrap(auc.data, auc, b=B, seed=seed)
-      value.se <- sd(value.bootstrap)
+      value.se <- sd(value.bootstrap, na.rm=TRUE)
     }
 
   } else {

--- a/man/varsel-statistics.Rd
+++ b/man/varsel-statistics.Rd
@@ -26,6 +26,7 @@ statistics are:
  \item{mse:} {Mean squared error (gaussian family only)}
  \item{rmse:} {Root mean squared error (gaussian family only)}
  \item{acc/pctcorr:} {Classification accuracy (binomial family only)}
+ \item{auc:} {Area under the ROC curve (binomial family only)}
 }
 Default is elpd.}
 

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -421,7 +421,7 @@ context('varsel_stats')
 
 valid_stats_all <- c('elpd', 'mlpd')
 valid_stats_gauss_only <- c('mse', 'rmse')
-valid_stats_binom_only <- c('acc')
+valid_stats_binom_only <- c('acc', 'auc')
 valid_stats_gauss <- c(valid_stats_all, valid_stats_gauss_only)
 valid_stats_binom <- c(valid_stats_all, valid_stats_binom_only)
 vs_funs <- c(varsel_stats, varsel_plot, suggest_size)

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -416,7 +416,7 @@ test_that('varsel_stats output seems legit', {
       if (cvs$family_kl$family == 'gaussian')
         stats_str <- c('mse','rmse','elpd','mlpd')
       else if (cvs$family_kl$family == 'binomial')
-        stats_str <- c('acc','elpd','mlpd')
+        stats_str <- c('acc','auc','elpd','mlpd')
       else
         stats_str <- c('elpd','mlpd')
       stats <- varsel_stats(cvs, stats=stats_str, type=c('mean','lower','upper','se'))


### PR DESCRIPTION
This addresses #25. The AUC results are consistent to those produced by the WeightedROC package, which helped me to sort out the issue of ties in predicted probabilities. It's worth double-checking the computation of bootstrapped standard errors, especially in the `!is.null(mu.bs)` case (when `varsel_stats()` is called with `delta=TRUE`). 