### PR TITLE
Fix names of `summary.vsel()$selection` for `varsel()` output

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -528,14 +528,13 @@ summary.vsel <- function(object, nterms_max = NULL, stats = "elpd",
 
   if (length(stats) > 1) {
     suffix <- lapply(stats, function(s) {
-      paste0(
-        s,
-        unname(sapply(type, function(t) {
+      unname(sapply(type, function(t) {
+        paste0(
+          s,
           switch(t, mean = cv_suffix, upper = ".upper", lower = ".lower",
-                 se = ".se", diff = ".diff", diff.se = ".diff.se"
-          )
-        }))
-      )
+                 se = ".se", diff = ".diff", diff.se = ".diff.se")
+        )
+      }))
     })
   } else {
     suffix <- list(unname(sapply(type, function(t) {


### PR DESCRIPTION
For `"vsel"` objects created by `varsel()`, we have `is.null(cv_suffix)` within `summary.vsel()`. And in this case, the former way of constructing the suffices for the names of the `$selection` output failed (we got `elpdNULL` instead of `elpd`, for example). This PR fixes this.