### PR TITLE
Fix PR #142

### DIFF
--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -29,7 +29,6 @@ if (require(rstanarm)) {
                           chains = chains, seed = seed, iter = iter)
     fit_binom <- stan_glm(cbind(y, weights - y) ~ x.1 + x.2 + x.3 + x.4 + x.5,
                           data = df_binom, family = f_binom,
-                          weights = weights,
                           chains = chains, seed = seed, iter = iter)
   })
 
@@ -139,7 +138,7 @@ if (require(rstanarm)) {
     fit_binom <- stan_glmer(
       cbind(y, weights - y) ~ x.1 + x.2 + x.3 + x.4 + x.5 + (x.1 | xgr),
       data = df_binom, family = f_binom,
-      weights = weights, offset = offset,
+      offset = offset,
       chains = chains, seed = seed, iter = iter
     )
   })

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -36,7 +36,7 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
   )
   SW(
     fit_binom <- stan_glm(cbind(y, weights - y) ~ x.1 + x.2 + x.3 + x.4 + x.5,
-                          family = f_binom, data = df_binom, weights = weights,
+                          family = f_binom, data = df_binom,
                           chains = chains, seed = seed, iter = iter
     )
   )

--- a/tests/testthat/test_proj_pred.R
+++ b/tests/testthat/test_proj_pred.R
@@ -36,7 +36,7 @@ if (require(rstanarm) && Sys.getenv("NOT_CRAN") == "true") {
                           family = f_gauss, data = df_gauss,
                           chains = chains, seed = seed, iter = iter)
     fit_binom <- stan_glm(cbind(y, weights - y) ~ x.1 + x.2 + x.3 + x.4 + x.5,
-                          family = f_binom, data = df_binom, weights = weights,
+                          family = f_binom, data = df_binom,
                           chains = chains, seed = seed, iter = iter)
     fit_poiss <- stan_glm(y ~ x.1 + x.2 + x.3 + x.4 + x.5,
                           family = f_poiss, data = df_poiss,

--- a/tests/testthat/test_project.R
+++ b/tests/testthat/test_project.R
@@ -34,7 +34,7 @@ if (require(rstanarm)) {
                           chains = chains, seed = seed, iter = iter
     )
     fit_binom <- stan_glm(cbind(y, weights - y) ~ x.1 + x.2 + x.3 + x.4 + x.5,
-                          family = f_binom, weights = weights,
+                          family = f_binom,
                           data = df_binom, chains = chains, seed = seed,
                           iter = iter
     )

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -32,7 +32,7 @@ if (require(rstanarm)) {
                           chains = chains, seed = seed, iter = iter
     )
     fit_binom <- stan_glm(cbind(y, weights - y) ~ x.1 + x.2 + x.3 + x.4 + x.5,
-                          family = f_binom, weights = weights,
+                          family = f_binom,
                           data = df_binom, chains = chains, seed = seed,
                           iter = iter
     )


### PR DESCRIPTION
This PR fixes a bug introduced by PR #142 (`<refmodel_object_from_stanreg>$wobs` and `<refmodel_object_from_stanreg>$offset` were always vectors of ones and zeros, respectively, even if the `"stanreg"` fit contained weights and offsets). I'm sorry for not having realized this bug earlier (and especially not when creating that PR #142).

I based this PR on commit 34e24dec82e0e5f4ddd49779d58bdcf690e0d072 since the state at commit e529ec1080e45de2b27aaaa6efde8ff5285e0f90 seems unfinished and leads to failing tests.
