### PR TITLE
Enhance/fix `fit_glmer_callback()`

### DIFF
--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -157,6 +157,12 @@ fit_glmer_callback <- function(formula, data, family, weights,
         formula, data = data, family = family, weights = weights,
         control = control, nAGQ = 20L, ...
       ))
+    } else if (grepl("pwrssUpdate did not converge in \\(maxit\\) iterations",
+                     as.character(e))) {
+      return(fit_glmer_callback(
+        formula, data = data, family = family, weights = weights,
+        control = control_callback(family, tolPwrss = 1e-6), ...
+      ))
     } else {
       stop(e)
     }

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -133,24 +133,20 @@ fit_glmer_callback <- function(formula, data, family, weights,
   environment(formula) <- environment()
   suppressMessages(suppressWarnings(tryCatch({
     if (family$family == "gaussian" && family$link == "identity") {
-      return(lme4::lmer(formula,
-                        data = data, weights = weights,
+      return(lme4::lmer(formula, data = data, weights = weights,
                         control = control))
     } else {
-      return(lme4::glmer(formula,
-                         data = data, family = family, weights = weights,
-                         control = control))
+      return(lme4::glmer(formula, data = data, family = family,
+                         weights = weights, control = control))
     }
-  },
-  error = function(e) {
+  }, error = function(e) {
     if (grepl("No random effects", as.character(e))) {
-      return(fit_glm_ridge_callback(formula,
-                                    data = data, family = family,
-                                    weights = weights, ...))
+      return(fit_glm_ridge_callback(
+        formula, data = data, family = family, weights = weights, ...
+      ))
     } else if (grepl("not positive definite", as.character(e))) {
       return(fit_glmer_callback(
-        formula,
-        data = data, weights = weights, family = family,
+        formula, data = data, family = family, weights = weights,
         control = control_callback(family,
                                    optimizer = "optimx",
                                    optCtrl = list(method = "nlminb"))
@@ -158,8 +154,7 @@ fit_glmer_callback <- function(formula, data, family, weights,
     } else if (grepl("PIRLS step-halvings", as.character(e))) {
       data <- preprocess_data(data, formula)
       return(fit_glmer_callback(
-        formula,
-        data = data, weights = weights, family = family
+        formula, data = data, family = family, weights = weights
       ))
     } else {
       stop(e)

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -153,9 +153,9 @@ fit_glmer_callback <- function(formula, data, family, weights,
         ...
       ))
     } else if (grepl("PIRLS step-halvings", as.character(e))) {
-      data <- preprocess_data(data, formula)
       return(fit_glmer_callback(
-        formula, data = data, family = family, weights = weights, ...
+        formula, data = data, family = family, weights = weights,
+        control = control, nAGQ = 20L, ...
       ))
     } else {
       stop(e)

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -134,10 +134,10 @@ fit_glmer_callback <- function(formula, data, family, weights,
   suppressMessages(suppressWarnings(tryCatch({
     if (family$family == "gaussian" && family$link == "identity") {
       return(lme4::lmer(formula, data = data, weights = weights,
-                        control = control))
+                        control = control, ...))
     } else {
       return(lme4::glmer(formula, data = data, family = family,
-                         weights = weights, control = control))
+                         weights = weights, control = control, ...))
     }
   }, error = function(e) {
     if (grepl("No random effects", as.character(e))) {
@@ -149,12 +149,13 @@ fit_glmer_callback <- function(formula, data, family, weights,
         formula, data = data, family = family, weights = weights,
         control = control_callback(family,
                                    optimizer = "optimx",
-                                   optCtrl = list(method = "nlminb"))
+                                   optCtrl = list(method = "nlminb")),
+        ...
       ))
     } else if (grepl("PIRLS step-halvings", as.character(e))) {
       data <- preprocess_data(data, formula)
       return(fit_glmer_callback(
-        formula, data = data, family = family, weights = weights
+        formula, data = data, family = family, weights = weights, ...
       ))
     } else {
       stop(e)


### PR DESCRIPTION
This PR enhances (and possibly fixes) `fit_glmer_callback()` in the following ways:

* It handles the error `"pwrssUpdate did not converge in (maxit) iterations"` (or at least it tries to). At least in the examples I have run, the advice given [here](https://github.com/lme4/lme4/issues/573#issuecomment-802267549) worked.
* It avoids the `preprocess_data()` call since:
  - scaling predictors changes their regression coefficients;
  - `preprocess_data()` is not adopted to categorical predictors;
  - `preprocess_data()`'s implementation for interactions is probably incorrect (the interaction columns in the model matrix must not be scaled; they need to be re-calculated from the scaled inputs, see [Gelman (2008, section 3.1)](https://doi.org/10.1002/sim.3107)).
  
  At least in the examples I have run, avoiding `preprocess_data()` is possible due to the advice given [here](https://github.com/lme4/lme4/issues/579#issuecomment-662789003).

Note that there is another `preprocess_data()` call in `fit_gamm_callback()` which probably should and perhaps could also be avoided. If not, I think it needs at least a warning when `preprocess_data()` is applied (so the users knows of the modified regression coefficients).
