### PR TITLE
Refactor extend family

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -1,6 +1,6 @@
 .onAttach <- function(...) {
   ver <- utils::packageVersion("projpred")
-  msg <- paste0('This is projpred version ', ver, '.')
+  msg <- paste0("This is projpred version ", ver, ".")
   packageStartupMessage(msg)
 }
 
@@ -47,7 +47,7 @@ auc <- function(x) {
   pred <- x[, 2]
   weights <- x[, 3]
   n <- nrow(x)
-  ord <- order(pred, decreasing=TRUE)
+  ord <- order(pred, decreasing = TRUE)
   resp <- resp[ord]
   pred <- pred[ord]
   weights <- weights[ord]
@@ -69,7 +69,7 @@ auc <- function(x) {
   return(sum(delta_fpr * tpr) + sum(delta_fpr * delta_tpr) / 2)
 }
 
-bootstrap <- function(x, fun=mean, b=1000, oobfun=NULL, seed=NULL, ...) {
+bootstrap <- function(x, fun = mean, b = 1000, oobfun = NULL, seed = NULL, ...) {
   #
   # bootstrap an arbitrary quantity fun that takes the sample x
   # as the first input. other parameters to fun can be passed in as ...
@@ -77,7 +77,7 @@ bootstrap <- function(x, fun=mean, b=1000, oobfun=NULL, seed=NULL, ...) {
   #
 
   # set random seed but ensure the old RNG state is restored on exit
-  if (exists('.Random.seed')) {
+  if (exists(".Random.seed")) {
     rng_state_old <- .Random.seed
     on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
   }
@@ -88,7 +88,7 @@ bootstrap <- function(x, fun=mean, b=1000, oobfun=NULL, seed=NULL, ...) {
   bsstat <- rep(NA, b)
   oobstat <- rep(NA, b)
   for (i in 1:b) {
-    bsind <- sample(seq_x, replace=T)
+    bsind <- sample(seq_x, replace = T)
     bsstat[i] <- fun(if (is_vector) x[bsind] else x[bsind, ], ...)
     if (!is.null(oobfun)) {
       oobind <- setdiff(seq_x, unique(bsind))
@@ -96,17 +96,18 @@ bootstrap <- function(x, fun=mean, b=1000, oobfun=NULL, seed=NULL, ...) {
     }
   }
   if (!is.null(oobfun)) {
-    return(list(bs=bsstat, oob=oobstat))
-  } else
+    return(list(bs = bsstat, oob = oobstat))
+  } else {
     return(bsstat)
+  }
 }
 
 
-.bbweights <- function(N,B) {
+.bbweights <- function(N, B) {
   # generate Bayesian bootstrap weights, N = original sample size,
   # B = number of bootstrap samples
-  bbw <- matrix(rgamma(N*B, 1), ncol = N)
-  bbw <- bbw/rowSums(bbw)
+  bbw <- matrix(rgamma(N * B, 1), ncol = N)
+  bbw <- bbw / rowSums(bbw)
   return(bbw)
 }
 
@@ -119,46 +120,54 @@ bootstrap <- function(x, fun=mean, b=1000, oobfun=NULL, seed=NULL, ...) {
 .is.wholenumber <- function(x) abs(x - round(x)) < .Machine$double.eps^0.5
 
 .validate_num_folds <- function(k, n) {
-  if (!is.numeric(k) || length(k) != 1 || !.is.wholenumber(k))
-    stop('Number of folds must be a single integer value.')
-  if (k < 2)
-    stop('Number of folds must be at least 2.')
-  if (k > n)
-    stop('Number of folds cannot exceed n.')
+  if (!is.numeric(k) || length(k) != 1 || !.is.wholenumber(k)) {
+    stop("Number of folds must be a single integer value.")
+  }
+  if (k < 2) {
+    stop("Number of folds must be at least 2.")
+  }
+  if (k > n) {
+    stop("Number of folds cannot exceed n.")
+  }
 }
 
 .validate_vsel_object_stats <- function(object, stats) {
+  if (!inherits(object, c("vsel", "cvsel"))) {
+    stop("The object is not a variable selection object. Run variable selection first")
+  }
 
-  if (!inherits(object, c('vsel', 'cvsel')))
-    stop('The object is not a variable selection object. Run variable selection first')
-
-  recognized_stats <- c('elpd', 'mlpd','mse', 'rmse', 'acc', 'pctcorr', 'auc')
-  binomial_only_stats <- c('acc', 'pctcorr', 'auc')
+  recognized_stats <- c("elpd", "mlpd", "mse", "rmse", "acc", "pctcorr", "auc")
+  binomial_only_stats <- c("acc", "pctcorr", "auc")
   family <- object$family$family
 
-  if (is.null(stats))
-     stop('Statistic specified as NULL.')
+  if (is.null(stats)) {
+    stop("Statistic specified as NULL.")
+  }
   for (stat in stats) {
-    if (!(stat %in% recognized_stats))
-      stop(sprintf('Statistic \'%s\' not recognized.', stat))
-    if (stat %in% binomial_only_stats && family != 'binomial')
-      stop('Statistic \'', stat, '\' available only for the binomial family.')
+    if (!(stat %in% recognized_stats)) {
+      stop(sprintf("Statistic '%s' not recognized.", stat))
+    }
+    if (stat %in% binomial_only_stats && family != "binomial") {
+      stop("Statistic '", stat, "' available only for the binomial family.")
+    }
   }
 }
 
 .validate_baseline <- function(refmodel, baseline, deltas) {
   if (is.null(baseline)) {
-    if (inherits(refmodel, 'datafit'))
-      baseline <- 'best'
-    else
-      baseline <- 'ref'
+    if (inherits(refmodel, "datafit")) {
+      baseline <- "best"
+    } else {
+      baseline <- "ref"
+    }
   } else {
-    if (!(baseline %in% c('ref', 'best')))
-      stop('Argument \'baseline\' must be either \'ref\' or \'best\'.')
-    if (baseline == 'ref' && deltas == TRUE && inherits(refmodel, 'datafit')) {
+    if (!(baseline %in% c("ref", "best"))) {
+      stop("Argument 'baseline' must be either 'ref' or 'best'.")
+    }
+    if (baseline == "ref" && deltas == TRUE && inherits(refmodel, "datafit")) {
       # no reference model (or the results missing for some other reason),
       # so cannot compute differences between the reference model and submodels
-      stop('Cannot use deltas = TRUE and baseline = \'ref\' when there is no reference model.')
+      stop("Cannot use deltas = TRUE and baseline = 'ref' when there is no reference model.")
     }
   }
   return(baseline)
@@ -170,30 +179,33 @@ bootstrap <- function(x, fun=mean, b=1000, oobfun=NULL, seed=NULL, ...) {
   # and weights give the number of observations at each x.
   # for all other families, y and weights are kept as they are (unless weights is
   # a vector with length zero in which case it is replaced by a vector of ones).
-  if(NCOL(y) == 1) {
+  if (NCOL(y) == 1) {
     # weights <- if(length(weights) > 0) unname(weights) else rep(1, length(y))
-    if(length(weights) > 0)
+    if (length(weights) > 0) {
       weights <- unname(weights)
-    else
-      weights <- rep(1, length(y))
-    if (fam$family == 'binomial') {
-      if (is.factor(y)) {
-        if (nlevels(y) > 2)
-          stop('y cannot contain more than two classes if specified as factor.')
-        y <- as.vector(y, mode='integer') - 1 # zero-one vector
-      } else {
-        if (any(y < 0 | y > 1))
-          stop("y values must be 0 <= y <= 1 for the binomial model.")
-      }
     } else {
-      if (is.factor(y))
-        stop('y cannot be a factor for models other than the binomial model.')
+      weights <- rep(1, length(y))
+    }
+    if (fam$family == "binomial") {
+      if (is.factor(y)) {
+        if (nlevels(y) > 2) {
+          stop("y cannot contain more than two classes if specified as factor.")
+        }
+        y <- as.vector(y, mode = "integer") - 1 # zero-one vector
+      } ## else {
+      ##   if (any(y < 0 | y > 1))
+      ##     stop("y values must be 0 <= y <= 1 for the binomial model.")
+      ## }
+    } else {
+      if (is.factor(y)) {
+        stop("y cannot be a factor for models other than the binomial model.")
+      }
     }
   } else if (NCOL(y) == 2) {
     weights <- rowSums(y)
     y <- y[, 1] / weights
   } else {
-    stop('y cannot have more than two columns.')
+    stop("y cannot have more than two columns.")
   }
   return(nlist(y, weights))
 }
@@ -269,7 +281,7 @@ bootstrap <- function(x, fun=mean, b=1000, oobfun=NULL, seed=NULL, ...) {
   return(p_ref)
 }
 
-.get_p_clust <- function(family, mu, dis, nc=10, wobs=rep(1,dim(mu)[1]), wsample=rep(1,dim(mu)[2]), cl = NULL) {
+.get_p_clust <- function(family, mu, dis, nc = 10, wobs = rep(1, dim(mu)[1]), wsample = rep(1, dim(mu)[2]), cl = NULL) {
   # Function for perfoming the clustering over the samples.
   #
   # cluster the samples in the latent space if no clustering provided

--- a/R/misc.R
+++ b/R/misc.R
@@ -88,7 +88,7 @@ bootstrap <- function(x, fun = mean, b = 1000, oobfun = NULL, seed = NULL, ...) 
   bsstat <- rep(NA, b)
   oobstat <- rep(NA, b)
   for (i in 1:b) {
-    bsind <- sample(seq_x, replace = T)
+    bsind <- sample(seq_x, replace = TRUE)
     bsstat[i] <- fun(if (is_vector) x[bsind] else x[bsind, ], ...)
     if (!is.null(oobfun)) {
       oobind <- setdiff(seq_x, unique(bsind))
@@ -299,7 +299,7 @@ bootstrap <- function(x, fun = mean, b = 1000, oobfun = NULL, seed = NULL, ...) 
 
   # (re)compute the cluster centers, because they may be different from the ones
   # returned by kmeans if the samples have differing weights
-  nc <- max(cl, na.rm = T) # number of clusters (assumes labeling 1,...,nc)
+  nc <- max(cl, na.rm = TRUE) # number of clusters (assumes labeling 1,...,nc)
   centers <- matrix(0, nrow = nc, ncol = dim(mu)[1])
   wcluster <- rep(0, nc) # cluster weights
   eps <- 1e-10
@@ -398,7 +398,7 @@ bootstrap <- function(x, fun = mean, b = 1000, oobfun = NULL, seed = NULL, ...) 
 
 .df_to_model_mat <- function(dfnew, var_names) {
   f <- formula(paste("~", paste(c("0", var_names), collapse = " + ")))
-  model.matrix(terms(f, keep.order = T), data = dfnew)
+  model.matrix(terms(f, keep.order = TRUE), data = dfnew)
 }
 
 .is_proj_list <- function(proj) {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -17,16 +17,16 @@
 #'
 #' @examples
 #' \donttest{
-## Usage with stanreg objects
+#' ## Usage with stanreg objects
 #' dat <- data.frame(y = rnorm(100), x = rnorm(100))
 #' fit <- stan_glm(y ~ x, family = gaussian(), data = dat)
 #' ref <- get_refmodel(fit)
 #' print(class(ref))
 #'
-## variable selection, use the already constructed reference model
+#' ## variable selection, use the already constructed reference model
 #' vs <- varsel(ref)
-## this will first construct the reference model and then execute
-## exactly the same way as the previous command (the result is identical)
+#' ## this will first construct the reference model and then execute
+#' ## exactly the same way as the previous command (the result is identical)
 #' vs <- varsel(fit)
 #' }
 #'
@@ -57,15 +57,18 @@ NULL
 
 #' @export
 predict.refmodel <- function(object, znew, ynew = NULL, offsetnew = NULL,
-                             weightsnew = NULL, type = 'response', ...) {
-
-  if (!(type %in% c("response", "link")))
+                             weightsnew = NULL, type = "response", ...) {
+  if (!(type %in% c("response", "link"))) {
     stop("type should be one of ('response', 'link')")
-  if ('datafit' %in% class(object))
-    stop('Cannot make predictions with data reference only.')
-  if (!is.null(ynew))
-    if (!(inherits(ynew, "numeric")) || NCOL(ynew) != 1)
+  }
+  if ("datafit" %in% class(object)) {
+    stop("Cannot make predictions with data reference only.")
+  }
+  if (!is.null(ynew)) {
+    if (!(inherits(ynew, "numeric")) || NCOL(ynew) != 1) {
       stop("ynew must be a numerical vector")
+    }
+  }
 
   if (is.null(offsetnew)) offsetnew <- rep(0, nrow(znew))
   if (is.null(weightsnew)) weightsnew <- rep(1, nrow(znew))
@@ -74,28 +77,29 @@ predict.refmodel <- function(object, znew, ynew = NULL, offsetnew = NULL,
   mu <- object$predfun(object$fit, znew)
 
   if (is.null(ynew)) {
-
-    if (type == 'link')
+    if (type == "link") {
       pred <- mu
-    else
+    } else {
       pred <- object$family$linkinv(mu + offsetnew)
+    }
 
     ## integrate over the samples
-    if (NCOL(pred) > 1)
+    if (NCOL(pred) > 1) {
       pred <- rowMeans(pred)
+    }
 
     return(pred)
-
   } else {
 
     ## evaluate the log predictive density at the given ynew values
-    loglik <- object$fam$ll_fun(object$family$linkinv(mu), object$dis, ynew,
-                                weightsnew)
+    loglik <- object$fam$ll_fun(
+      object$family$linkinv(mu), object$dis, ynew,
+      weightsnew
+    )
     S <- ncol(loglik)
     lpd <- apply(loglik, 1, log_sum_exp) - log(S)
     return(lpd)
   }
-
 }
 
 #' @export
@@ -123,28 +127,32 @@ get_refmodel.cvsel <- function(object, ...) {
 
 #' @export
 get_refmodel.default <- function(fit, data, y, formula, predfun, proj_predfun,
-                                     mle, fetch_data, family=NULL, wobs=NULL,
-                                     folds=NULL, cvfits=NULL, penalized=FALSE,
-                                     offest=NULL, cvfun=NULL) {
-  fetch_data_wrapper <- function(obs=folds, newdata=NULL)
+                                 mle, fetch_data, family = NULL, wobs = NULL,
+                                 folds = NULL, cvfits = NULL, penalized = FALSE,
+                                 offest = NULL, cvfun = NULL) {
+  fetch_data_wrapper <- function(obs = folds, newdata = NULL) {
     fetch_data(data, obs, newdata)
+  }
 
-  if (is.null(family))
+  if (is.null(family)) {
     family <- extend_family(family(fit))
-  else
+  } else {
     family <- extend_family(family)
+  }
 
   refmodel <- init_refmodel(fit, data, y, formula, family, predfun, mle,
-                                proj_predfun, penalized=penalized, weights=wobs,
-                                offset=offset, cvfits=cvfits, folds=folds,
-                                cvfun=cvfun)
+    proj_predfun,
+    penalized = penalized, weights = wobs,
+    offset = offset, cvfits = cvfits, folds = folds,
+    cvfun = cvfun
+  )
   return(refmodel)
 }
 
 #' export
-get_refmodel.brmsfit <- function(fit, data=NULL, y=NULL, formula=NULL,
-                                     predfun=NULL, proj_predfun=NULL, mle=NULL,
-                                     folds=NULL, ...) {
+get_refmodel.brmsfit <- function(fit, data = NULL, y = NULL, formula = NULL,
+                                 predfun = NULL, proj_predfun = NULL, mle = NULL,
+                                 folds = NULL, ...) {
   family_name <- family(fit)$family
   fam <- ifelse(family_name == "bernoulli", "binomial", family_name)
   fam <- get(fam, mode = "function")()
@@ -155,8 +163,9 @@ get_refmodel.brmsfit <- function(fit, data=NULL, y=NULL, formula=NULL,
   family <- extend_family(brms_family)
 
   brms_formula <- formula(fit)
-  if (is.null(formula))
+  if (is.null(formula)) {
     formula <- brms_formula$formula
+  }
 
   terms <- extract_terms_response(formula)
   response_name <- brms_formula$resp
@@ -164,60 +173,72 @@ get_refmodel.brmsfit <- function(fit, data=NULL, y=NULL, formula=NULL,
   formula <- update(formula, paste(response_name, " ~ ."))
   p <- parse_bf(brms_formula)
 
-  if (is.null(data))
+  if (is.null(data)) {
     data <- fit$data
-  if (is.null(y))
+  }
+  if (is.null(y)) {
     y <- fit$data[, response_name]
+  }
 
   if ("trials" %in% family$ad &&
-      inherits(p$adforms$trials, "formula")) {
+    inherits(p$adforms$trials, "formula")) {
     trials_form <- p$adforms$trials
-    trials_var <- eval(trials_form[[2]], data,
-                       environment(trials_form))$vars$trials
+    trials_var <- eval(
+      trials_form[[2]], data,
+      environment(trials_form)
+    )$vars$trials
     weights <- data[, trials_var]
-    y <- y / weights
   } else {
     weights <- NULL
   }
 
   ## TODO: return y, weights and offset as right hand side formulas
   refmodel <- init_refmodel(fit, data, y, formula, family, predfun, mle,
-                            proj_predfun, folds, weights=weights, ...)
+    proj_predfun, folds,
+    weights = weights, ...
+  )
   return(refmodel)
 }
 
 #' @export
-get_refmodel.stanreg <- function(fit, data=NULL, y=NULL, formula=NULL,
-                                     predfun=NULL, proj_predfun=NULL, mle=NULL,
-                                     folds=NULL, penalized=FALSE, ...) {
+get_refmodel.stanreg <- function(fit, data = NULL, y = NULL, formula = NULL,
+                                 predfun = NULL, proj_predfun = NULL, mle = NULL,
+                                 folds = NULL, penalized = FALSE, ...) {
   family <- family(fit)
   family <- extend_family(family)
 
-  if (is.null(formula))
+  if (is.null(formula)) {
     formula <- formula(fit)
+  }
   terms <- extract_terms_response(formula)
   response_name <- terms$response
 
-  if (is.null(data))
+  if (is.null(data)) {
     data <- fit$data
-  if (is.null(y))
+  }
+  if (is.null(y)) {
     y <- fit$data[, colnames(fit$data) == response_name]
+  }
 
-  refmodel <- init_refmodel(fit, data, y, formula, family, predfun, mle,
-                            proj_predfun, folds, penalized, ...)
+  refmodel <- init_refmodel(
+    fit, data, y, formula, family, predfun, mle,
+    proj_predfun, folds, penalized, ...
+  )
   return(refmodel)
 }
 
 #' @export
-init_refmodel <- function(fit, data, y, formula, family, predfun=NULL, mle=NULL,
-                          proj_predfun=NULL, folds=NULL, penalized=FALSE,
-                          weights=NULL, offset=NULL, cvfun=NULL, cvfits=NULL, ...) {
+init_refmodel <- function(fit, data, y, formula, family, predfun = NULL, mle = NULL,
+                          proj_predfun = NULL, folds = NULL, penalized = FALSE,
+                          weights = NULL, offset = NULL, cvfun = NULL, cvfits = NULL, ...) {
   terms <- extract_terms_response(formula)
-  if (is.null(predfun))
-    predfun <- function(fit, newdata=NULL)
+  if (is.null(predfun)) {
+    predfun <- function(fit, newdata = NULL) {
       t(posterior_linpred(fit, transform = FALSE, newdata = newdata))
+    }
+  }
 
-  if (is.null(mle) && is.null(proj_predfun))
+  if (is.null(mle) && is.null(proj_predfun)) {
     if (length(terms$group_terms) != 0) {
       mle <- linear_multilevel_mle
       proj_predfun <- linear_multilevel_proj_predfun
@@ -230,33 +251,39 @@ init_refmodel <- function(fit, data, y, formula, family, predfun=NULL, mle=NULL,
         proj_predfun <- penalized_linear_proj_predfun
       }
     }
-  else if (is.null(mle) && !is.null(proj_predfun))
-    if (length(terms$group_terms) != 0)
+  } else if (is.null(mle) && !is.null(proj_predfun)) {
+    if (length(terms$group_terms) != 0) {
       mle <- linear_multilevel_mle
-    else
-      if (!penalized)
-        mle <- linear_mle
-    else
+    } else
+    if (!penalized) {
+      mle <- linear_mle
+    } else {
       mle <- penalized_linear_mle
-  else if (!is.null(mle) && is.null(proj_predfun))
-    if (length(terms$group_terms) != 0)
+    }
+  } else if (!is.null(mle) && is.null(proj_predfun)) {
+    if (length(terms$group_terms) != 0) {
       proj_predfun <- linear_multilevel_proj_predfun
-    else
-      if (!penalized)
-        proj_predfun <- linear_proj_predfun
-    else
+    } else
+    if (!penalized) {
+      proj_predfun <- linear_proj_predfun
+    } else {
       proj_predfun <- penalized_linear_proj_predfun
+    }
+  }
 
-  fetch_data_wrapper <- function(obs=folds, newdata=NULL)
+  fetch_data_wrapper <- function(obs = folds, newdata = NULL) {
     as.data.frame(fetch_data(data, obs, newdata))
+  }
 
-  if (!.has_family_extras (family))
+  if (!.has_family_extras(family)) {
     family <- extend_family(family)
+  }
 
   ## TODO: ideally remove this, have to think about it
-  family$mu_fun <- function(fit, obs=folds, xnew=NULL, offset=NULL) {
-    if (is.null(offset))
+  family$mu_fun <- function(fit, obs = folds, xnew = NULL, offset = NULL) {
+    if (is.null(offset)) {
       offset <- rep(0, length(obs))
+    }
     newdata <- fetch_data_wrapper(obs = obs, newdata = xnew)
     family$linkinv(proj_predfun(fit, newdata = newdata) + offset)
   }
@@ -271,14 +298,16 @@ init_refmodel <- function(fit, data, y, formula, family, predfun=NULL, mle=NULL,
     mu <- family$linkinv(mu)
   } else {
     mu <- matrix(y, NROW(y), 1)
-		predfun_datafit <- function(fit=NULL, newdata=NULL, offset = 0) {
-      if (is.null(fit))
-        if (is.null(newdata))
+    predfun_datafit <- function(fit = NULL, newdata = NULL, offset = 0) {
+      if (is.null(fit)) {
+        if (is.null(newdata)) {
           matrix(rep(NA, NROW(y)))
-        else
+        } else {
           matrix(rep(NA, NROW(newdata)))
-      else
+        }
+      } else {
         family$linkinv(predfun(fit, newdata))
+      }
     }
   }
 
@@ -287,7 +316,8 @@ init_refmodel <- function(fit, data, y, formula, family, predfun=NULL, mle=NULL,
   dis <- rep(0, ndraws)
   if (proper_model) {
     ## TODO: eventually this will be a function provided by the user
-    tryCatch({
+    tryCatch(
+      {
         dis <- as.data.frame(fit)$sigma %ORifNULL% rep(0, ndraws)
       },
       error = function(e) e
@@ -301,23 +331,27 @@ init_refmodel <- function(fit, data, y, formula, family, predfun=NULL, mle=NULL,
     weights <- rep(1, length(y))
   }
 
-  if (proper_model)
+  if (proper_model) {
     loglik <- t(family$ll_fun(mu, dis, y, weights = weights))
-  else
+  } else {
     loglik <- NULL
+  }
 
   # this is a dummy definition for cvfun, but it will lead to standard cross-validation
   # for datafit reference; see cv_varsel and get_kfold
   cvfun <- function(folds) lapply(1:max(folds), function(k) list())
 
   wsample <- rep(1 / ndraws, ndraws) # equal sample weights by default
-  if (is.null(offset))
+  if (is.null(offset)) {
     offset <- rep(0, NROW(y))
+  }
 
-  intercept <- as.logical(attr(terms(formula), 'intercept'))
+  intercept <- as.logical(attr(terms(formula), "intercept"))
   refmodel <- nlist(fit, formula, mle, family, mu, dis, y, loglik,
-                    intercept, proj_predfun, fetch_data=fetch_data_wrapper,
-                    wobs=weights, wsample, offset, folds, cvfun, cvfits)
+    intercept, proj_predfun,
+    fetch_data = fetch_data_wrapper,
+    wobs = weights, wsample, offset, folds, cvfun, cvfits
+  )
   if (proper_model) {
     refmodel$predfun <- predfun
     class(refmodel) <- "refmodel"


### PR DESCRIPTION
Change `dbinom(y * weights, weights)` to `dbinom(y, weights)`.

This involves some light changes in `get_refmodel` and `.get_standard_y`.
At some point we should move `get_refmodel.stanreg` to `rstanarm`, and update `get_refmodel.brmsfit` in `brms` @paul-buerkner (now you don't need to return the target divided by the weights).