### PR TITLE
no longer import tidyverse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,6 @@ Imports:
     Rcpp,
     utils,
     rngtools (>= 1.2.4),
-    tidyverse,
     MASS,
     magrittr,
     mgcv,

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -11,6 +11,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{magrittr}{\code{\link[magrittr]{\%>\%}}}
+  \item{magrittr}{\code{\link[magrittr:pipe]{\%>\%}}}
 }}
 


### PR DESCRIPTION
This PR removes the redundant dependency on the whole tidyverse. 