### PR TITLE
Add missing `else` cases for `weights` and `offset` in `.extract_model_data()`

### DIFF
--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -165,12 +165,16 @@ predict.refmodel <- function(object, newdata, ynew = NULL, offsetnew = NULL,
     weights <- eval_rhs(wrhs, newdata)
   } else if (is.null(wrhs)) {
     weights <- rep(1, NROW(newdata))
+  } else {
+    weights <- wrhs
   }
 
   if (inherits(orhs, "formula")) {
     offset <- eval_rhs(orhs, newdata)
   } else if (is.null(orhs)) {
     offset <- rep(0, NROW(newdata))
+  } else {
+    offset <- orhs
   }
 
   if (inherits(resp_form, "formula")) {


### PR DESCRIPTION
This fixes the following:
```r
library(projpred)
library(rstanarm)
options(mc.cores = parallel::detectCores(logical = FALSE))
data("df_gaussian", package = "projpred")
mydat <- cbind("y" = df_gaussian$y, as.data.frame(df_gaussian$x))
myfit <- stan_glm(y ~ V1 + V2 + V3 + V4 + V5,
                  family = gaussian(),
                  data = mydat,
                  prior = hs(df = 1, global_scale = 0.01),
                  seed = 1140350788)

mylinpred <- proj_linpred(myfit,
                          solution_terms = c("V3", "V2"),
                          newdata = mydat[1:3, , drop = FALSE],
                          offsetnew = c(0.1, 0.2, 0.3),
                          ndraws = 20)
## --> Gives:
##  Error in proj_predfun(fit, newdata = newdata, weights = weights) + offset : 
##    non-numeric argument to binary operator

```