### PR TITLE
Fix test_varsel.R: object 'seed' not found

### DIFF
--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -184,10 +184,16 @@ SW({
 
   # without weights/offset because kfold does not support them currently
   # test only with one family to make the tests faster
+
+  # the chains, seed and iter arguments to the rstanarm functions here must be
+  # specified directly rather than through a variable (eg, seed = 1235 instead
+  # of seed = seed), otherwise when the calls are evaluated in refmodel$cvfun()
+  # they may not be found in the evaluation frame of the calling function,
+  # causing the test to fail
   glm_simp <- stan_glm(y ~ x, family = poisson(), data = df_poiss, QR = T,
-                       chains = 2, seed = seed, iter = 400)
+                       chains = 2, seed = 1235, iter = 400)
   lm_simp <- stan_lm(y ~ x, data = df_gauss, prior = R2(0.6),
-                     chains = 2, seed = seed, iter = 400)
+                     chains = 2, seed = 1235, iter = 400)
   simp_list = list(glm = glm_simp, lm = lm_simp)
 
   cv_kf_list <- list(l1 = lapply(simp_list, cvsf, 'L1', 'kfold', K = 2),


### PR DESCRIPTION
A change made in 0a726c2 which caused this sort of errors when running `test_varsel.R`:

```
test_varsel.R:181: error: (unknown)
object 'seed' not found
1: SW({
       cvs_list <- list(l1 = lapply(fit_list, cvsf, "L1", "LOO"), fs = lapply(fit_list,
           cvsf, "forward", "LOO"))
       glm_simp <- stan_glm(y ~ x, family = poisson(), data = df_poiss, QR = T, chains = 2,
           seed = seed, iter = 400)
       lm_simp <- stan_lm(y ~ x, data = df_gauss, prior = R2(0.6), chains = 2, seed = seed,
           iter = 400)
       simp_list = list(glm = glm_simp, lm = lm_simp)
       cv_kf_list <- list(l1 = lapply(simp_list, cvsf, "L1", "kfold", K = 2), fs = lapply(simp_list,
           cvsf, "forward", "kfold", K = 2))
       cvsref_list <- list(l1 = lapply(ref_list, cvsf, "L1", "kfold"), fs = lapply(ref_list,
           cvsf, "forward", "kfold"))
   }) at tests/testthat/test_varsel.R:181
2: capture.output(suppressWarnings(expr)) at helpers/SW.R:1
3: evalVis(expr)
4: withVisible(eval(expr, pf))
5: eval(expr, pf)
6: eval(expr, pf)
7: suppressWarnings(expr)
8: withCallingHandlers(expr, warning = function(w) invokeRestart("muffleWarning"))
9: lapply(simp_list, cvsf, "L1", "kfold", K = 2) at tests/testthat/test_varsel.R:199
10: FUN(X[[i]], ...)
...
17: capture.output(fit_k <- eval(calls[[k]]))
18: evalVis(expr)
19: withVisible(eval(expr, pf))
20: eval(expr, pf)
21: eval(expr, pf)
22: eval(calls[[k]])
23: eval(calls[[k]])
24: stan_glm(formula = y ~ x, family = poisson(), data = structure(list(y = c(2L, 1L,
   1L, 1L, 0L, 1L, 4L, 0L, 1L, 1L, 1L, 4L, 2L, 2L, 0L, 2L, 0L, 0L, 0L, 3L, 0L, 4L, 1L,
  <cut a lot of stuff>
       chains = 2, seed = seed, iter = 400,
       QR = T, subset = c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
       TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
       TRUE, TRUE), weights = NULL, cores = 1, refresh = 0, open_progress = FALSE)
25: stan_glm.fit(x = X, y = Y, weights = weights, offset = offset, family = family, prior = prior,
       prior_intercept = prior_intercept, prior_aux = prior_aux, prior_PD = prior_PD,
       algorithm = algorithm, mean_PPD = mean_PPD, adapt_delta = adapt_delta, QR = QR,
       sparse = sparse, ...)
26: set_sampling_args(object = stanfit, prior = prior, user_dots = list(...), user_adapt_delta = adapt_delta,
       data = standata, pars = pars, show_messages = FALSE)
```

I think this has to do with how R evaluates function arguments (https://cran.r-project.org/doc/manuals/r-release/R-lang.html#Evaluation, section 4.3.3). When the `refmodel$cvfun` function is evaluated from `.get_kfold()`, it calls `rstanarm::kfold()` which tries to evaluate again the exact call to `stan_glm()`, but at that point there is no `seed` variable in the environment, so it fails. The thing is that if a variable called `seed` was present in the workspace before running `testthat` (which was the case for me), then the test would work, but not `covr::package_coverage()`.

I don't pretend to fully understand all this, nor to know how to solve it properly (which may perhaps require a fix in rstanarm), so reverting those lines in 0a726c2 is probably enough.