### PR TITLE
Fix `extract_model_data()` in `get_refmodel.stanreg()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@
 * Fix the list names of element `search_path` in, e.g., `varsel()`'s output. (GitHub: #140)
 * Fix a bug (error `unused argument`) when initializing the K reference models in a K-fold CV with CV fits not of class `"brmsfit"` or `"stanreg"`. (GitHub: #140)
 * In `get_refmodel.default()`, remove old defunct arguments `fetch_data`, `wobs`, and `offset`. (GitHub: #140)
+* Fix a bug in `get_refmodel.stanreg()`. (GitHub: #142)
 
 ## projpred 2.0.5
 

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -301,18 +301,14 @@ get_refmodel.stanreg <- function(object, data = NULL, ref_predfun = NULL,
 
     if (is.null(newdata)) {
       newdata <- object$data
-    }
-
-    if (is.null(wrhs) && !is.null(object) &&
-        !is.null(object$weights) && length(object$weights) != 0) {
-      wrhs <- ~weights
-      newdata <- cbind(newdata, weights = object$weights)
-    }
-
-    if (is.null(orhs) && !is.null(object) &&
-        !is.null(object$offset) && length(object$offset) != 0) {
-      orhs <- ~offset
-      newdata <- cbind(newdata, offset = object$offset)
+      if (is.null(wrhs) && length(object$weights) != 0) {
+        wrhs <- ~weights
+        newdata <- cbind(newdata, weights = object$weights)
+      }
+      if (is.null(orhs) && length(object$offset) != 0) {
+        orhs <- ~offset
+        newdata <- cbind(newdata, offset = object$offset)
+      }
     }
 
     args <- nlist(object, newdata, wrhs, orhs, resp_form)


### PR DESCRIPTION
This fixes the following issue:
```r
# Source: `./tests/testthat/test_proj_pred.R`
library(projpred)
library(rstanarm)
seed <- 1235
set.seed(seed)
n <- 40
nterms <- 5
x <- matrix(rnorm(n * nterms, 0, 1), n, nterms)
b <- runif(nterms) - 0.5
dis <- runif(1, 1, 2)
weights <- sample(1:4, n, replace = TRUE)
chains <- 2
iter <- 500
f_binom <- binomial()
df_binom <- data.frame(
  y = rbinom(n, weights, f_binom$linkinv(x %*% b)), x = x,
  weights = weights
)
fit_binom <- stan_glm(cbind(y, weights - y) ~ x.1 + x.2 + x.3 + x.4 + x.5,
                      family = f_binom, data = df_binom, weights = weights,
                      chains = chains, seed = seed, iter = iter)
refmod <- get_refmodel(fit_binom)
pl <- proj_linpred(
  refmod, nclusters = 1L,
  newdata = head(data.frame(y = refmod$y, x = x), 1L),
  solution_terms = c("x.3", "x.5")
)
str(pl)

```
Previously, that last line gave:
```
List of 2
 $ pred: num [1:40] 0.0526 0.0526 0.0526 0.0526 0.0526 ...
 $ lpd : num [1:40] -1.44 -0.667 -0.694 -0.667 -1.44 ...
```
(and the second-to-last line also threw the warning
```
Warning message:
In data.frame(..., check.names = FALSE) :
  row names were found from a short variable and have been discarded
```
). With this PR, we get:
```
List of 2
 $ pred: num 0.0526
 $ lpd : num -0.667
```
as desired (and no warning by the call to `proj_linpred()`).