### PR TITLE
Fix `proj_predfun()` for `"datafit"`s

### DIFF
--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -255,7 +255,7 @@ predict.subfit <- function(subfit, newdata = NULL, weights = NULL) {
   w <- subfit$w
   if (is.null(newdata)) {
     if (is.null(beta)) {
-      return(rep(alpha, NROW(subfit$x)))
+      return(as.matrix(rep(alpha, NROW(subfit$x))))
     } else {
       return(x %*% rbind(alpha, beta))
     }
@@ -265,7 +265,7 @@ predict.subfit <- function(subfit, newdata = NULL, weights = NULL) {
                       contrasts.arg = contrasts_arg)
     ## x <- weights * x
     if (is.null(beta)) {
-      return(rep(alpha, NROW(x)))
+      return(as.matrix(rep(alpha, NROW(x))))
     } else {
       return(x %*% rbind(alpha, beta))
     }


### PR DESCRIPTION
For `"datafit"`s, the case `is.null(beta)` in `predict.subfit()` is possible (contrary to what I assumed [here](https://github.com/stan-dev/projpred/pull/174#issue-690825576)), so `predict.subfit()` needs to make sure to return a matrix in that case. (See also #174.)