### PR TITLE
Fix the fix for issue #159

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -104,7 +104,11 @@ proj_helper <- function(object, newdata,
         object <- list(object)
       }
       projs <- Filter(function(x) {
-        count_terms_chosen(x$solution_terms) %in% (filter_nterms + 1)
+        solterms_tocount <- x$solution_terms
+        if (length(solterms_tocount) == 0) {
+          solterms_tocount <- "1"
+        }
+        count_terms_chosen(solterms_tocount) %in% (filter_nterms + 1)
       }, object)
     } else {
       projs <- object

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -75,7 +75,7 @@ project_submodel <- function(solution_terms, p_ref, refmodel, family, intercept,
     ## need to project again for each submodel size
     projfun <- .get_proj_handle(refmodel, p_ref, family, regul, intercept)
     fetch_submodel <- function(nterms) {
-      solution_terms <- varorder[seq_len(nterms)]
+      solution_terms <- utils::head(varorder, nterms)
       return(projfun(solution_terms))
     }
   }

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -65,10 +65,6 @@ project_submodel <- function(solution_terms, p_ref, refmodel, family, intercept,
       ## reuse sub_fit as projected during search
       sub_refit <- search_path$sub_fits[[nterms + 1]]
 
-      if (length(solution_terms) == 0 && intercept) {
-        solution_terms <- character()
-      }
-
       return(.init_submodel(
         sub_fit = sub_refit, p_ref = search_path$p_sel, refmodel = refmodel,
         family = family, solution_terms = solution_terms,
@@ -79,12 +75,7 @@ project_submodel <- function(solution_terms, p_ref, refmodel, family, intercept,
     ## need to project again for each submodel size
     projfun <- .get_proj_handle(refmodel, p_ref, family, regul, intercept)
     fetch_submodel <- function(nterms) {
-      if (nterms == 0 && intercept) {
-        ## empty
-        solution_terms <- character()
-      } else {
-        solution_terms <- varorder[seq_len(nterms)]
-      }
+      solution_terms <- varorder[seq_len(nterms)]
       return(projfun(solution_terms))
     }
   }

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -66,7 +66,7 @@ project_submodel <- function(solution_terms, p_ref, refmodel, family, intercept,
       sub_refit <- search_path$sub_fits[[nterms + 1]]
 
       if (length(solution_terms) == 0 && intercept) {
-        solution_terms <- c()
+        solution_terms <- character()
       }
 
       return(.init_submodel(
@@ -81,7 +81,7 @@ project_submodel <- function(solution_terms, p_ref, refmodel, family, intercept,
     fetch_submodel <- function(nterms) {
       if (nterms == 0 && intercept) {
         ## empty
-        solution_terms <- c()
+        solution_terms <- character()
       } else {
         solution_terms <- varorder[seq_len(nterms)]
       }

--- a/R/search.R
+++ b/R/search.R
@@ -13,7 +13,7 @@ search_forward <- function(p_ref, refmodel, family, intercept, nterms_max,
     allterms <- search_terms
   }
 
-  chosen <- NULL
+  chosen <- character()
   total_terms <- count_terms_chosen(allterms)
   stop_search <- min(total_terms, nterms_max)
   submodels <- c()


### PR DESCRIPTION
This PR ensures that after the fix for #159 (commit a422b9b7d20ed521d1293354a8dff99bb95d361d), `solution_terms` is still always of type `character`, even for an empty submodel. (The fix for #159 was using `c()` but that is equivalent to `NULL`.) It also fixes an issue with `filter_nterms` caused by the fix for #159.