### PR TITLE
refmodel: Remove brmsfit-specific code

### DIFF
--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -456,22 +456,10 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   # this is a dummy definition for cvfun, but it will lead to standard
   # cross-validation for datafit reference; see cv_varsel and get_kfold
   if (is.null(cvfun)) {
-    if (inherits(object, "brmsfit")) {
-      cvfun <- function(folds) {
-        cvres <- brms::kfold(
-          object,
-          K = max(folds),
-          save_fits = TRUE, folds = folds
-        )
-        fits <- cvres$fits[, "fit"]
-        return(fits)
-      }
-    } else {
-      if (!proper_model) {
-        cvfun <- function(folds) lapply(1:max(folds), function(k) list())
-      } else if (is.null(cvfits)) {
-        stop("Please provide either 'cvfun' or 'cvfits'.")
-      }
+    if (!proper_model) {
+      cvfun <- function(folds, ...) lapply(1:max(folds), function(k) list())
+    } else if (is.null(cvfits)) {
+      stop("Please provide either 'cvfun' or 'cvfits'.")
     }
   }
 


### PR DESCRIPTION
This is, and should be, handled by `get_refmodel.brmsfit`. See https://github.com/paul-buerkner/brms/pull/1136.