### PR TITLE
Fix `proj_predfun()` for GLMMs

### DIFF
--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -241,7 +241,7 @@ additive_proj_predfun <- function(fit, newdata = NULL, weights = NULL) {
   if (!is.null(newdata)) {
     newdata <- cbind(`(Intercept)` = rep(1, NROW(newdata)), newdata)
   }
-  return(as.matrix(linear_multilevel_proj_predfun(fit, newdata, weights)))
+  return(linear_multilevel_proj_predfun(fit, newdata, weights))
 }
 
 ## FIXME: find a way that allows us to remove this

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -209,7 +209,7 @@ linear_multilevel_proj_predfun <- function(fit, newdata = NULL,
       predict_multilevel_callback(fit, newdata, weights)
     })))
   } else {
-    return(predict_multilevel_callback(fit, newdata, weights))
+    return(as.matrix(predict_multilevel_callback(fit, newdata, weights)))
   }
 }
 


### PR DESCRIPTION
Up to now, `linear_multilevel_proj_predfun()` did not return a matrix if there was only 1 projected (clustered) draw. Apart from the inconsistency with `linear_proj_predfun()` (and `additive_proj_predfun()`, as far as I can read from the source code), this caused `proj_linpred()` to raise an error for the 1-cluster projection of a GLMM with `integrated = TRUE`:
```r
options(mc.cores = parallel::detectCores(logical = FALSE))
data("df_gaussian", package = "projpred")
df_gaussian <- df_gaussian[1:40, ]
mydat <- cbind("y" = df_gaussian$y, as.data.frame(df_gaussian$x))
mydat$mygroup <- gl(n = 8, k = floor(nrow(mydat) / 8), length = nrow(mydat),
                    labels = paste0("gr", seq_len(8)))
set.seed(457211)
mydat$noise <- rnorm(nrow(mydat))
mygroup_icpts_truth <- rnorm(nlevels(mydat$mygroup), sd = 0.6)
mygroup_V1_truth <- rnorm(nlevels(mydat$mygroup), sd = 0.6)
myicpt <- -0.42
mydat$y <- rbinom(nrow(mydat), size = 1, prob = brms::inv_logit_scaled(
  myicpt +
    mygroup_icpts_truth[mydat$mygroup] +
    mygroup_V1_truth[mydat$mygroup] * mydat$V1
))
library(rstanarm)
myfit <- stan_glmer(y ~ V1 + V2 + V3 + V4 + V5 + noise + (1 + V1 | mygroup),
                    data = mydat,
                    family = binomial(link = "logit"),
                    seed = 1140350788)
library(projpred)
myproj <- project(myfit,
                  solution_terms = c("(1 | mygroup)", "V1", "V3",
                                     "(V1 | mygroup)", "V2"),
                  nclusters = 1,
                  seed = 74345)
mylinpred <- proj_linpred(myproj,
                          integrated = TRUE)

```
throwing the error
```
Error in pred_out %*% proj$weights : non-conformable arguments
```
Therefore, this PR ensures that `linear_multilevel_proj_predfun()` always returns a matrix. This also fixes the `proj_linpred()` issue shown in the reprex.

Btw, in `predict.subfit()`, the case `is.null(beta)` doesn't seem to be occurring (for an intercept-only model, `beta` seems to be a matrix with 0 rows). If it did, it would also have to be adopted to ensure a matrix output. But since it doesn't seem to be occurring, I think it's better to remove that case. See lines https://github.com/stan-dev/projpred/blob/2ed7e42ef78f69ff3b3dcd32f7e4d6da1ad99d8e/R/divergence_minimizers.R#L257-L258 and https://github.com/stan-dev/projpred/blob/2ed7e42ef78f69ff3b3dcd32f7e4d6da1ad99d8e/R/divergence_minimizers.R#L267-L268