### PR TITLE
Bug fix in `proj_linpred()`

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -232,7 +232,11 @@ proj_linpred_aux <- function(proj, mu, weights, ...) {
   if (dot_args$integrated) {
     ## average over the posterior draws
     pred_out <- pred_out %*% proj$weights
-    lpd_out <- as.matrix(apply(lpd_out, 1, log_weighted_mean_exp, proj$weights))
+    if (!is.null(lpd_out)) {
+      lpd_out <- as.matrix(
+        apply(lpd_out, 1, log_weighted_mean_exp, proj$weights)
+      )
+    }
   }
   return(nlist(pred = t(pred_out),
                lpd = if(is.null(lpd_out)) lpd_out else t(lpd_out)))


### PR DESCRIPTION
This fixes a bug in `proj_linpred()`: For `integrated = TRUE` and `is.null(ynew)`, a `if (!is.null(lpd_out))` condition had to be added before averaging `lpd_out`.