### PR TITLE
Fix formula parsing with multidimensional interactions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Authors@R: c(person("Juho", "Piironen", role = c("aut"), email = "juho.t.piirone
              person("Aki", "Vehtari", role = "aut"),
              person("Jonah", "Gabry", role = "ctb"),
              person("Marco", "Colombo", role = "ctb"),
-             person("Paul-Christian", "Bürkner", role = "ctb"))
+             person("Paul-Christian", "Bürkner", role = "ctb"),
+             person("Hamada S.", "Badr", role = "ctb"))
 Maintainer:
     Alejandro Catalina <alecatfel@gmail.com>
 Description:

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,6 @@
 * Fixed a bug in `cv_varsel()`, causing an error in case of `!validate_search && cv_method != "LOO"`. (GitHub: #95)
 * Fixed bugs related to the setting of the seed. (GitHub: commit 02cd50db76b0f2d835ce8f8f39cbe94353540d64)
 * Fixed a bug causing `proj_linpred()` to raise an error if argument `newdata` was `NULL`. (GitHub: #97)
-* Fixed a bug causing `varsel()`/`make_formula` to fail with multidimensional interaction terms. (GitHub: #102)
 * Fixed an incorrect usage of the dispersion parameter values when calculating output element `lpd` in `proj_linpred()` (for `integrated = TRUE` as well as for `integrated = FALSE`). (GitHub: #105)
 * Fixed bugs in `proj_linpred()`'s calculation of output element `lpd` (for `integrated = TRUE`). (GitHub: #106)
 * Fixed an inconsistency in the dimensions of `proj_linpred()`'s output elements `pred` and `lpd` (for `integrated = FALSE`): Now, they are both S x N matrices, with S denoting the number of (possibly clustered) posterior draws and N denoting the number of observations. (GitHub: #107)

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 * Fixed a bug in `cv_varsel()`, causing an error in case of `!validate_search && cv_method != "LOO"`. (GitHub: #95)
 * Fixed bugs related to the setting of the seed. (GitHub: commit 02cd50db76b0f2d835ce8f8f39cbe94353540d64)
 * Fixed a bug causing `proj_linpred()` to raise an error if argument `newdata` was `NULL`. (GitHub: #97)
+* Fixed a bug causing `varsel()`/`make_formula` to fail with multidimensional interaction terms. (GitHub: #102)
 
 ## projpred 2.0.4
 

--- a/R/formula.R
+++ b/R/formula.R
@@ -52,6 +52,7 @@ remove_duplicates <- function(formula) {
       perl = TRUE
     )
   ))
+  additive <- unique(unlist(strsplit(paste0(additive, collapse = ","), ",")))
   dups <- linear[!is.na(match(linear, additive))]
   if (length(dups) > 0) {
     update(formula, as.formula(paste0(
@@ -270,6 +271,7 @@ split_formula <- function(formula, return_group_terms = TRUE, data = NULL,
       perl = TRUE
     )
   ))
+  additive <- unique(unlist(strsplit(paste0(additive, collapse = ","), ",")))
   if (return_group_terms) {
     ## if there are group levels we should split that into basic components
     group_split <- unlist(lapply(group_terms, split_group_term,

--- a/R/formula.R
+++ b/R/formula.R
@@ -52,7 +52,7 @@ remove_duplicates <- function(formula) {
       perl = TRUE
     )
   ))
-  additive <- unique(unlist(strsplit(paste0(additive, collapse = ","), ",")))
+  additive <- trimws(unique(unlist(strsplit(paste0(additive, collapse = ","), ","))))
   dups <- linear[!is.na(match(linear, additive))]
   if (length(dups) > 0) {
     update(formula, as.formula(paste0(
@@ -271,7 +271,7 @@ split_formula <- function(formula, return_group_terms = TRUE, data = NULL,
       perl = TRUE
     )
   ))
-  additive <- unique(unlist(strsplit(paste0(additive, collapse = ","), ",")))
+  additive <- trimws(unique(unlist(strsplit(paste0(additive, collapse = ","), ","))))
   if (return_group_terms) {
     ## if there are group levels we should split that into basic components
     group_split <- unlist(lapply(group_terms, split_group_term,

--- a/tests/testthat/test_formula.R
+++ b/tests/testthat/test_formula.R
@@ -29,6 +29,32 @@ test_that(paste(
   expect_length(tt$response, 1)
 })
 
+test_that(paste(
+  "check that we recover the correct terms for a simple ",
+  "additive model without interactions"
+), {
+  formula <- y ~ x + s(z)
+  tt <- extract_terms_response(formula)
+  expect_length(tt$individual_terms, 1)
+  expect_length(tt$interaction_terms, 0)
+  expect_length(tt$additive_terms, 1)
+  expect_length(tt$group_terms, 0)
+  expect_length(tt$response, 1)
+})
+
+test_that(paste(
+  "check that we recover the correct terms for a simple ",
+  "additive model with multidimensional interactions"
+), {
+  formula <- y ~ t2(x, z)
+  tt <- extract_terms_response(formula)
+  expect_length(tt$individual_terms, 0)
+  expect_length(tt$interaction_terms, 0)
+  expect_length(tt$additive_terms, 1)
+  expect_length(tt$group_terms, 0)
+  expect_length(tt$response, 1)
+})
+
 test_that("check that we return the same formula for a single response", {
   formula <- y ~ x + z
   expect_equal(formula, validate_response_formula(formula))

--- a/tests/testthat/test_formula.R
+++ b/tests/testthat/test_formula.R
@@ -143,6 +143,26 @@ test_that("check that we properly split a formula", {
     ),
     sp
   ), 0)
+
+  formula <- y ~ s(x) + s(z)
+  sp <- split_formula(formula)
+  expect_length(sp, 5)
+  expect_length(setdiff(
+    c(
+      "1", "s(x)", "s(z)", "x", "z"
+    ),
+    sp
+  ), 0)
+
+  formula <- y ~ t2(x, z)
+  sp <- split_formula(formula)
+  expect_length(sp, 4)
+  expect_length(setdiff(
+    c(
+      "1", "t2(x, z)", "x", "z"
+    ),
+    sp
+  ), 0)
 })
 
 test_that("check that we can identify formulas with group terms", {


### PR DESCRIPTION
This PR fixes #102 (see https://github.com/paul-buerkner/brms/pull/1133). `projpred:::split_formula()` splits the multidimentional interactions into comma-separated additive terms, which cause `projpred:::make_formula()` to fail. This splits all comma-separated terms and trims any whitespaces.