### PR TITLE
Change arguments `size_sub` and `seed_sub`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 ### Major changes
 
 * The behavior of arguments `ndraws`, `nclusters`, `ndraws_pred`, and `nclusters_pred` in `varsel()`, `cv_varsel()`, and `project()` has been changed: Now, `ndraws` and `ndraws_pred` have non-`NULL` defaults and for `ndraws <= 20` or `ndraws_pred <= 20`, the value of `ndraws` or `ndraws_pred` is passed to `nclusters` or `nclusters_pred`, respectively (so that clustering is used). (GitHub: commits babe031db7732e0d81dd2591938551d02dcf374d, 4ef95d3b4ab85eaaa5177c4d40f33b2943bff37c, and ce7d1e001fd76830c4379cbbe0dfe730cba8d9e5)
-* For `proj_linpred()` and `proj_predict()`, arguments `nterms`, `ndraws`, and `seed` have been removed to allow the user to pass them to `project()`. New arguments `filter_nterms`, `size_sub`, and `seed_sub` have been introduced (see the documentation for details). (GitHub: #92)
+* For `proj_linpred()` and `proj_predict()`, arguments `nterms`, `ndraws`, and `seed` have been removed to allow the user to pass them to `project()`. New arguments `filter_nterms`, `nclusters_resample`, and `seed_ppd` have been introduced (see the documentation for details). (GitHub: #92, #135)
 * Reference models lacking an intercept are not supported anymore (actually, the previous implementation for such models was incomplete). Support might be re-introduced in the future (when fixed), but for now it is withdrawn as it requires some larger changes. (GitHub: #124, but see also #96 and #100)
 
 ## Minor changes

--- a/R/methods.R
+++ b/R/methods.R
@@ -37,17 +37,15 @@
 #'   only.
 #' @param integrated If \code{TRUE}, the output is averaged over the projected
 #'   posterior draws. Default is \code{FALSE}. For \code{proj_linpred} only.
-#' @param size_sub For \code{proj_predict} only: Number of draws to return from
-#'   the predictive distribution of the projection. Not to be confused with
-#'   arguments \code{ndraws} and \code{nclusters} of \link{project}:
-#'   \code{size_sub} gives a \emph{subset} of the (possibly clustered) posterior
-#'   draws after projection (as determined by arguments \code{ndraws} and
-#'   \code{nclusters} of \link{project}). The default for \code{size_sub} is
-#'   1000. We compute as many clusters from the reference posterior as draws, so
-#'   we end up projecting a single draw from each cluster.
-#' @param seed_sub For \code{proj_predict} only: An optional seed for subsetting
-#'   the (possibly clustered) posterior draws after projection (see argument
-#'   \code{size_sub}).
+#' @param size_sub For \code{proj_predict} with clustered projection only:
+#'   Number of draws to return from the predictive distribution of the
+#'   projection. Not to be confused with argument \code{nclusters} of
+#'   \link{project}: \code{size_sub} gives the number of draws (\emph{with}
+#'   replacement) from the set of clustered posterior draws after projection (as
+#'   determined by argument \code{nclusters} of \link{project}).
+#' @param seed_sub For \code{proj_predict} only: An optional seed for drawing
+#'   from the set of clustered posterior draws after projection (if clustered
+#'   projection was performed; see argument \code{size_sub}).
 #' @param ... Additional arguments passed to \link{project} if \code{object} is
 #'   not already an object returned by \link{project}.
 #'

--- a/R/methods.R
+++ b/R/methods.R
@@ -263,11 +263,16 @@ proj_predict <- function(object, filter_nterms = NULL, newdata = NULL,
 ## function applied to each projected submodel in case of proj_predict()
 proj_predict_aux <- function(proj, mu, weights, ...) {
   dot_args <- list(...)
-  stopifnot(!is.null(dot_args$size_sub))
-  draw_inds <- sample(
-    x = seq_along(proj$weights), size = dot_args$size_sub,
-    replace = TRUE, prob = proj$weights
-  )
+  if (proj$p_type) {
+    # In this case, the posterior draws have been clustered.
+    stopifnot(!is.null(dot_args$size_sub))
+    draw_inds <- sample(
+      x = seq_along(proj$weights), size = dot_args$size_sub,
+      replace = TRUE, prob = proj$weights
+    )
+  } else {
+    draw_inds <- seq_along(proj$weights)
+  }
 
   do.call(rbind, lapply(draw_inds, function(i) {
     proj$family$ppd(mu[, i], proj$dis[i], weights)

--- a/R/methods.R
+++ b/R/methods.R
@@ -43,9 +43,10 @@
 #'   \link{project}: \code{size_sub} gives the number of draws (\emph{with}
 #'   replacement) from the set of clustered posterior draws after projection (as
 #'   determined by argument \code{nclusters} of \link{project}).
-#' @param seed_sub For \code{proj_predict} only: An optional seed for drawing
-#'   from the set of clustered posterior draws after projection (if clustered
-#'   projection was performed; see argument \code{size_sub}).
+#' @param seed_ppd For \code{proj_predict} only: An optional seed for drawing
+#'   from the posterior predictive distribution. If a clustered projection was
+#'   performed, `seed_ppd` is also used for drawing from the set of clustered
+#'   posterior draws after projection (see argument \code{size_sub}).
 #' @param ... Additional arguments passed to \link{project} if \code{object} is
 #'   not already an object returned by \link{project}.
 #'
@@ -243,11 +244,11 @@ compute_lpd <- function(ynew, pred, proj, weights, integrated = FALSE,
 #' @export
 proj_predict <- function(object, filter_nterms = NULL, newdata = NULL,
                          offsetnew = NULL, weightsnew = NULL, size_sub = 1000,
-                         seed_sub = NULL, ...) {
+                         seed_ppd = NULL, ...) {
   ## set random seed but ensure the old RNG state is restored on exit
   rng_state_old <- rngtools::RNGseed()
   on.exit(rngtools::RNGseed(rng_state_old))
-  set.seed(seed_sub)
+  set.seed(seed_ppd)
 
   ## proj_helper lapplies fun to each projection in object
   proj_helper(

--- a/man/proj-pred.Rd
+++ b/man/proj-pred.Rd
@@ -69,18 +69,16 @@ posterior draws. Default is \code{FALSE}. For \code{proj_linpred} only.}
 \item{...}{Additional arguments passed to \link{project} if \code{object} is
 not already an object returned by \link{project}.}
 
-\item{size_sub}{For \code{proj_predict} only: Number of draws to return from
-the predictive distribution of the projection. Not to be confused with
-arguments \code{ndraws} and \code{nclusters} of \link{project}:
-\code{size_sub} gives a \emph{subset} of the (possibly clustered) posterior
-draws after projection (as determined by arguments \code{ndraws} and
-\code{nclusters} of \link{project}). The default for \code{size_sub} is
-1000. We compute as many clusters from the reference posterior as draws, so
-we end up projecting a single draw from each cluster.}
+\item{size_sub}{For \code{proj_predict} with clustered projection only:
+Number of draws to return from the predictive distribution of the
+projection. Not to be confused with argument \code{nclusters} of
+\link{project}: \code{size_sub} gives the number of draws (\emph{with}
+replacement) from the set of clustered posterior draws after projection (as
+determined by argument \code{nclusters} of \link{project}).}
 
-\item{seed_sub}{For \code{proj_predict} only: An optional seed for subsetting
-the (possibly clustered) posterior draws after projection (see argument
-\code{size_sub}).}
+\item{seed_sub}{For \code{proj_predict} only: An optional seed for drawing
+from the set of clustered posterior draws after projection (if clustered
+projection was performed; see argument \code{size_sub}).}
 }
 \value{
 If the prediction is done for one submodel only (\code{nterms} has

--- a/man/proj-pred.Rd
+++ b/man/proj-pred.Rd
@@ -24,7 +24,7 @@ proj_predict(
   newdata = NULL,
   offsetnew = NULL,
   weightsnew = NULL,
-  size_sub = 1000,
+  nclusters_resample = 1000,
   seed_ppd = NULL,
   ...
 )
@@ -69,17 +69,17 @@ posterior draws. Default is \code{FALSE}. For \code{proj_linpred} only.}
 \item{...}{Additional arguments passed to \link{project} if \code{object} is
 not already an object returned by \link{project}.}
 
-\item{size_sub}{For \code{proj_predict} with clustered projection only:
-Number of draws to return from the predictive distribution of the
+\item{nclusters_resample}{For \code{proj_predict} with clustered projection
+only: Number of draws to return from the predictive distribution of the
 projection. Not to be confused with argument \code{nclusters} of
-\link{project}: \code{size_sub} gives the number of draws (\emph{with}
-replacement) from the set of clustered posterior draws after projection (as
-determined by argument \code{nclusters} of \link{project}).}
+\link{project}: \code{nclusters_resample} gives the number of draws
+(\emph{with} replacement) from the set of clustered posterior draws after
+projection (as determined by argument \code{nclusters} of \link{project}).}
 
 \item{seed_ppd}{For \code{proj_predict} only: An optional seed for drawing
 from the posterior predictive distribution. If a clustered projection was
 performed, `seed_ppd` is also used for drawing from the set of clustered
-posterior draws after projection (see argument \code{size_sub}).}
+posterior draws after projection (see argument \code{nclusters_resample}).}
 }
 \value{
 If the prediction is done for one submodel only (\code{nterms} has

--- a/man/proj-pred.Rd
+++ b/man/proj-pred.Rd
@@ -25,7 +25,7 @@ proj_predict(
   offsetnew = NULL,
   weightsnew = NULL,
   size_sub = 1000,
-  seed_sub = NULL,
+  seed_ppd = NULL,
   ...
 )
 }
@@ -76,9 +76,10 @@ projection. Not to be confused with argument \code{nclusters} of
 replacement) from the set of clustered posterior draws after projection (as
 determined by argument \code{nclusters} of \link{project}).}
 
-\item{seed_sub}{For \code{proj_predict} only: An optional seed for drawing
-from the set of clustered posterior draws after projection (if clustered
-projection was performed; see argument \code{size_sub}).}
+\item{seed_ppd}{For \code{proj_predict} only: An optional seed for drawing
+from the posterior predictive distribution. If a clustered projection was
+performed, `seed_ppd` is also used for drawing from the set of clustered
+posterior draws after projection (see argument \code{size_sub}).}
 }
 \value{
 If the prediction is done for one submodel only (\code{nterms} has

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -131,12 +131,12 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
         SW({
           foo <- proj_predict(fit, frame,
                               solution_terms = solution_terms,
-                              seed = seed, seed_sub = seed
+                              seed = seed, seed_ppd = seed
           )
           r1 <- rnorm(s)
           foo <- proj_predict(fit, frame,
                               solution_terms = solution_terms,
-                              seed = seed, seed_sub = seed
+                              seed = seed, seed_ppd = seed
           )
           r2 <- rnorm(s)
         })
@@ -215,11 +215,11 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
         SW({
           foo <- proj_predict(fit, frame,
                               solution_terms = solution_terms,
-                              seed = seed, seed_sub = seed
+                              seed = seed, seed_ppd = seed
           )
           bar <- proj_predict(fit, frame,
                               solution_terms = solution_terms,
-                              seed = seed, seed_sub = seed
+                              seed = seed, seed_ppd = seed
           )
         })
         expect_equal(foo, bar)

--- a/tests/testthat/test_proj_pred.R
+++ b/tests/testthat/test_proj_pred.R
@@ -472,8 +472,9 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
     for (i in 1:length(proj_solution_terms_list)) {
       i_inf <- names(proj_solution_terms_list)[i]
       pl <- proj_predict(proj_solution_terms_list[[i]],
-                         newdata = data.frame(x = x), size_sub = iter)
-      expect_equal(dim(pl), c(iter, n))
+                         newdata = data.frame(x = x))
+      # 400 is the default for project()'s argument `ndraws`:
+      expect_equal(dim(pl), c(400, n))
     }
   })
 

--- a/tests/testthat/test_proj_pred.R
+++ b/tests/testthat/test_proj_pred.R
@@ -442,11 +442,11 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
   test_that("proj_predict: specifying weightsnew has an expected effect", {
     pl <- proj_predict(proj_solution_terms_list[["binom"]],
                        newdata = data.frame(x = x, weights = rep(1, NROW(x))),
-                       seed = seed, seed_sub = seed
+                       seed = seed, seed_ppd = seed
     )
     plw <- proj_predict(proj_solution_terms_list[["binom"]],
                         newdata = data.frame(x = x, weights = weights),
-                        seed = seed, seed_sub = seed,
+                        seed = seed, seed_ppd = seed,
                         weightsnew = ~weights
     )
     expect_true(sum(pl != plw) > 0)
@@ -457,12 +457,12 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
       i_inf <- names(proj_solution_terms_list)[i]
       pl <- proj_predict(proj_solution_terms_list[[i]],
                          newdata = data.frame(x = x), size_sub = iter,
-                         seed = seed, seed_sub = seed
+                         seed = seed, seed_ppd = seed
       )
       plo <- proj_predict(proj_solution_terms_list[[i]],
                           newdata = data.frame(x = x, offset = offset),
                           size_sub = iter,
-                          seed = seed, seed_sub = seed, offsetnew = ~offset
+                          seed = seed, seed_ppd = seed, offsetnew = ~offset
       )
       expect_true(sum(pl != plo) > 0, info = i_inf)
     }
@@ -478,17 +478,17 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
   })
 
   test_that(paste(
-    "proj_predict: specifying seed and seed_sub has an expected",
+    "proj_predict: specifying seed and seed_ppd has an expected",
     "effect"
   ), {
     for (i in 1:length(proj_solution_terms_list)) {
       i_inf <- names(proj_solution_terms_list)[i]
       pl1 <- proj_predict(proj_solution_terms_list[[i]],
                           newdata = data.frame(x = x),
-                          seed = seed, seed_sub = seed)
+                          seed = seed, seed_ppd = seed)
       pl2 <- proj_predict(proj_solution_terms_list[[i]],
                           newdata = data.frame(x = x),
-                          seed = seed, seed_sub = seed)
+                          seed = seed, seed_ppd = seed)
       expect_equal(pl1, pl2, info = i_inf)
     }
   })
@@ -498,18 +498,18 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
       i_inf <- names(vs_list)[i]
       prp1 <- proj_predict(vs_list[[i]],
                            newdata = data.frame(x = x), size_sub = 100,
-                           seed = 12, seed_sub = 12, nterms = c(2, 4),
+                           seed = 12, seed_ppd = 12, nterms = c(2, 4),
                            nclusters = 2,
                            regul = 1e-08
       )
       prp2 <- proj_predict(vs_list[[i]],
                            newdata = data.frame(x = x), size_sub = 100,
                            nterms = c(2, 4), nclusters = 2, regul = 1e-8,
-                           seed = 12, seed_sub = 12
+                           seed = 12, seed_ppd = 12
       )
       prp3 <- proj_predict(vs_list[[i]],
                            newdata = data.frame(x = x), size_sub = 100,
-                           seed = 120, seed_sub = 120, nterms = c(2, 4),
+                           seed = 120, seed_ppd = 120, nterms = c(2, 4),
                            nclusters = 2,
                            regul = 1e-08
       )

--- a/tests/testthat/test_proj_pred.R
+++ b/tests/testthat/test_proj_pred.R
@@ -456,19 +456,21 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
     for (i in seq_len(length(proj_solution_terms_list))) {
       i_inf <- names(proj_solution_terms_list)[i]
       pl <- proj_predict(proj_solution_terms_list[[i]],
-                         newdata = data.frame(x = x), size_sub = iter,
+                         newdata = data.frame(x = x), nclusters_resample = iter,
                          seed = seed, seed_ppd = seed
       )
       plo <- proj_predict(proj_solution_terms_list[[i]],
                           newdata = data.frame(x = x, offset = offset),
-                          size_sub = iter,
+                          nclusters_resample = iter,
                           seed = seed, seed_ppd = seed, offsetnew = ~offset
       )
       expect_true(sum(pl != plo) > 0, info = i_inf)
     }
   })
 
-  test_that("proj_predict: specifying size_sub has an expected effect", {
+  test_that(paste(
+    "proj_predict: specifying nclusters_resample has an expected effect"
+  ), {
     for (i in 1:length(proj_solution_terms_list)) {
       i_inf <- names(proj_solution_terms_list)[i]
       pl <- proj_predict(proj_solution_terms_list[[i]],
@@ -498,18 +500,21 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
     for (i in 1:length(vs_list)) {
       i_inf <- names(vs_list)[i]
       prp1 <- proj_predict(vs_list[[i]],
-                           newdata = data.frame(x = x), size_sub = 100,
+                           newdata = data.frame(x = x),
+                           nclusters_resample = 100,
                            seed = 12, seed_ppd = 12, nterms = c(2, 4),
                            nclusters = 2,
                            regul = 1e-08
       )
       prp2 <- proj_predict(vs_list[[i]],
-                           newdata = data.frame(x = x), size_sub = 100,
+                           newdata = data.frame(x = x),
+                           nclusters_resample = 100,
                            nterms = c(2, 4), nclusters = 2, regul = 1e-8,
                            seed = 12, seed_ppd = 12
       )
       prp3 <- proj_predict(vs_list[[i]],
-                           newdata = data.frame(x = x), size_sub = 100,
+                           newdata = data.frame(x = x),
+                           nclusters_resample = 100,
                            seed = 120, seed_ppd = 120, nterms = c(2, 4),
                            nclusters = 2,
                            regul = 1e-08


### PR DESCRIPTION
This PR fixes (and extends) PR #134 which I unfortunately messed up.

This PR concerns arguments `size_sub` and `seed_sub` of `proj_predict`. A summary of the changes is:

- Argument `size_sub` is only applied to clustered projection. For non-clustered projection, all draws are used. Correspondingly, I renamed argument `size_sub` to `nclusters_resample` to match that new behavior and to avoid the suffix `_sub` which is inappropriate because of `replace = TRUE` in the corresponding `sample()` call.
- I realized that `seed_sub` is not only used for resampling the (clustered) posterior draws, but also for drawing from the posterior predictive distribution (PPD). Correspondingly, I renamed `seed_sub` to `seed_ppd`.

Notes:

- It might be helpful to amend this PR to either:
    - have two separate seed arguments for drawing from the PPD (`seed_ppd`) and for resampling the (clustered) posterior draws (e.g. `seed_clusters_resample` which is very long, so perhaps you have a better idea) *or*
    - keep the implementation from this PR, but to rename `seed_ppd` to something like `seed_resample_ppd` to better reflect the fact that this seed is used for both, drawing from the PPD and resampling the (clustered) posterior draws. But again, `seed_resample_ppd` is very long so I decided to stick with `seed_ppd` as this is the primary purpose of that argument and since the resampling only applies to clustered projection (at least with this PR).
- As a next step, it could make sense to offer the resampling of clustered posterior draws at other places, too: e.g. in `as.matrix.projection()` (which currently warns in case of clustered posterior draws) or in `proj_linpred(..., integrated = FALSE)`.

