### PR TITLE
Fix observation weights

### DIFF
--- a/R/projfun.R
+++ b/R/projfun.R
@@ -96,7 +96,6 @@ project_submodel <- function(solution_terms, p_ref, refmodel, family, intercept,
     wsample <- ref_wsample
   }
 
-  wobs <- wobs / sum(wobs)
   wsample <- wsample / sum(wsample)
   return(nlist(wobs, wsample))
 }

--- a/R/search.R
+++ b/R/search.R
@@ -66,7 +66,7 @@ search_L1_surrogate <- function(p_ref, d_train, family, intercept, nterms_max,
                       lambda_min_ratio = opt$lambda_min_ratio,
                       nlambda = opt$nlambda,
                       pmax = nterms_max + 1, pmax_strict = FALSE,
-                      offset = d_train$offset, weights = d_train$weights,
+                      weights = d_train$weights,
                       intercept = intercept, obsvar = v, penalty = penalty,
                       thresh = opt$thresh)
 
@@ -153,7 +153,7 @@ search_L1 <- function(p_ref, refmodel, family, intercept, nterms_max, penalty,
   tt <- terms(refmodel$formula)
   terms_ <- attr(tt, "term.labels")
   search_path <- search_L1_surrogate(
-    p_ref, list(refmodel, x = x), family,
+    p_ref, nlist(x, weights = refmodel$wobs), family,
     intercept, ncol(x), penalty, opt
   )
   solution_terms <- collapse_contrasts_solution_path(


### PR DESCRIPTION
*Disclaimer:* I'm very unsure about this PR. There are a few things that keep confusing me, so I decided to create it, but you need to take a thorough look at it.

----

First of all, in `search_L1_surrogate()`'s `glm_elnet()` call, `d_train$weights` was always `NULL` (and `glm_elnet()` calls `glm_ridge()` via `lambda_grid()`, so it seems like this was not on purpose). This is what the first commit (87c5687) is fixing.

----

Secondly, there was line https://github.com/stan-dev/projpred/blob/6cec7d67624742e46f172979813fa67f7389835a/R/projfun.R#L99 and I *think* (but I'm not sure) this normalization of the weights is not appropriate. For example, it caused an inconsistency: `pseudo_data()` used

* normalized weights when called directly in `.init_submodel()` (which is only the case for the Gaussian family);
* unnormalized weights when called via `project_submodel()` &rarr; `<refmodel_object>$div_minimizer()` &rarr; `glm_ridge()` &rarr; `pseudo_data()`.

(Unnormalized weights are returned by `<refmodel_object>$extract_model_data()` and stored in `<refmodel_object>$wobs`, for example.)

Sometimes, the differentiation between normalized and unnormalized weights doesn't matter (because the sum of the weights cancels out somewhere), but here, I think this differentiation does matter since `pseudo_data()` calls `family$deviance()` and to my knowledge, `family$deviance()` needs unnormalized weights.

Another hint that normalized weights are inappropriate is that `.init_submodel()` calls `family$kl()` which (to my knowledge) needs unnormalized weights.

So the second commit (d7902ee) removes line https://github.com/stan-dev/projpred/blob/6cec7d67624742e46f172979813fa67f7389835a/R/projfun.R#L99
