### PR TITLE
properly deal with response in predict.subfit

### DIFF
--- a/R/formula.R
+++ b/R/formula.R
@@ -293,11 +293,11 @@ subset_formula_and_data <- function(formula, terms_, data, y=NULL, split_formula
       formula <- lapply(response_cols, function(response)
         update(formula, paste0(response, " ~ .")))
     }
+    data <- data.frame(y, data)
   } else {
     formula <- update(formula, paste(response_cols, "~ ."))
   }
 
-  data <- data.frame(y, data)
   colnames(data)[seq_len(response_ncol)] <- response_cols
   return(nlist(formula, data))
 }

--- a/R/search.R
+++ b/R/search.R
@@ -143,6 +143,7 @@ search_L1_poc <- function(p_ref, refmodel, family, intercept, nv_max, penalty, o
     sub <- list(alpha = spath$alpha[nv + 1],
                 beta = spath$beta[, nv  + 1, drop = FALSE],
                 w = spath$w[, nv + 1],
+                formula = refmodel$formula,
                 x = x)
     class(sub) <- "subfit"
     return(sub)
@@ -159,8 +160,7 @@ predict.subfit <- function(subfit, newdata=NULL) {
   if (is.null(newdata))
     return((x * w) %*% rbind(alpha, beta))
   else {
-    ## FIXME: find better way of removing the response
-    x <- as.matrix(newdata[, -1])
-    return(alpha + x %*% beta)
+    x <- model.matrix(subfit$formula, newdata)
+    return(x %*% rbind(alpha, beta))
   }
 }


### PR DESCRIPTION
This PR addresses #42 . Now we retrieve the data matrix in a safe way by using `model.matrix`.

I'm not sure if this should stay like this for the time being. We can leave this open until I investigate how `glmnet` exactly differs from the current approach.

ping @jpiironen if you remember why the current method is different and how so?