### PR TITLE
Improve tests for variable selection related functions

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -446,6 +446,8 @@ suggest_size <- function(object, stat = 'elpd', alpha = 0.32, pct = 0.0, type='u
                          baseline=NULL, warnings=TRUE, ...) {
 
   .validate_vsel_object_stats(object, stat)
+  if (length(stat) > 1)
+    stop('Only one statistic can be specified to suggest_size')
   
   if (.is_util(stat)) {
     sgn <- 1

--- a/R/methods.R
+++ b/R/methods.R
@@ -253,10 +253,8 @@ NULL
 #' @rdname varsel-statistics
 #' @export
 varsel_plot <- function(object, nv_max = NULL, stats = 'elpd', deltas = F, alpha = 0.32, baseline=NULL, ...) {
-  
-	if ( !('vsel' %in% class(object) || 'cvsel' %in% class(object)) )
-		stop('The object does not look like a variable selection -object. Run variable selection first')
-  
+
+  .validate_vsel_object_stats(object, stats)
   if (is.null(baseline)) {
     if ('datafit' %in% class(object$refmodel))
       baseline <- 'best'
@@ -331,10 +329,8 @@ varsel_plot <- function(object, nv_max = NULL, stats = 'elpd', deltas = F, alpha
 #' @export
 varsel_stats <- function(object, nv_max = NULL, stats = 'elpd', type = c('mean','se'), 
                          deltas = F, alpha=0.32, baseline=NULL, ...) {
-  
-	if ( !('vsel' %in% class(object) || 'cvsel' %in% class(object)) )
-		stop('The object does not look like a variable selection -object. Run variable selection first')
-  
+
+  .validate_vsel_object_stats(object, stats)
   if (is.null(baseline)) {
     if ('datafit' %in% class(object$refmodel))
       baseline <- 'best'
@@ -448,10 +444,8 @@ varsel_stats <- function(object, nv_max = NULL, stats = 'elpd', type = c('mean',
 #' @export
 suggest_size <- function(object, stat = 'elpd', alpha = 0.32, pct = 0.0, type='upper', 
                          baseline=NULL, warnings=TRUE, ...) {
-  
-	
-	if ( !('vsel' %in% class(object) || 'cvsel' %in% class(object)) )
-		stop('The object does not look like a variable selection -object. Run variable selection first')
+
+  .validate_vsel_object_stats(object, stat)
   
   if (.is_util(stat)) {
     sgn <- 1

--- a/R/misc.R
+++ b/R/misc.R
@@ -86,6 +86,24 @@ bootstrap <- function(x, fun=mean, b=1000, oobfun=NULL, seed=NULL, ...) {
 `%ORifNULL%` <- function(a, b) if (is.null(a)) b else a
 
 
+.validate_vsel_object_stats <- function(object, stats) {
+
+  if (!inherits(object, c('vsel', 'cvsel')))
+    stop('The object is not a variable selection object. Run variable selection first')
+
+  recognized_stats <- c('elpd', 'mlpd','mse', 'rmse', 'acc', 'pctcorr')
+  binomial_only_stats <- c('acc', 'pctcorr')
+  family <- object$family_kl$family
+
+  if (is.null(stats))
+     stop('Statistic specified as NULL.')
+  for (stat in stats) {
+    if (!(stat %in% recognized_stats))
+      stop(sprintf('Statistic \'%s\' not recognized.', stat))
+    if (stat %in% binomial_only_stats && family != 'binomial')
+      stop('Statistic \'', stat, '\' available only for the binomial family.')
+  }
+}
 
 
 .get_standard_y <- function(y, weights, fam) {

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -214,9 +214,8 @@ get_stat <- function(mu, lppd, d_test, family, stat, mu.bs=NULL, lppd.bs=NULL,
 .is_util <- function(stat) {
   # a simple function to determine whether a given statistic (string) is
   # a utility (we want to maximize) or loss (we want to minimize)
-  recognized_stats <- c('elpd','mlpd','acc','pctcorr','r2','mse','rmse')
-  if (!(stat %in% recognized_stats))
-    stop(sprintf('Internal error: non-recognized statistic \'%s\'', stat))
+  # by the time we get here, stat should have already been validated
+
   if (stat %in% c('rmse','mse'))
     return(F)
   else

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -3,7 +3,8 @@ library(rstanarm)
 
 # tests for varsel and cv_varsel
 
-set.seed(1235)
+seed <- 1235
+set.seed(seed)
 n <- 50
 nv <- 5
 x <- matrix(rnorm(n*nv, 0, 1), n, nv)
@@ -11,7 +12,6 @@ b <- runif(nv)-0.5
 dis <- runif(1, 1, 2)
 weights <- sample(1:4, n, replace = T)
 chains <- 2
-seed <- 1235
 iter <- 500
 offset <- rnorm(n)
 source(file.path('helpers', 'SW.R'))
@@ -180,9 +180,9 @@ SW({
   # without weights/offset because kfold does not support them currently
   # test only with one family to make the tests faster
   glm_simp <- stan_glm(y ~ x, family = poisson(), data = df_poiss, QR = T,
-                       chains = 2, seed = 1235, iter = 400)
+                       chains = 2, seed = seed, iter = 400)
   lm_simp <- stan_lm(y ~ x, data = df_gauss, prior = R2(0.6),
-                     chains = 2, seed = 1235, iter = 400)
+                     chains = 2, seed = seed, iter = 400)
   simp_list = list(glm = glm_simp, lm = lm_simp)
 
   cv_kf_list <- list(l1 = lapply(simp_list, cvsf, 'L1', 'kfold', K = 2),

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -452,3 +452,24 @@ test_that('varsel_stats output seems legit', {
     }
   }
 })
+
+
+# -------------------------------------------------------------
+context('suggest_size')
+
+test_that('suggest_size checks the length of stat', {
+  expect_error(suggest_size(vs_list[[1]][["gauss"]], stat = valid_stats_all), 'Only one statistic')
+})
+
+test_that('suggest_size works on all stats', {
+  for (stat in valid_stats_gauss) {
+    ssize <- suggest_size(vs_list[[1]][["gauss"]], stat = stat)
+    expect_true(!is.na(ssize))
+    expect_true(ssize >= 0)
+  }
+  for (stat in valid_stats_binom) {
+    ssize <- suggest_size(vs_list[[1]][["binom"]], stat = stat)
+    expect_true(!is.na(ssize))
+    expect_true(ssize >= 0)
+  }
+})

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -57,7 +57,7 @@ test_that('varsel returns an object of type "vsel"', {
   }
 })
 
-test_that('object retruned by varsel contains the relevant fields', {
+test_that('object returned by varsel contains the relevant fields', {
   for(i in 1:length(vs_list)) {
     i_inf <- names(vs_list)[i]
     for(j in 1:length(vs_list[[i]])) {
@@ -200,7 +200,7 @@ test_that('cv_varsel returns an object of type "cvsel"', {
   }
 })
 
-test_that('object retruned by cv_varsel contains the relevant fields', {
+test_that('object returned by cv_varsel contains the relevant fields', {
   for(i in 1:length(cvs_list)) {
     i_inf <- names(cvs_list)[i]
     for(j in 1:length(cvs_list[[i]])) {
@@ -287,7 +287,7 @@ test_that('Having something else than stan_glm as the fit throws an error', {
 	expect_error(cv_varsel(rnorm(5), verbose = FALSE), regexp = 'no applicable method')
 })
 
-test_that('object retruned by cv_varsel, kfold contains the relevant fields', {
+test_that('object returned by cv_varsel, kfold contains the relevant fields', {
   for(i in 1:length(cv_kf_list)) {
     i_inf <- names(cv_kf_list)[i]
     for(j in 1:length(cv_kf_list[[i]])) {

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -415,6 +415,23 @@ valid_stats_gauss_only <- c('mse', 'rmse')
 valid_stats_binom_only <- c('acc')
 valid_stats_gauss <- c(valid_stats_all, valid_stats_gauss_only)
 valid_stats_binom <- c(valid_stats_all, valid_stats_binom_only)
+vs_funs <- c(varsel_stats, varsel_plot, suggest_size)
+
+test_that('invalid objects are rejected', {
+  for (fun in vs_funs) {
+    expect_error(fun(NULL), "is not a variable selection object")
+    expect_error(fun(fit_gauss), "is not a variable selection object")
+  }
+})
+
+test_that('invalid stats are rejected', {
+  for (fun in vs_funs) {
+    expect_error(fun(vs_list[[1]][["gauss"]], stat = NULL), 'specified as NULL')
+    expect_error(fun(vs_list[[1]][["gauss"]], stat = NA), 'not recognized')
+    expect_error(fun(vs_list[[1]][["gauss"]], stat = 'zzz'), 'not recognized')
+    expect_error(fun(vs_list[[1]][["gauss"]], stat = 'acc'), 'available only for the binomial family')
+  }
+})
 
 test_that('varsel_stats output seems legit', {
   for(i in seq_along(cvs_list)) {

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -108,7 +108,7 @@ test_that('object retruned by varsel contains the relevant fields', {
                    info = paste(i_inf, j_inf))
       expect_equal(typeof(vs_list[[i]][[j]]$d_test$type), 'character',
                    info = paste(i_inf, j_inf))
-      expect_equal(cvs_list[[i]][[j]]$d_test$type, 'loo',
+      expect_equal(vs_list[[i]][[j]]$d_test$type, 'train',
                    info = paste(i_inf, j_inf))
       # summaries seems legit
       expect_named(vs_list[[i]][[j]]$summaries, c('sub', 'ref'),


### PR DESCRIPTION
This cleans up a bit `test-varsel.R`, adds a `.validate_vsel_object_stats` to consolidate the checks that the object and the stats argument is valid, and adds a few sanity checks for `suggest_size`.