### PR TITLE
Fix error for L1 search applied to an empty (i.e. intercept-only) reference model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 * Minor documentation fixes.
 * Fix a bug for `as.matrix.projection()` in case of 1 (clustered) draw after projection. (GitHub: #130)
 * For submodels of class `"subfit"`, make the column names of `as.matrix.projection()`'s output matrix consistent with other classes of submodels. (GitHub: #132)
+* Throw an appropriate error message when trying to apply an L1 search to an empty (i.e. intercept-only) reference model. (GitHub: #139)
 
 ## projpred 2.0.5
 

--- a/R/search.R
+++ b/R/search.R
@@ -136,6 +136,10 @@ search_L1_surrogate <- function(p_ref, d_train, family, intercept, nterms_max,
 
 search_L1 <- function(p_ref, refmodel, family, intercept, nterms_max, penalty,
                       opt) {
+  if (nterms_max == 0) {
+    stop("L1 search cannot be used for an empty (i.e. intercept-only) ",
+         "reference model.")
+  }
   frame <- model.frame(refmodel$formula, refmodel$fetch_data())
   contrasts_arg <- get_contrasts_arg_list(
     refmodel$formula,


### PR DESCRIPTION
This fixes the following issue:
```r
library(projpred)
library(rstanarm)
options(mc.cores = parallel::detectCores(logical = FALSE))
data("df_gaussian", package = "projpred")
mydat <- cbind("y" = df_gaussian$y, as.data.frame(df_gaussian$x))
myfit <- stan_glm(y ~ 1,
                  data = mydat,
                  seed = 1140350788)
my_vs <- varsel(myfit, nclusters = 3, nclusters_pred = 5, method = "L1")
```
That last line threw the uninformative error
```
Error in seq.default(log(lambda_min), log(lambda_max), len = nlam) :
  'from' must be a finite number
In addition: Warning messages:
  1: In max(lambda_max_cand[is.finite(lambda_max_cand)]) :
  no non-missing arguments to max; returning -Inf
2: In log(lambda_min) : NaNs produced
3: In log(lambda_max) :
```
Now it throws the more appropriate error
```
Error in search_L1(p_sel, refmodel, family, intercept, nterms_max - intercept,  : 
  L1 search cannot be used for an empty (i.e. intercept-only) reference model.
```
The problem for this special case is that in lines https://github.com/stan-dev/projpred/blob/fb16ff3304e38c94fed3c4ef3924022d936c745a/R/glmfun.R#L110-L111 we have `length(lambda_max_cand) == 0`.