### PR TITLE
Fix offset issues

### DIFF
--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -345,7 +345,8 @@ get_refmodel.stanreg <- function(object, data = NULL, ref_predfun = NULL,
       is.null(attr(terms(object$formula), "offset"))) {
     # In this case, we would have to use argument `offset` of
     # posterior_linpred.stanreg() to allow for new offsets, requiring changes in
-    # all ref_predfun() calls. Thus, throw an error:
+    # all ref_predfun() calls. Furthermore, there is rstanarm issue #541. Thus,
+    # throw an error:
     stop("It looks like `object` was fitted with offsets specified via ",
          "argument `offset`. Currently, projpred does not support offsets ",
          "specified this way. Please use an `offset()` term in the model ",
@@ -450,8 +451,10 @@ get_refmodel.stanreg <- function(object, data = NULL, ref_predfun = NULL,
            "the package maintainer.")
     }
     # Since posterior_linpred() is supposed to include the offsets in its
-    # result, subtract them here (and use a workaround for rstanarm issue #541
-    # and rstanarm issue #542):
+    # result, subtract them here and use a workaround for rstanarm issue #541
+    # and rstanarm issue #542. This workaround consists of using `cond_no_offs`
+    # which indicates whether posterior_linpred() excluded (`TRUE`) or included
+    # (`FALSE`) the offsets:
     cond_no_offs <- (
       fit$stan_function %in% c("stan_lmer", "stan_glmer") &&
         !is.null(attr(terms(fit$formula), "offset"))


### PR DESCRIPTION
This PR fixes #186, i.e. the following issues related to offsets:

* issue stan-dev/rstanarm#541 for which a workaround is added here;
* issue stan-dev/rstanarm#542 for which a workaround is added here;
* in the output of `ref_predfun()`, offsets need to be *excluded* (see the discussion in #186), but up to now, `posterior_linpred()` *included* offsets (leaving the two rstanarm issues out of consideration).

Remarks:

* This PR requires `"stanreg"` fits with offsets to have them specified via an `offset()` term in the formula. This is done and explained in lines https://github.com/fweber144/projpred/blob/087979ba6fe3199fde7a194cb58d869d24a6a8eb/R/refmodel.R#L344-L354 
* This PR is just a quick-and-dirty solution. It should work for now, but it's a bit fragile: When the two rstanarm issues are resolved, this probably needs a bigger overhaul since non-`NULL` `newdata` typically does not contain the internal column `projpred_internal_offs_stanreg`, so `get_refmodel.stanreg()` then needs to use the original offset column(s) instead of the `projpred_internal_offs_stanreg` column. But even that would not be the most desirable solution as it would still make things complicated. A more straightforward (and probably also safer) way would be:

    1. Offsets have to be specified via an `offset()` term in the formula. This will ensure that the offsets are contained in the original dataset as well as in any `newdata`.
    2. `ref_predfun()` always *includes* the offsets and any occurrences of `ref_predfun()` do *not* add offsets manually afterwards. In contrast to the current implementation, this would cause `<refmodel_object>$mu` to include the offsets, too (making the following step 3 necessary).
    3. The submodels are fitted with offsets, too.
    
    The first step is already implemented with this PR, at least for brms and rstanarm fits (because brms only supports offsets via an `offset()` term and for rstanarm fits, this PR introduces this requirement). The second step should be easy to implement. The third step is the big problem (at least for GLMs): In contrast to the lme4 and gamm4 fitting functions, the projpred-internal C++ functions don't seem able to deal with offsets, so these C++ functions would have to be extended. At that occasion, I think it would be desirable to move the C++ functions out to their own package because they could serve more general purposes than just projpred.
