### PR TITLE
Fix a `fetch_submodel()` for intercept-only submodels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * Fixed a bug causing `varsel()`/`make_formula` to fail with multidimensional interaction terms. (GitHub: #102, #103)
 * Fixed an indexing bug in `cv_varsel()` for models with a single predictor. (GitHub: #115)
 * Fixed bugs for argument `nterms` of `proj_linpred()` and `proj_predict()`. (GitHub: #110)
+* Fixed an inconsistency for some intercept-only submodels. (GitHub: #119)
 
 ## projpred 2.0.5
 

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -68,6 +68,10 @@ project_submodel <- function(solution_terms, p_ref, refmodel, family, intercept,
       ## reuse sub_fit as projected during search
       sub_refit <- search_path$sub_fits[[nterms + 1]]
 
+      if (length(solution_terms) == 0 && intercept) {
+        solution_terms <- "1"
+      }
+
       return(.init_submodel(
         sub_fit = sub_refit, p_ref = p_sel, refmodel = refmodel,
         family = family, solution_terms = solution_terms,

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -181,7 +181,9 @@ test_that(paste("output of project is sensible with only data provided as" <
       }
       # j:th element should have j-1 variables
       expect_equal(length(which(p[[j]]$sub_fit$beta != 0)), j - 1)
-      expect_equal(length(p[[j]]$solution_terms), j - 1)
+      if (j > 1) {
+        expect_equal(length(p[[j]]$solution_terms), j - 1)
+      }
       # family kl
       expect_equal(p[[j]]$family, vsd_list[[i]]$family)
     }


### PR DESCRIPTION
This fixes an inconsistency like this one:
```r
library(projpred)

### From `test_datafit.R`:
set.seed(1235)
n <- 40
nterms <- 5
x <- matrix(rnorm(n * nterms, 0, 1), n, nterms)
b <- runif(nterms) - 0.5
dis <- runif(1, 1, 2)
weights <- sample(1:4, n, replace = TRUE)
offset <- rnorm(n)
chains <- 2
seed <- 1235
iter <- 500
ndraws <- 1
ndraws_pred <- 5

f_gauss <- gaussian()
df_gauss <- data.frame(y = rnorm(n, f_gauss$linkinv(x %*% b), dis), x = x)
f_binom <- binomial()
df_binom <- data.frame(
  y = rbinom(n, weights, f_binom$linkinv(x %*% b)),
  x = x, weights = weights
)
f_poiss <- poisson()
df_poiss <- data.frame(y = rpois(n, f_poiss$linkinv(x %*% b)), x = x)

formula <- y ~ x.1 + x.2 + x.3 + x.4 + x.5
extract_model_data <- function(object, newdata = NULL, wrhs = NULL,
                               orhs = NULL, extract_y = FALSE) {
  if (!is.null(object)) {
    formula <- formula(object)
    tt <- extract_terms_response(formula)
    response_name <- tt$response
  } else {
    response_name <- NULL
  }

  if (is.null(newdata)) {
    newdata <- object$data
  }

  resp_form <- NULL
  if (is.null(object)) {
    if ("weights" %in% colnames(newdata))
      wrhs <- ~ weights
    if ("offset" %in% colnames(newdata))
      orhs <- ~ offset
    if ("y" %in% colnames(newdata))
      resp_form <- ~ y
  }

  args <- nlist(object, newdata, wrhs, orhs, resp_form)
  return(do_call(.extract_model_data, args))
}

dref_gauss <- init_refmodel(
  object = NULL, df_gauss, formula, f_gauss,
  extract_model_data = extract_model_data
)
dref_binom <- init_refmodel(
  object = NULL, df_binom, formula, f_binom,
  extract_model_data = extract_model_data
)
dref_poiss <- init_refmodel(
  object = NULL, df_poiss, formula, f_poiss,
  extract_model_data = extract_model_data
)

dref_list <- list(gauss = dref_gauss, binom = dref_binom, poiss = dref_poiss)

# varsel
vsd_list <- lapply(dref_list, varsel, nterms_max = nterms + 1, verbose = FALSE)

# cv_varsel
cvvsd_list <- lapply(dref_list, cv_varsel,
                     nterms_max = nterms + 1, ndraws = ndraws,
                     ndraws_pred = ndraws_pred, verbose = FALSE
)

predd_list <- lapply(vsd_list, proj_linpred,
                     newdata = data.frame(x = x, weights = weights, offset = offset),
                     offsetnew = ~offset, weightsnew = ~weights, nterms = 3,
                     seed = seed
)

p <- project(vsd_list[[1]], nterms = 0:nterms)
###

sapply(p, function(x) {
  count_terms_chosen(x$solution_terms)
})
## --> Without the fix, this gives:
## [1] 0 2 3 4 5 6
## --> With the fix, this gives:
## [1] 1 2 3 4 5 6

```