### PR TITLE
Fix `plot.vsel()` if there is just the intercept-only submodel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 * Minor documentation fixes.
 * Fix a bug for `as.matrix.projection()` in case of 1 (clustered) draw after projection. (GitHub: #130)
 * For submodels of class `"subfit"`, make the column names of `as.matrix.projection()`'s output matrix consistent with other classes of submodels. (GitHub: #132)
+* Fix a bug for argument `nterms_max` of `plot.vsel()` if there is just the intercept-only submodel. (GitHub: #138)
 
 ## projpred 2.0.5
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -339,9 +339,9 @@ plot.vsel <- function(x, nterms_max = NULL, stats = "elpd",
   } else {
     # don't exceed the maximum submodel size
     nterms_max <- min(nterms_max, max(stats_sub$size))
-    if (nterms_max < 1) {
-      stop("nterms_max must be at least 1")
-    }
+  }
+  if (nterms_max < 1) {
+    stop("nterms_max must be at least 1")
   }
   ylab <- if (deltas) "Difference to the baseline" else "Value"
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -334,11 +334,16 @@ plot.vsel <- function(x, nterms_max = NULL, stats = "elpd",
     ))
   }
 
+  max_size <- max(stats_sub$size)
+  if (max_size == 0) {
+    stop("plot.vsel() cannot be used if there is just the intercept-only ",
+         "submodel.")
+  }
   if (is.null(nterms_max)) {
-    nterms_max <- max(stats_sub$size)
+    nterms_max <- max_size
   } else {
     # don't exceed the maximum submodel size
-    nterms_max <- min(nterms_max, max(stats_sub$size))
+    nterms_max <- min(nterms_max, max_size)
   }
   if (nterms_max < 1) {
     stop("nterms_max must be at least 1")


### PR DESCRIPTION
This fixes the following issue (see the commit messages for details):
```r

options(mc.cores = parallel::detectCores(logical = FALSE))
data("df_gaussian", package = "projpred")
df_gaussian <- df_gaussian[1:40, ]
my_dat <- cbind("y" = df_gaussian$y, as.data.frame(df_gaussian$x))
my_dat$my_group <- gl(n = 8, k = floor(nrow(my_dat) / 8),
                      labels = paste0("gr", seq_len(8)))
set.seed(457211)
my_dat$noise <- rnorm(nrow(my_dat))
my_group_icpts_truth <- rnorm(nlevels(my_dat$my_group), sd = 0.6) # sd = 6
my_group_V1_truth <- rnorm(nlevels(my_dat$my_group), sd = 0.6) # sd = 6
my_icpt <- -0.42
my_dat$y <- rbinom(nrow(my_dat), size = 1, prob = brms::inv_logit_scaled(
  my_icpt +
    my_group_icpts_truth[my_dat$my_group] +
    my_group_V1_truth[my_dat$my_group] * my_dat$V1
))

seed_fit <- 1140350788
suppressPackageStartupMessages(library(brms))
my_fit <- brm(y ~ V1 + V2 + V3 + V4 + V5 + noise + (1 + V1 | my_group),
              data = my_dat,
              family = bernoulli(link = "logit"),
              control = list(adapt_delta = 0.95,
                             max_treedepth = 15L),
              seed = seed_fit)

library(projpred)
my_refmodel <- brms:::get_refmodel.brmsfit(my_fit)
my_vs <- varsel(my_refmodel, nclusters = 3, nclusters_pred = 5, nterms_max = 0)
plot(my_vs)
```
That last line threw the uninformative error
```
Error in seq.default(0, by * min(nterms_max, nb), by) : 
  'to' must be a finite number 
```
Now it throws the more appropriate error
```
Error in plot.vsel(my_vs) : 
  plot.vsel() cannot be used if there is just the intercept-only submodel.
```
