### PR TITLE
Avoid re-ordered interaction terms

### DIFF
--- a/R/formula.R
+++ b/R/formula.R
@@ -705,7 +705,7 @@ select_possible_terms_size <- function(chosen, terms, size) {
   })
   valid_submodels <- unlist(valid_submodels[!is.na(valid_submodels)])
   if (length(chosen) > 0) {
-    add_chosen <- paste0(paste(chosen, collapse = "+"), " + ")
+    add_chosen <- paste0(" + ", paste(chosen, collapse = "+"))
     remove_chosen <- paste0(" - ", paste(chosen, collapse = "-"))
   } else {
     add_chosen <- ""
@@ -713,7 +713,7 @@ select_possible_terms_size <- function(chosen, terms, size) {
   }
   full_valid_submodels <- unique(unlist(lapply(valid_submodels, function(x)
     to_character_rhs(flatten_formula(make_formula(
-      paste(add_chosen, x, remove_chosen)))))))
+      paste(x, add_chosen, remove_chosen)))))))
   return(full_valid_submodels)
 }
 


### PR DESCRIPTION
This PR fixes an issue related to re-ordered interaction terms (re-ordered in the sense that the parts separated by `:` are ordered differently than in the corresponding interaction term from the reference model formula). As far as I can tell, that issue should only occur with `search_forward()`, not with `search_L1()`. Reprex (tested on branch `develop`):
```r
nobsv <- 29
nvars <- 2
set.seed(1235)
x_mat <- matrix(rnorm(nobsv * nvars), nrow = nobsv, ncol = nvars)
x_mat <- cbind(x_mat, x_mat[, 1] * x_mat[, 2])
b <- c(-3, 1, 2)
dat <- data.frame(y = rnorm(nobsv, mean = x_mat %*% b, sd = 1.5), x_mat)
suppressPackageStartupMessages(library(rstanarm))
options(mc.cores = parallel::detectCores(logical = FALSE))
fitobj <- stan_glm(y ~ X2*X1,
                   data = dat,
                   seed = 11403)

library(projpred)
cvvs <- cv_varsel(fitobj, method = "forward", nclusters = 2, nclusters_pred = 3,
                  seed = 457634)
cvvs$pct_solution_terms_cv
```
gives
```
     size  X1  X2 X1:X2
[1,]    1   1   0     0
[2,]    2   0   1     0
[3,]    3 NaN NaN   NaN
```
With this PR, `cvvs$pct_solution_terms_cv` gives
```
     size X1 X2 X2:X1
[1,]    1  1  0     0
[2,]    2  0  1     0
[3,]    3  0  0     1
```
as expected.

The origin of that issue may be seen from the fact that on branch `develop`
```r
solution_terms(cvvs)
```
gives
```
[1] "X1"    "X2"    "X1:X2"
```
whereas
```r
split_formula(cvvs$refmodel$formula, add_main_effects = FALSE)
```
gives
```
[1] "1"     "X2:X1" "X2"    "X1"
```
With this PR, `solution_terms(cvvs)` gives
```
[1] "X1"    "X2"    "X2:X1"
```
i.e. the interaction term order now matching the result of `split_formula()`.

Note that when projecting onto the submodels, interaction terms may still be re-ordered. However, up to now, this doesn't seem to have any undesired consequences (apart from the fact that it makes testing the submodel formulas harder). A fix for that would require lots of changes since basically every use of `terms.formula()` (or `update.formula()` which uses `terms.formula()` internally) re-orders interaction terms. Re-ordering the reference model interaction terms in the first place is no option since we don't know in advance the order in which the terms will be selected. So I guess this PR is all we can (and need to) do for now.

Also note that I'm not sure if the original order `paste(add_chosen, x, remove_chosen)` (modified in this PR to `paste(x, add_chosen, remove_chosen)`) was chosen for a specific reason. If it was, then this PR needs to be changed.