### PR TITLE
Use brms's naming convention also for submodels of class `"subfit"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,7 @@
 * Fixed bugs for argument `nterms` of `proj_linpred()` and `proj_predict()`. (GitHub: #110)
 * Fixed an inconsistency for some intercept-only submodels. (GitHub: #119)
 * Minor documentation fixes.
-* For submodels of class `"subfit"`, make the column names of `as.matrix.projection()`'s output matrix consistent with other classes of submodels. (GitHub: #<INSERT_PR_NUMBER>)
+* For submodels of class `"subfit"`, make the column names of `as.matrix.projection()`'s output matrix consistent with other classes of submodels. (GitHub: #132)
 
 ## projpred 2.0.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 * Fixed bugs for argument `nterms` of `proj_linpred()` and `proj_predict()`. (GitHub: #110)
 * Fixed an inconsistency for some intercept-only submodels. (GitHub: #119)
 * Minor documentation fixes.
+* For submodels of class `"subfit"`, make the column names of `as.matrix.projection()`'s output matrix consistent with other classes of submodels. (GitHub: #<INSERT_PR_NUMBER>)
 
 ## projpred 2.0.5
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -785,9 +785,9 @@ replace_population_names <- function(population_effects) {
 }
 
 #' @method coef subfit
-coef.subfit <- function(x, ...) {
-  variables <- colnames(x$x)
-  coefs <- with(x, rbind(alpha, beta))
+coef.subfit <- function(object, ...) {
+  variables <- colnames(object$x)
+  coefs <- with(object, rbind(alpha, beta))
   named_coefs <- setNames(coefs, variables)
   return(named_coefs)
 }

--- a/R/methods.R
+++ b/R/methods.R
@@ -786,10 +786,10 @@ replace_population_names <- function(population_effects) {
 
 #' @method coef subfit
 coef.subfit <- function(object, ...) {
-  variables <- colnames(object$x)
-  coefs <- with(object, rbind(alpha, beta))
-  named_coefs <- setNames(coefs, variables)
-  return(named_coefs)
+  return(with(object, c(
+    "Intercept" = alpha,
+    setNames(beta, colnames(x))
+  )))
 }
 
 #' @method as.matrix lm

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -57,7 +57,7 @@ if (require(rstanarm)) {
     expect_length(setdiff(
       colnames(m),
       c(
-        "Intercept", vs_gauss$solution_terms[solution_terms],
+        paste0("b_", c("Intercept", vs_gauss$solution_terms[solution_terms])),
         "sigma"
       )
     ), 0)
@@ -70,8 +70,9 @@ if (require(rstanarm)) {
   ), {
     m <- as.matrix(p_binom)
     expect_length(setdiff(colnames(m),
-                          c("Intercept",
-                            vs_binom$solution_terms[solution_terms])),
+                          paste0("b_",
+                                 c("Intercept",
+                                   vs_binom$solution_terms[solution_terms]))),
                   0)
     expect_equal(dim(m), c(ndraws, length(solution_terms) + 1))
   })
@@ -79,7 +80,7 @@ if (require(rstanarm)) {
   test_that("as.matrix.projection works as expected with zero variables", {
     p_novars <- project(vs_gauss, nterms = 0, ndraws = ndraws)
     m <- as.matrix(p_novars)
-    expect_length(setdiff(colnames(m), c("Intercept", "sigma")), 0)
+    expect_length(setdiff(colnames(m), c("b_Intercept", "sigma")), 0)
     expect_equal(dim(m), c(ndraws, 2))
   })
 
@@ -93,7 +94,7 @@ if (require(rstanarm)) {
       setdiff(
         colnames(m),
         c(
-          "Intercept", vs_gauss$solution_terms[solution_terms],
+          paste0("b_", c("Intercept", vs_gauss$solution_terms[solution_terms])),
           "sigma"
         )
       ),

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -37,12 +37,12 @@ if (require(rstanarm)) {
     gauss = list(
       fitobj = fit_gauss,
       solution_terms_list = list(character(), c("x.3", "x.5")),
-      ndraws_list = list(100, 3, 1)
+      ndraws_list = list(25, 2, 1)
     ),
     binom = list(
       fitobj = fit_binom,
       solution_terms_list = list(c("x.3", "x.5")),
-      ndraws_list = list(100)
+      ndraws_list = list(25)
     )
   )
 

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -38,9 +38,9 @@ if (require(rstanarm)) {
   p_gauss <- project(fit_gauss,
                      solution_terms = solution_terms,
                      ndraws = ndraws)
-  p_binom <- project(fit_binom,
-                     solution_terms = solution_terms,
-                     ndraws = ndraws)
+  SW(p_binom <- project(fit_binom,
+                        solution_terms = solution_terms,
+                        ndraws = ndraws))
 
   test_that(paste(
     "as.matrix.projection returns the relevant variables for",

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -43,40 +43,37 @@ if (require(rstanarm)) {
                         ndraws = ndraws))
 
   test_that(paste(
-    "as.matrix.projection returns the relevant variables for",
-    "gaussian"
+    "as.matrix.projection()'s output structure is correct (for the Gaussian",
+    "family)"
   ), {
     m <- as.matrix(p_gauss)
-    expect_length(setdiff(
-      colnames(m),
-      c(
-        paste0("b_", c("Intercept", solution_terms)),
-        "sigma"
-      )
-    ), 0)
     expect_equal(dim(m), c(ndraws, length(solution_terms) + 2))
+    expect_identical(
+      colnames(m),
+      c(paste0("b_", c("Intercept", solution_terms)),
+        "sigma")
+    )
   })
 
   test_that(paste(
-    "as.matrix.projection returns the relevant variables for",
-    "binomial"
+    "as.matrix.projection()'s output structure is correct (for the binomial",
+    "family)"
   ), {
     m <- as.matrix(p_binom)
-    expect_length(setdiff(colnames(m),
-                          paste0("b_",
-                                 c("Intercept",
-                                   solution_terms))),
-                  0)
     expect_equal(dim(m), c(ndraws, length(solution_terms) + 1))
+    expect_identical(
+      colnames(m),
+      paste0("b_", c("Intercept", solution_terms))
+    )
   })
 
-  test_that("as.matrix.projection works as expected with zero variables", {
+  test_that("as.matrix.projection works as expected with zero solution terms", {
     p_novars <- project(fit_gauss,
                         solution_terms = character(),
                         ndraws = ndraws)
     m <- as.matrix(p_novars)
-    expect_length(setdiff(colnames(m), c("b_Intercept", "sigma")), 0)
     expect_equal(dim(m), c(ndraws, 2))
+    expect_identical(colnames(m), c("b_Intercept", "sigma"))
   })
 
   test_that("as.matrix.projection works with clustering", {
@@ -85,16 +82,11 @@ if (require(rstanarm)) {
                        solution_terms = solution_terms,
                        nclusters = nclusters)
     SW(m <- as.matrix(p_clust))
-    expect_length(
-      setdiff(
-        colnames(m),
-        c(
-          paste0("b_", c("Intercept", solution_terms)),
-          "sigma"
-        )
-      ),
-      0
-    )
     expect_equal(dim(m), c(nclusters, length(solution_terms) + 2))
+    expect_identical(
+      colnames(m),
+      c(paste0("b_", c("Intercept", solution_terms)),
+        "sigma")
+    )
   })
 }

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -1,7 +1,6 @@
 context("as.matrix.projection")
 
-# tests for as_matrix
-
+# Gaussian and binomial reference models without multilevel or additive terms:
 if (require(rstanarm)) {
   set.seed(1235)
   n <- 40
@@ -26,27 +25,23 @@ if (require(rstanarm)) {
 
   SW({
     fit_gauss <- stan_glm(y ~ x.1 + x.2 + x.3 + x.4 + x.5,
-                          family = f_gauss, data = df_gauss,
-                          chains = chains, seed = seed, iter = iter
-    )
+                          data = df_gauss, family = f_gauss,
+                          chains = chains, seed = seed, iter = iter)
     fit_binom <- stan_glm(cbind(y, weights - y) ~ x.1 + x.2 + x.3 + x.4 + x.5,
-                          family = f_binom, weights = weights,
-                          data = df_binom, chains = chains, seed = seed,
-                          iter = iter
-    )
+                          data = df_binom, family = f_binom,
+                          weights = weights,
+                          chains = chains, seed = seed, iter = iter)
 
-    vs_gauss <- varsel(fit_gauss, ndraws = 1, ndraws_pred = 5)
-    vs_binom <- varsel(fit_binom, ndraws = 1, ndraws_pred = 5)
+    vs_gauss <- varsel(fit_gauss, nclusters = 1, nclusters_pred = 5)
+    vs_binom <- varsel(fit_binom, nclusters = 1, nclusters_pred = 5)
     solution_terms <- c(2, 3)
     ndraws <- 100
     p_gauss <- project(vs_gauss,
                        solution_terms = vs_gauss$solution_terms[solution_terms],
-                       ndraws = ndraws
-    )
+                       ndraws = ndraws)
     p_binom <- project(vs_binom,
                        solution_terms = vs_binom$solution_terms[solution_terms],
-                       ndraws = ndraws
-    )
+                       ndraws = ndraws)
   })
 
   test_that(paste(

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -31,18 +31,15 @@ if (require(rstanarm)) {
                           data = df_binom, family = f_binom,
                           weights = weights,
                           chains = chains, seed = seed, iter = iter)
-
-    vs_gauss <- varsel(fit_gauss, nclusters = 1, nclusters_pred = 5)
-    vs_binom <- varsel(fit_binom, nclusters = 1, nclusters_pred = 5)
   })
 
-  solution_terms <- c(2, 3)
+  solution_terms <- c("x.3", "x.5")
   ndraws <- 100
-  p_gauss <- project(vs_gauss,
-                     solution_terms = vs_gauss$solution_terms[solution_terms],
+  p_gauss <- project(fit_gauss,
+                     solution_terms = solution_terms,
                      ndraws = ndraws)
-  p_binom <- project(vs_binom,
-                     solution_terms = vs_binom$solution_terms[solution_terms],
+  p_binom <- project(fit_binom,
+                     solution_terms = solution_terms,
                      ndraws = ndraws)
 
   test_that(paste(
@@ -53,7 +50,7 @@ if (require(rstanarm)) {
     expect_length(setdiff(
       colnames(m),
       c(
-        paste0("b_", c("Intercept", vs_gauss$solution_terms[solution_terms])),
+        paste0("b_", c("Intercept", solution_terms)),
         "sigma"
       )
     ), 0)
@@ -68,13 +65,15 @@ if (require(rstanarm)) {
     expect_length(setdiff(colnames(m),
                           paste0("b_",
                                  c("Intercept",
-                                   vs_binom$solution_terms[solution_terms]))),
+                                   solution_terms))),
                   0)
     expect_equal(dim(m), c(ndraws, length(solution_terms) + 1))
   })
 
   test_that("as.matrix.projection works as expected with zero variables", {
-    p_novars <- project(vs_gauss, nterms = 0, ndraws = ndraws)
+    p_novars <- project(fit_gauss,
+                        solution_terms = character(),
+                        ndraws = ndraws)
     m <- as.matrix(p_novars)
     expect_length(setdiff(colnames(m), c("b_Intercept", "sigma")), 0)
     expect_equal(dim(m), c(ndraws, 2))
@@ -82,15 +81,15 @@ if (require(rstanarm)) {
 
   test_that("as.matrix.projection works with clustering", {
     nclusters <- 3
-    p_clust <- project(vs_gauss,
-                       solution_terms = vs_gauss$solution_terms[solution_terms],
+    p_clust <- project(fit_gauss,
+                       solution_terms = solution_terms,
                        nclusters = nclusters)
     SW(m <- as.matrix(p_clust))
     expect_length(
       setdiff(
         colnames(m),
         c(
-          paste0("b_", c("Intercept", vs_gauss$solution_terms[solution_terms])),
+          paste0("b_", c("Intercept", solution_terms)),
           "sigma"
         )
       ),

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -34,15 +34,16 @@ if (require(rstanarm)) {
 
     vs_gauss <- varsel(fit_gauss, nclusters = 1, nclusters_pred = 5)
     vs_binom <- varsel(fit_binom, nclusters = 1, nclusters_pred = 5)
-    solution_terms <- c(2, 3)
-    ndraws <- 100
-    p_gauss <- project(vs_gauss,
-                       solution_terms = vs_gauss$solution_terms[solution_terms],
-                       ndraws = ndraws)
-    p_binom <- project(vs_binom,
-                       solution_terms = vs_binom$solution_terms[solution_terms],
-                       ndraws = ndraws)
   })
+
+  solution_terms <- c(2, 3)
+  ndraws <- 100
+  p_gauss <- project(vs_gauss,
+                     solution_terms = vs_gauss$solution_terms[solution_terms],
+                     ndraws = ndraws)
+  p_binom <- project(vs_binom,
+                     solution_terms = vs_binom$solution_terms[solution_terms],
+                     ndraws = ndraws)
 
   test_that(paste(
     "as.matrix.projection returns the relevant variables for",

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -37,7 +37,7 @@ if (require(rstanarm)) {
     gauss = list(
       fitobj = fit_gauss,
       solution_terms_list = list(character(), c("x.3", "x.5")),
-      ndraws_list = list(100, 3)
+      ndraws_list = list(100, 3, 1)
     ),
     binom = list(
       fitobj = fit_binom,


### PR DESCRIPTION
Since commit e420740961529c2f13fc26675b0e6ba30cf94a32 ff., the `as.matrix.<class_name>()` methods use brms's naming convention for the parameters. However, the `as.matrix.subfit()` method was somehow forgotten at that time, as illustrated by the following reprex:
```r
# Source: <https://github.com/stan-dev/projpred/blob/master/README.md>
library(projpred)
library(rstanarm)
options(mc.cores = parallel::detectCores(logical = FALSE))
data("df_gaussian", package = "projpred")
mydat <- cbind("y" = df_gaussian$y, as.data.frame(df_gaussian$x))
myfit <- stan_glm(y ~ V1 + V2 + V3 + V4 + V5,
                  family = gaussian(),
                  data = mydat,
                  prior = hs(df = 1, global_scale = 0.01),
                  seed = 1140350788)

myprj <- project(myfit,
                 solution_terms = c("V1"),
                 nclusters = 2)
# Only to show that the submodels are of class "subfit":
stopifnot(identical(
  class(myprj$sub_fit[[1]]),
  c("subfit")
))
myprjmat <- as.matrix(myprj)
colnames(myprjmat)
```
Previously (i.e. on branch `develop`, for example), that last line gave:
```
[1] "Intercept" "V1"        "sigma"
```
This PR fixes that issue (i.e. it uses brms's naming convention also for submodels of class `"subfit"`), so that the reprex's last line gives:
```
[1] "b_Intercept" "b_V1"        "sigma"
```

Note that commit 6e56e6c is basically taken from PR #130. It is included here to have a clear history.