### PR TITLE
Handle `size_sub` differently and fix `seed_sub`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 * Fixed bugs for argument `nterms` of `proj_linpred()` and `proj_predict()`. (GitHub: #110)
 * Fixed an inconsistency for some intercept-only submodels. (GitHub: #119)
 * Minor documentation fixes.
+* Argument `size_sub` of `proj_predict()` is now cut off at its maximum possible value. (GitHub: #134)
 
 ## projpred 2.0.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,8 @@
 * Fixed bugs for argument `nterms` of `proj_linpred()` and `proj_predict()`. (GitHub: #110)
 * Fixed an inconsistency for some intercept-only submodels. (GitHub: #119)
 * Minor documentation fixes.
-* Argument `size_sub` of `proj_predict()` is now cut off at its maximum possible value. (GitHub: #134)
+* Argument `size_sub` of `proj_predict()` is now handled differently; see its documentation. (GitHub: #134)
+* Argument `seed_sub` of `proj_predict()` was renamed to `seed_ppd` and its documentation was fixed. (GitHub: #134)
 
 ## projpred 2.0.5
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -264,6 +264,7 @@ proj_predict <- function(object, filter_nterms = NULL, newdata = NULL,
 proj_predict_aux <- function(proj, mu, weights, ...) {
   dot_args <- list(...)
   stopifnot(!is.null(dot_args$size_sub))
+  dot_args$size_sub <- min(NCOL(mu), dot_args$size_sub)
   draw_inds <- sample(
     x = seq_along(proj$weights), size = dot_args$size_sub,
     replace = TRUE, prob = proj$weights

--- a/R/methods.R
+++ b/R/methods.R
@@ -263,12 +263,16 @@ proj_predict <- function(object, filter_nterms = NULL, newdata = NULL,
 ## function applied to each projected submodel in case of proj_predict()
 proj_predict_aux <- function(proj, mu, weights, ...) {
   dot_args <- list(...)
-  stopifnot(!is.null(dot_args$size_sub))
-  dot_args$size_sub <- min(NCOL(mu), dot_args$size_sub)
-  draw_inds <- sample(
-    x = seq_along(proj$weights), size = dot_args$size_sub,
-    replace = TRUE, prob = proj$weights
-  )
+  if (proj$p_type) {
+    # In this case, the posterior draws have been clustered.
+    stopifnot(!is.null(dot_args$size_sub))
+    draw_inds <- sample(
+      x = seq_along(proj$weights), size = dot_args$size_sub,
+      replace = TRUE, prob = proj$weights
+    )
+  } else {
+    draw_inds <- seq_along(proj$weights)
+  }
 
   do.call(rbind, lapply(draw_inds, function(i) {
     proj$family$ppd(mu[, i], proj$dis[i], weights)

--- a/R/methods.R
+++ b/R/methods.R
@@ -37,17 +37,15 @@
 #'   only.
 #' @param integrated If \code{TRUE}, the output is averaged over the projected
 #'   posterior draws. Default is \code{FALSE}. For \code{proj_linpred} only.
-#' @param size_sub For \code{proj_predict} only: Number of draws to return from
-#'   the predictive distribution of the projection. Not to be confused with
-#'   arguments \code{ndraws} and \code{nclusters} of \link{project}:
-#'   \code{size_sub} gives a \emph{subset} of the (possibly clustered) posterior
-#'   draws after projection (as determined by arguments \code{ndraws} and
-#'   \code{nclusters} of \link{project}). The default for \code{size_sub} is
-#'   1000. We compute as many clusters from the reference posterior as draws, so
-#'   we end up projecting a single draw from each cluster.
-#' @param seed_sub For \code{proj_predict} only: An optional seed for subsetting
-#'   the (possibly clustered) posterior draws after projection (see argument
-#'   \code{size_sub}).
+#' @param size_sub For \code{proj_predict} with clustered projection only:
+#'   Number of draws to return from the predictive distribution of the
+#'   projection. Not to be confused with argument \code{nclusters} of
+#'   \link{project}: \code{size_sub} gives the number of draws (\emph{with}
+#'   replacement) from the set of clustered posterior draws after projection (as
+#'   determined by argument \code{nclusters} of \link{project}).
+#' @param seed_sub For \code{proj_predict} only: An optional seed for drawing
+#'   from the set of clustered posterior draws after projection (if clustered
+#'   projection was performed; see argument \code{size_sub}).
 #' @param ... Additional arguments passed to \link{project} if \code{object} is
 #'   not already an object returned by \link{project}.
 #'
@@ -798,27 +796,37 @@ coef.subfit <- function(x, ...) {
 }
 
 #' @method as.matrix lm
+#' @keywords internal
+#' @export
 as.matrix.lm <- function(x, ...) {
   return(coef(x) %>%
            replace_population_names())
 }
 
 #' @method as.matrix ridgelm
+#' @keywords internal
+#' @export
 as.matrix.ridgelm <- function(x, ...) {
   return(as.matrix.lm(x))
 }
 
 #' @method as.matrix subfit
+#' @keywords internal
+#' @export
 as.matrix.subfit <- function(x, ...) {
   return(as.matrix.lm(x))
 }
 
 #' @method as.matrix glm
+#' @keywords internal
+#' @export
 as.matrix.glm <- function(x, ...) {
   return(as.matrix.lm(x))
 }
 
 #' @method as.matrix lmerMod
+#' @keywords internal
+#' @export
 as.matrix.lmerMod <- function(x, ...) {
   population_effects <- lme4::fixef(x) %>%
     replace_population_names()
@@ -942,31 +950,42 @@ as.matrix.noquote <- function(x, ...) {
 }
 
 #' @method as.matrix list
+#' @keywords internal
+#' @export
 as.matrix.list <- function(x, ...) {
   return(do.call(cbind, lapply(x, as.matrix.glm)))
 }
 
 #' @method t glm
+#' @keywords internal
+#' @export
 t.glm <- function(x, ...) {
   return(t(as.matrix(x)))
 }
 
 #' @method t lm
+#' @keywords internal
+#' @export
 t.lm <- function(x, ...) {
   return(t(as.matrix(x)))
 }
 
 #' @method t ridgelm
+#' @keywords internal
+#' @export
 t.ridgelm <- function(x, ...) {
   return(t(as.matrix(x)))
 }
 
 #' @method t list
+#' @keywords internal
+#' @export
 t.list <- function(x, ...) {
   return(t(as.matrix.list(x)))
 }
 
 #' @method as.matrix projection
+#' @keywords internal
 #' @export
 as.matrix.projection <- function(x, ...) {
   if (x$p_type) {

--- a/R/methods.R
+++ b/R/methods.R
@@ -43,9 +43,10 @@
 #'   \link{project}: \code{size_sub} gives the number of draws (\emph{with}
 #'   replacement) from the set of clustered posterior draws after projection (as
 #'   determined by argument \code{nclusters} of \link{project}).
-#' @param seed_sub For \code{proj_predict} only: An optional seed for drawing
-#'   from the set of clustered posterior draws after projection (if clustered
-#'   projection was performed; see argument \code{size_sub}).
+#' @param seed_ppd For \code{proj_predict} only: An optional seed for drawing
+#'   from the posterior predictive distribution. If a clustered projection was
+#'   performed, `seed_ppd` is also used for drawing from the set of clustered
+#'   posterior draws after projection (see argument \code{size_sub}).
 #' @param ... Additional arguments passed to \link{project} if \code{object} is
 #'   not already an object returned by \link{project}.
 #'
@@ -243,11 +244,11 @@ compute_lpd <- function(ynew, pred, proj, weights, integrated = FALSE,
 #' @export
 proj_predict <- function(object, filter_nterms = NULL, newdata = NULL,
                          offsetnew = NULL, weightsnew = NULL, size_sub = 1000,
-                         seed_sub = NULL, ...) {
+                         seed_ppd = NULL, ...) {
   ## set random seed but ensure the old RNG state is restored on exit
   rng_state_old <- rngtools::RNGseed()
   on.exit(rngtools::RNGseed(rng_state_old))
-  set.seed(seed_sub)
+  set.seed(seed_ppd)
 
   ## proj_helper lapplies fun to each projection in object
   proj_helper(

--- a/man/proj-pred.Rd
+++ b/man/proj-pred.Rd
@@ -69,18 +69,16 @@ posterior draws. Default is \code{FALSE}. For \code{proj_linpred} only.}
 \item{...}{Additional arguments passed to \link{project} if \code{object} is
 not already an object returned by \link{project}.}
 
-\item{size_sub}{For \code{proj_predict} only: Number of draws to return from
-the predictive distribution of the projection. Not to be confused with
-arguments \code{ndraws} and \code{nclusters} of \link{project}:
-\code{size_sub} gives a \emph{subset} of the (possibly clustered) posterior
-draws after projection (as determined by arguments \code{ndraws} and
-\code{nclusters} of \link{project}). The default for \code{size_sub} is
-1000. We compute as many clusters from the reference posterior as draws, so
-we end up projecting a single draw from each cluster.}
+\item{size_sub}{For \code{proj_predict} with clustered projection only:
+Number of draws to return from the predictive distribution of the
+projection. Not to be confused with argument \code{nclusters} of
+\link{project}: \code{size_sub} gives the number of draws (\emph{with}
+replacement) from the set of clustered posterior draws after projection (as
+determined by argument \code{nclusters} of \link{project}).}
 
-\item{seed_sub}{For \code{proj_predict} only: An optional seed for subsetting
-the (possibly clustered) posterior draws after projection (see argument
-\code{size_sub}).}
+\item{seed_sub}{For \code{proj_predict} only: An optional seed for drawing
+from the set of clustered posterior draws after projection (if clustered
+projection was performed; see argument \code{size_sub}).}
 }
 \value{
 If the prediction is done for one submodel only (\code{nterms} has

--- a/man/proj-pred.Rd
+++ b/man/proj-pred.Rd
@@ -25,7 +25,7 @@ proj_predict(
   offsetnew = NULL,
   weightsnew = NULL,
   size_sub = 1000,
-  seed_sub = NULL,
+  seed_ppd = NULL,
   ...
 )
 }
@@ -76,9 +76,10 @@ projection. Not to be confused with argument \code{nclusters} of
 replacement) from the set of clustered posterior draws after projection (as
 determined by argument \code{nclusters} of \link{project}).}
 
-\item{seed_sub}{For \code{proj_predict} only: An optional seed for drawing
-from the set of clustered posterior draws after projection (if clustered
-projection was performed; see argument \code{size_sub}).}
+\item{seed_ppd}{For \code{proj_predict} only: An optional seed for drawing
+from the posterior predictive distribution. If a clustered projection was
+performed, `seed_ppd` is also used for drawing from the set of clustered
+posterior draws after projection (see argument \code{size_sub}).}
 }
 \value{
 If the prediction is done for one submodel only (\code{nterms} has

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -131,12 +131,12 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
         SW({
           foo <- proj_predict(fit, frame,
                               solution_terms = solution_terms,
-                              seed = seed, seed_sub = seed
+                              seed = seed, seed_ppd = seed
           )
           r1 <- rnorm(s)
           foo <- proj_predict(fit, frame,
                               solution_terms = solution_terms,
-                              seed = seed, seed_sub = seed
+                              seed = seed, seed_ppd = seed
           )
           r2 <- rnorm(s)
         })
@@ -215,11 +215,11 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
         SW({
           foo <- proj_predict(fit, frame,
                               solution_terms = solution_terms,
-                              seed = seed, seed_sub = seed
+                              seed = seed, seed_ppd = seed
           )
           bar <- proj_predict(fit, frame,
                               solution_terms = solution_terms,
-                              seed = seed, seed_sub = seed
+                              seed = seed, seed_ppd = seed
           )
         })
         expect_equal(foo, bar)

--- a/tests/testthat/test_proj_pred.R
+++ b/tests/testthat/test_proj_pred.R
@@ -442,11 +442,11 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
   test_that("proj_predict: specifying weightsnew has an expected effect", {
     pl <- proj_predict(proj_solution_terms_list[["binom"]],
                        newdata = data.frame(x = x, weights = rep(1, NROW(x))),
-                       seed = seed, seed_sub = seed
+                       seed = seed, seed_ppd = seed
     )
     plw <- proj_predict(proj_solution_terms_list[["binom"]],
                         newdata = data.frame(x = x, weights = weights),
-                        seed = seed, seed_sub = seed,
+                        seed = seed, seed_ppd = seed,
                         weightsnew = ~weights
     )
     expect_true(sum(pl != plw) > 0)
@@ -457,12 +457,12 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
       i_inf <- names(proj_solution_terms_list)[i]
       pl <- proj_predict(proj_solution_terms_list[[i]],
                          newdata = data.frame(x = x), size_sub = iter,
-                         seed = seed, seed_sub = seed
+                         seed = seed, seed_ppd = seed
       )
       plo <- proj_predict(proj_solution_terms_list[[i]],
                           newdata = data.frame(x = x, offset = offset),
                           size_sub = iter,
-                          seed = seed, seed_sub = seed, offsetnew = ~offset
+                          seed = seed, seed_ppd = seed, offsetnew = ~offset
       )
       expect_true(sum(pl != plo) > 0, info = i_inf)
     }
@@ -478,17 +478,17 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
   })
 
   test_that(paste(
-    "proj_predict: specifying seed and seed_sub has an expected",
+    "proj_predict: specifying seed and seed_ppd has an expected",
     "effect"
   ), {
     for (i in 1:length(proj_solution_terms_list)) {
       i_inf <- names(proj_solution_terms_list)[i]
       pl1 <- proj_predict(proj_solution_terms_list[[i]],
                           newdata = data.frame(x = x),
-                          seed = seed, seed_sub = seed)
+                          seed = seed, seed_ppd = seed)
       pl2 <- proj_predict(proj_solution_terms_list[[i]],
                           newdata = data.frame(x = x),
-                          seed = seed, seed_sub = seed)
+                          seed = seed, seed_ppd = seed)
       expect_equal(pl1, pl2, info = i_inf)
     }
   })
@@ -498,18 +498,18 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
       i_inf <- names(vs_list)[i]
       prp1 <- proj_predict(vs_list[[i]],
                            newdata = data.frame(x = x), size_sub = 100,
-                           seed = 12, seed_sub = 12, nterms = c(2, 4),
+                           seed = 12, seed_ppd = 12, nterms = c(2, 4),
                            nclusters = 2,
                            regul = 1e-08
       )
       prp2 <- proj_predict(vs_list[[i]],
                            newdata = data.frame(x = x), size_sub = 100,
                            nterms = c(2, 4), nclusters = 2, regul = 1e-8,
-                           seed = 12, seed_sub = 12
+                           seed = 12, seed_ppd = 12
       )
       prp3 <- proj_predict(vs_list[[i]],
                            newdata = data.frame(x = x), size_sub = 100,
-                           seed = 120, seed_sub = 120, nterms = c(2, 4),
+                           seed = 120, seed_ppd = 120, nterms = c(2, 4),
                            nclusters = 2,
                            regul = 1e-08
       )


### PR DESCRIPTION
This fixes the following issue:
```r
library(projpred)
library(rstanarm)
options(mc.cores = parallel::detectCores(logical = FALSE))
data("df_gaussian", package = "projpred")
mydat <- cbind("y" = df_gaussian$y, as.data.frame(df_gaussian$x))
myfit <- stan_glm(y ~ V1 + V2 + V3 + V4 + V5,
                  family = gaussian(),
                  data = mydat,
                  prior = hs(df = 1, global_scale = 0.01),
                  seed = 1140350788)

mypred <- proj_predict(myfit,
                       solution_terms = c("V3", "V2"),
                       newdata = mydat[1:3, , drop = FALSE],
                       nclusters = 2)
str(mypred)
```
Previously (i.e. on branch `develop`, for example), that last line gave:
```
num [1:1000, 1:3] 2.834 -1.349 -0.357 0.392 3.44 ...
```
This PR fixes that issue (i.e. it cuts off `size_sub` at its maximum possible value), so that the reprex's last line gives:
```
num [1:2, 1:3] 0.0801 1.9877 0.6548 2.1995 -0.9375 ...
```
**EDIT:** Please read the comments below before merging.
