### PR TITLE
Fix `"datafit"`s with binomial family and two-column response

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -185,7 +185,7 @@ bootstrap <- function(x, fun = mean, b = 1000, oobfun = NULL, seed = NULL,
     if (fam$family != "binomial") {
       stop("For non-binomial families, a two-column response is not allowed.")
     }
-    weights <- unname(rowSums(y))
+    weights <- unname(y[, 1] + y[, 2])
     y <- unname(y[, 1])
   } else {
     stop("The response is not allowed to have more than two columns.")

--- a/R/misc.R
+++ b/R/misc.R
@@ -182,10 +182,13 @@ bootstrap <- function(x, fun = mean, b = 1000, oobfun = NULL, seed = NULL,
       }
     }
   } else if (NCOL(y) == 2) {
+    if (fam$family != "binomial") {
+      stop("For non-binomial families, a two-column response is not allowed.")
+    }
     weights <- y[, 2]
     y <- y[, 1]
   } else {
-    stop("y cannot have more than two columns.")
+    stop("The response is not allowed to have more than two columns.")
   }
   return(nlist(y, weights))
 }

--- a/R/misc.R
+++ b/R/misc.R
@@ -185,7 +185,7 @@ bootstrap <- function(x, fun = mean, b = 1000, oobfun = NULL, seed = NULL,
     if (fam$family != "binomial") {
       stop("For non-binomial families, a two-column response is not allowed.")
     }
-    weights <- y[, 2]
+    weights <- rowSums(y)
     y <- y[, 1]
   } else {
     stop("The response is not allowed to have more than two columns.")

--- a/R/misc.R
+++ b/R/misc.R
@@ -185,8 +185,8 @@ bootstrap <- function(x, fun = mean, b = 1000, oobfun = NULL, seed = NULL,
     if (fam$family != "binomial") {
       stop("For non-binomial families, a two-column response is not allowed.")
     }
-    weights <- rowSums(y)
-    y <- y[, 1]
+    weights <- unname(rowSums(y))
+    y <- unname(y[, 1])
   } else {
     stop("The response is not allowed to have more than two columns.")
   }

--- a/R/misc.R
+++ b/R/misc.R
@@ -155,12 +155,14 @@ bootstrap <- function(x, fun = mean, b = 1000, oobfun = NULL, seed = NULL,
   return(baseline)
 }
 
+# A function for retrieving `y` and the corresponding observation weights
+# `weights` in their "standard" forms:
+#   * If `NCOL(y) == 2`: `y` is the first column and `weights` the second.
+#   * If `NCOL(y) == 1`: `weights` is basically unchanged (unless of length zero
+#     in which case it is replaced by a vector of ones). For a binomial family,
+#     if `is.factor(y)`, `y` is transformed into a zero-one vector (i.e., with
+#     values in the set {0, 1}).
 .get_standard_y <- function(y, weights, fam) {
-  # Return `y` and the corresponding observation weights in the "standard" form:
-  # For the binomial family, `y` is transformed into a vector with values in the
-  # set {0, 1}, and `weights` gives the number of trials for each observation.
-  # For all other families, `y` and `weights` are kept as they are (unless
-  # `weights` has length zero in which case it is replaced by a vector of ones).
   if (NCOL(y) == 1) {
     if (length(weights) > 0) {
       weights <- unname(weights)

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -483,6 +483,10 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
 
   data[, response_name] <- y
 
+  target <- .get_standard_y(y, weights, family)
+  y <- target$y
+  weights <- target$weights
+
   if (is.null(div_minimizer)) {
     if (length(terms$additive_terms) != 0) {
       div_minimizer <- additive_mle
@@ -559,13 +563,6 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   if (is.null(offset)) {
     offset <- rep(0, NROW(y))
   }
-
-  if (is.null(weights)) {
-    weights <- rep(1, NROW(y))
-  }
-
-  target <- .get_standard_y(y, weights, family)
-  y <- target$y
 
   if (proper_model) {
     loglik <- t(family$ll_fun(mu, dis, y, weights = weights))


### PR DESCRIPTION
This PR mainly fixes a bug introduced by PR #193 when calculating `mu` for `"datafit"`s with a binomial family and a two-column response. But it also comes with two other (potential) bug fixes (see the commit messages for details).