### PR TITLE
Fix tests for large `ndraws` and `nclusters` in `project()`

### DIFF
--- a/tests/testthat/test_project.R
+++ b/tests/testthat/test_project.R
@@ -248,19 +248,17 @@ if (require(rstanarm)) {
   })
 
   test_that(paste(
-    "project: setting ndraws or nclusters to too",
-    "big throws an error"
+    "project: setting ndraws or nclusters too big causes them to be cut off at",
+    "the number of posterior draws in the reference model"
   ), {
-    expect_error(
-      project(vs_list[[1]], ndraws = 400000, nterms = nterms),
-      paste("Number of posterior draws exceeds the number of columns in the",
-            "reference model's posterior.")
-    )
-    expect_error(
-      project(vs_list[[1]], nclusters = 400000, nterms = nterms),
-      paste("Number of clusters exceeds the number of columns in the",
-            "reference model's posterior.")
-    )
+    p <- project(vs_list[[1]], ndraws = 400000, nterms = nterms)
+    expect_length(p$weights, nrow(as.matrix(fit_list[[1]])))
+    expect_length(p$sub_fit, nrow(as.matrix(fit_list[[1]])))
+    expect_length(p$dis, nrow(as.matrix(fit_list[[1]])))
+    p <- project(vs_list[[1]], nclusters = 400000, nterms = nterms)
+    expect_length(p$weights, nrow(as.matrix(fit_list[[1]])))
+    expect_length(p$sub_fit, nrow(as.matrix(fit_list[[1]])))
+    expect_length(p$dis, nrow(as.matrix(fit_list[[1]])))
   })
 
   test_that("project: specifying the seed does not cause errors", {


### PR DESCRIPTION
Because of line https://github.com/stan-dev/projpred/blob/689e792b04903afe74f9dfe07888713f18a78e6d/R/project.R#L169 and https://github.com/stan-dev/projpred/blob/689e792b04903afe74f9dfe07888713f18a78e6d/R/project.R#L175 `ndraws` and `nclusters` are now internally cut off at `NCOL(refmodel$mu)`, so there is no error thrown by `project()` anymore. The tests expecting an error are thus changed to check the number of draws after projection.