### PR TITLE
Clean-up code related to reference models

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -738,18 +738,18 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
   extract_model_data <- function(object, newdata = fetch_fold(), ...) {
     refmodel$extract_model_data(object = object, newdata = newdata, ...)
   }
-  if (!inherits(cvfit, "brmsfit") && !inherits(cvfit, "stanreg")) {
+  if (!inherits(refmodel, "datafit")) {
+    fit <- cvfit
+    k_refmodel <- get_refmodel(fit)
+  } else {
     fit <- NULL
     k_refmodel <- init_refmodel(
       object = fit, data = fetch_fold(),
       formula = refmodel$formula, family = refmodel$family,
-      ref_predfun = ref_predfun, div_minimizer = refmodel$div_minimizer,
+      div_minimizer = refmodel$div_minimizer,
       proj_predfun = proj_predfun, folds = seq_along(fold),
       extract_model_data = extract_model_data
     )
-  } else {
-    fit <- cvfit
-    k_refmodel <- get_refmodel(fit)
   }
 
   k_refmodel$fetch_data <- fetch_fold

--- a/R/extend_family.R
+++ b/R/extend_family.R
@@ -165,7 +165,7 @@ extend_family_gamma <- function(family) {
     ## TODO, IMPLEMENT THIS
     stop("Projection of dispersion parameter not yet implemented for family",
          " Gamma.")
-    ## mean(data$weights*((pref$mu - p_sub$mu)/
+    ## mean(wobs*((pref$mu - p_sub$mu)/
     ##                      family$mu.eta(family$linkfun(p_sub$mu))^2))
   }
   predvar_gamma <- function(mu, dis, wsample = 1) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -174,7 +174,7 @@ bootstrap <- function(x, fun = mean, b = 1000, oobfun = NULL, seed = NULL,
         if (nlevels(y) > 2) {
           stop("y cannot contain more than two classes if specified as factor.")
         }
-        y <- as.vector(y, mode = "integer") - 1 # zero-one vector
+        y <- as.vector(y, mode = "integer") - 1L # zero-one vector
       }
     } else {
       if (is.factor(y)) {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -484,7 +484,7 @@ get_refmodel.stanreg <- function(object, ...) {
 init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
                           div_minimizer = NULL, proj_predfun = NULL,
                           folds = NULL, extract_model_data, cvfun = NULL,
-                          cvfits = NULL, dis = NULL, ...) {
+                          cvfits = NULL, dis = NULL) {
   proper_model <- !is.null(object)
 
   # Formula -----------------------------------------------------------------

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -518,29 +518,30 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
 
   # Functions ---------------------------------------------------------------
 
-  if (is.null(ref_predfun)) {
-    if (proper_model) {
-      ref_predfun <- function(fit, newdata = NULL) {
-        linpred_out <- t(
-          posterior_linpred(fit, transform = FALSE, newdata = newdata)
-        )
-        # Since posterior_linpred() is supposed to include the offsets in its
-        # result, subtract them here:
-        offs <- extract_model_data(fit, newdata = newdata)$offset
-        if (length(offs) > 0) {
-          stopifnot(length(offs) %in% c(1L, nrow(linpred_out)))
-          linpred_out <- linpred_out - offs
-        }
-        return(linpred_out)
+  if (proper_model && is.null(ref_predfun)) {
+    ref_predfun <- function(fit, newdata = NULL) {
+      linpred_out <- t(
+        posterior_linpred(fit, transform = FALSE, newdata = newdata)
+      )
+      # Since posterior_linpred() is supposed to include the offsets in its
+      # result, subtract them here:
+      offs <- extract_model_data(fit, newdata = newdata)$offset
+      if (length(offs) > 0) {
+        stopifnot(length(offs) %in% c(1L, nrow(linpred_out)))
+        linpred_out <- linpred_out - offs
       }
-    } else {
-      ref_predfun <- function(fit, newdata = NULL) {
-        stopifnot(is.null(fit))
-        if (is.null(newdata)) {
-          matrix(rep(NA, NROW(y)))
-        } else {
-          matrix(rep(NA, NROW(newdata)))
-        }
+      return(linpred_out)
+    }
+  } else if (!proper_model) {
+    if (!is.null(ref_predfun)) {
+      warning("Ignoring argument `ref_predfun` because `object` is `NULL`.")
+    }
+    ref_predfun <- function(fit, newdata = NULL) {
+      stopifnot(is.null(fit))
+      if (is.null(newdata)) {
+        matrix(rep(NA, NROW(y)))
+      } else {
+        matrix(rep(NA, NROW(newdata)))
       }
     }
   }

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -202,7 +202,7 @@ predict.refmodel <- function(object, newdata, ynew = NULL, offsetnew = NULL,
     stop("type should be one of ('response', 'link')")
   }
   if (inherits(object, "datafit")) {
-    stop("Cannot make predictions with data reference only.")
+    stop("Cannot make predictions for an `object` of class \"datafit\".")
   }
   if (!is.null(ynew)) {
     if (!(inherits(ynew, "numeric")) || NCOL(ynew) != 1) {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -424,7 +424,7 @@ get_refmodel.stanreg <- function(object, ...) {
     return(do_call(.extract_model_data, args))
   }
 
-  ref_predfun_stanreg <- function(fit, newdata = NULL) {
+  ref_predfun <- function(fit, newdata = NULL) {
     linpred_out <- t(
       posterior_linpred(fit, transform = FALSE, newdata = newdata)
     )
@@ -473,7 +473,7 @@ get_refmodel.stanreg <- function(object, ...) {
 
   return(init_refmodel(
     object = object, data = data, formula = formula, family = family,
-    ref_predfun = ref_predfun_stanreg, extract_model_data = extract_model_data,
+    ref_predfun = ref_predfun, extract_model_data = extract_model_data,
     dis = dis, cvfun = cvfun, ...
   ))
 }

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -482,7 +482,7 @@ get_refmodel.stanreg <- function(object, ...) {
 init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
                           div_minimizer = NULL, proj_predfun = NULL,
                           folds = NULL, extract_model_data, cvfun = NULL,
-                          cvfits = NULL, dis = NULL) {
+                          cvfits = NULL, dis = NULL, ...) {
   proper_model <- !is.null(object)
 
   # Formula -----------------------------------------------------------------

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -536,7 +536,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
         return(linpred_out)
       }
     } else {
-      ref_predfun <- function(fit = NULL, newdata = NULL) {
+      ref_predfun <- function(fit, newdata = NULL) {
         stopifnot(is.null(fit))
         if (is.null(newdata)) {
           matrix(rep(NA, NROW(y)))

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -502,12 +502,6 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
 
   # Data --------------------------------------------------------------------
 
-  if (is.null(data)) {
-    stop("Please provide argument `data`.")
-  }
-  if (is.null(extract_model_data)) {
-    stop("Please provide argument `extract_model_data`.")
-  }
   model_data <- extract_model_data(object, newdata = data)
   weights <- model_data$weights
   offset <- model_data$offset

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -311,7 +311,6 @@ get_refmodel.default <- function(object, formula, family = NULL, ...) {
   if (is.null(family)) {
     family <- family(object)
   }
-  family <- extend_family(family)
 
   extract_model_data <- function(object, newdata = NULL, wrhs = NULL,
                                  orhs = NULL, extract_y = TRUE) {
@@ -333,7 +332,6 @@ get_refmodel.stanreg <- function(object, ...) {
   # Family ------------------------------------------------------------------
 
   family <- family(object)
-  family <- extend_family(family)
 
   # Data --------------------------------------------------------------------
 

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -454,9 +454,9 @@ get_refmodel.stanreg <- function(object, ...) {
     return(linpred_out)
   }
 
-  cvfun <- function(folds) {
+  cvfun <- function(folds, ...) {
     cvres <- rstanarm::kfold(object, K = max(folds), save_fits = TRUE,
-                             folds = folds)
+                             folds = folds, ...)
     fits <- cvres$fits[, "fit"]
     return(fits)
   }

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -307,11 +307,7 @@ get_refmodel.vsel <- function(object, ...) {
 
 #' @rdname get-refmodel
 #' @export
-get_refmodel.default <- function(object, data, formula, ref_predfun = NULL,
-                                 proj_predfun = NULL, div_minimizer = NULL,
-                                 family = NULL, folds = NULL,
-                                 cvfits = NULL, cvfun = NULL,
-                                 dis = NULL, ...) {
+get_refmodel.default <- function(object, formula, family = NULL, ...) {
   if (is.null(family)) {
     family <- extend_family(family(object))
   } else {
@@ -325,19 +321,16 @@ get_refmodel.default <- function(object, data, formula, ref_predfun = NULL,
     return(do_call(.extract_model_data, args))
   }
 
-  refmodel <- init_refmodel(object, data, formula, family, ref_predfun,
-                            div_minimizer, proj_predfun,
-                            extract_model_data = extract_model_data,
-                            cvfits = cvfits, folds = folds, cvfun = cvfun,
-                            dis = dis, ...)
+  refmodel <- init_refmodel(
+    object = object, formula = formula, family = family,
+    extract_model_data = extract_model_data, ...
+  )
   return(refmodel)
 }
 
 #' @rdname get-refmodel
 #' @export
-get_refmodel.stanreg <- function(object, data = NULL, ref_predfun = NULL,
-                                 proj_predfun = NULL, div_minimizer = NULL,
-                                 folds = NULL, ...) {
+get_refmodel.stanreg <- function(object, ...) {
   family <- family(object)
   family <- extend_family(family)
 
@@ -359,32 +352,27 @@ get_refmodel.stanreg <- function(object, data = NULL, ref_predfun = NULL,
     formula <- object$formula
   }
 
-  if (is.null(data)) {
-    data <- object$data
-    if (length(object$weights) != 0) {
-      if ("projpred_internal_wobs_stanreg" %in% names(data)) {
-        stop("Need to write to column `projpred_internal_wobs_stanreg` of ",
-             "`data`, but that column already exists. Please rename this ",
-             "column in `data` and try again.")
-      }
-      data$projpred_internal_wobs_stanreg <- object$weights
-      default_wrhs <- ~ projpred_internal_wobs_stanreg
-    } else {
-      default_wrhs <- NULL
+  data <- object$data
+  if (length(object$weights) != 0) {
+    if ("projpred_internal_wobs_stanreg" %in% names(data)) {
+      stop("Need to write to column `projpred_internal_wobs_stanreg` of ",
+           "`data`, but that column already exists. Please rename this ",
+           "column in `data` and try again.")
     }
-    if (length(object$offset) != 0) {
-      if ("projpred_internal_offs_stanreg" %in% names(data)) {
-        stop("Need to write to column `projpred_internal_offs_stanreg` of ",
-             "`data`, but that column already exists. Please rename this ",
-             "column in `data` and try again.")
-      }
-      data$projpred_internal_offs_stanreg <- object$offset
-      default_orhs <- ~ projpred_internal_offs_stanreg
-    } else {
-      default_orhs <- NULL
-    }
+    data$projpred_internal_wobs_stanreg <- object$weights
+    default_wrhs <- ~ projpred_internal_wobs_stanreg
   } else {
     default_wrhs <- NULL
+  }
+  if (length(object$offset) != 0) {
+    if ("projpred_internal_offs_stanreg" %in% names(data)) {
+      stop("Need to write to column `projpred_internal_offs_stanreg` of ",
+           "`data`, but that column already exists. Please rename this ",
+           "column in `data` and try again.")
+    }
+    data$projpred_internal_offs_stanreg <- object$offset
+    default_orhs <- ~ projpred_internal_offs_stanreg
+  } else {
     default_orhs <- NULL
   }
 
@@ -479,11 +467,9 @@ get_refmodel.stanreg <- function(object, data = NULL, ref_predfun = NULL,
   }
 
   refmodel <- init_refmodel(
-    object, data, formula, family,
-    ref_predfun = ref_predfun_stanreg, div_minimizer = div_minimizer,
-    proj_predfun = proj_predfun, folds = folds,
-    extract_model_data = extract_model_data, dis = dis,
-    cvfun = cvfun, ...
+    object = object, data = data, formula = formula, family = family,
+    ref_predfun = ref_predfun_stanreg, extract_model_data = extract_model_data,
+    dis = dis, cvfun = cvfun, ...
   )
   return(refmodel)
 }

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -507,7 +507,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   offset <- model_data$offset
   y <- model_data$y
 
-  # Add (transformed) response under the new name:
+  # Add (transformed) response under the (possibly) new name:
   data[, response_name] <- y
 
   target <- .get_standard_y(y, weights, family)

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -621,10 +621,10 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     loglik <- NULL
   }
 
-  # This is a dummy definition for cvfun(), but it will lead to standard
-  # cross-validation for datafit reference; see cv_varsel() and .get_kfold():
   if (is.null(cvfun)) {
     if (!proper_model) {
+      # This is a dummy definition for cvfun(), but it will lead to standard CV
+      # for `datafit`s; see cv_varsel() and .get_kfold():
       cvfun <- function(folds, ...) {
         lapply(seq_len(max(folds)), function(k) list())
       }

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -479,7 +479,7 @@ get_refmodel.stanreg <- function(object, ...) {
 #' @export
 init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
                           div_minimizer = NULL, proj_predfun = NULL,
-                          folds = NULL, extract_model_data = NULL, cvfun = NULL,
+                          folds = NULL, extract_model_data, cvfun = NULL,
                           cvfits = NULL, dis = NULL, ...) {
   stopifnot(inherits(formula, "formula"))
   formula <- expand_formula(formula, data)

--- a/man/get-refmodel.Rd
+++ b/man/get-refmodel.Rd
@@ -16,30 +16,9 @@ get_refmodel(object, ...)
 
 \method{get_refmodel}{vsel}(object, ...)
 
-\method{get_refmodel}{default}(
-  object,
-  data,
-  formula,
-  ref_predfun = NULL,
-  proj_predfun = NULL,
-  div_minimizer = NULL,
-  family = NULL,
-  folds = NULL,
-  cvfits = NULL,
-  cvfun = NULL,
-  dis = NULL,
-  ...
-)
+\method{get_refmodel}{default}(object, formula, family = NULL, ...)
 
-\method{get_refmodel}{stanreg}(
-  object,
-  data = NULL,
-  ref_predfun = NULL,
-  proj_predfun = NULL,
-  div_minimizer = NULL,
-  folds = NULL,
-  ...
-)
+\method{get_refmodel}{stanreg}(object, ...)
 
 init_refmodel(
   object,
@@ -72,12 +51,16 @@ object of the corresponding class.}
 arguments passed to \code{init_refmodel}. For the \code{get_refmodel}
 generic: arguments passed to the appropriate method. Else: ignored.}
 
-\item{data}{Data used for fitting the reference model.}
-
 \item{formula}{Reference model's formula. For general information on formulas
 in \R, see \code{\link{formula}}. For multilevel formulas, see also package
 \pkg{lme4}, in particular \code{\link[lme4:lmer]{lme4::lmer}} and
 \code{\link[lme4:glmer]{lme4::glmer}}.}
+
+\item{family}{A \code{"family"} object representing the observational model
+(i.e., the distributional family for the response). For general information
+on \code{"family"} objects in \R, see \code{\link{family}}.}
+
+\item{data}{Data used for fitting the reference model.}
 
 \item{ref_predfun}{Prediction function for the linear predictor of the
 reference model. May be \code{NULL} for using an internal default.
@@ -95,34 +78,6 @@ Let \eqn{N} denote the number of observations in the original dataset (used
 for fitting the reference model) and \eqn{S} the number of posterior draws
 for the reference model's parameters. Then the return value of
 \code{ref_predfun} has to be a \eqn{N \times S}{N x S} matrix.}
-
-\item{proj_predfun}{Prediction function for the linear predictor of a
-submodel onto which the reference model is projected. May be \code{NULL}
-for using an internal default. Otherwise, needs to have the prototype
-\code{proj_predfun(fit, newdata = NULL, weights = NULL)} where:
-\itemize{
-  \item{\code{fit} accepts fit(s) of a submodel as returned by
-  \code{\link{project}} in its output element \code{sub_fit} (which in turn
-  is the same as the return value of \code{div_minimizer}, except if
-  \code{\link{project}} was used with a \code{"vsel"} object from an L1
-  search as well as \code{cv_search = FALSE});}
-  \item{\code{newdata} accepts either \code{NULL} (for using the original
-  dataset, typically stored in \code{fit}) or data for new observations (at
-  least in the form of a \code{data.frame});}
-  \item{\code{weights} accepts either \code{NULL} (for using a vector of
-  ones) or weights for the new observations from \code{newdata} (at least
-  in the form of a numeric vector).}
-}
-Let \eqn{N} denote the number of observations and
-\eqn{S_{\mbox{prj}}}{S_prj} the number of projected draws (corresponding to
-the number of fits in \code{fit}). Then the return value of
-\code{proj_predfun} has to be:
-\itemize{
-  \item{a vector or a 1-column matrix of length \eqn{N} if
-  \eqn{S_{\mbox{prj}} = 1}{S_prj = 1};}
-  \item{a \eqn{N \times S_{\mbox{prj}}}{N x S_prj} matrix if
-  \eqn{S_{\mbox{prj}} > 1}{S_prj > 1}.}
-}}
 
 \item{div_minimizer}{A function for minimizing the Kullback-Leibler (KL)
 divergence from a submodel to the reference model (i.e., for performing the
@@ -154,30 +109,36 @@ The return value of \code{div_minimizer} has to be:
 This output of \code{div_minimizer} is used, e.g., by \code{proj_predfun}'s
 argument \code{fit}.}
 
-\item{family}{A \code{"family"} object representing the observational model
-(i.e., the distributional family for the response). For general information
-on \code{"family"} objects in \R, see \code{\link{family}}.}
+\item{proj_predfun}{Prediction function for the linear predictor of a
+submodel onto which the reference model is projected. May be \code{NULL}
+for using an internal default. Otherwise, needs to have the prototype
+\code{proj_predfun(fit, newdata = NULL, weights = NULL)} where:
+\itemize{
+  \item{\code{fit} accepts fit(s) of a submodel as returned by
+  \code{\link{project}} in its output element \code{sub_fit} (which in turn
+  is the same as the return value of \code{div_minimizer}, except if
+  \code{\link{project}} was used with a \code{"vsel"} object from an L1
+  search as well as \code{cv_search = FALSE});}
+  \item{\code{newdata} accepts either \code{NULL} (for using the original
+  dataset, typically stored in \code{fit}) or data for new observations (at
+  least in the form of a \code{data.frame});}
+  \item{\code{weights} accepts either \code{NULL} (for using a vector of
+  ones) or weights for the new observations from \code{newdata} (at least
+  in the form of a numeric vector).}
+}
+Let \eqn{N} denote the number of observations and
+\eqn{S_{\mbox{prj}}}{S_prj} the number of projected draws (corresponding to
+the number of fits in \code{fit}). Then the return value of
+\code{proj_predfun} has to be:
+\itemize{
+  \item{a vector or a 1-column matrix of length \eqn{N} if
+  \eqn{S_{\mbox{prj}} = 1}{S_prj = 1};}
+  \item{a \eqn{N \times S_{\mbox{prj}}}{N x S_prj} matrix if
+  \eqn{S_{\mbox{prj}} > 1}{S_prj > 1}.}
+}}
 
 \item{folds}{For K-fold cross-validation only. A vector of fold indices for
 each observation from \code{data}.}
-
-\item{cvfits}{For K-fold cross-validation only. A list with one sublist
-called \code{"fits"} containing K-fold fitted objects from which reference
-models are created. The \code{cvfits} list (i.e., the superlist) needs to
-have attributes \code{"K"} and \code{"folds"}: \code{"K"} has to be a
-single integer giving the number of folds and \code{"folds"} has to be an
-integer vector giving the fold indices (one fold index per observation).
-Note that \code{cvfits} takes precedence over \code{cvfun}, i.e., if both
-are provided, \code{cvfits} is used.}
-
-\item{cvfun}{For K-fold cross-validation only. A function that, given a folds
-vector, fits a reference model per fold and returns the fitted object. May
-be \code{NULL} if \code{object} is \code{NULL}. Note that \code{cvfits}
-takes precedence over \code{cvfun}, i.e., if both are provided,
-\code{cvfits} is used.}
-
-\item{dis}{A vector of posterior draws for the dispersion parameter (if such
-a parameter exists; else \code{dis} may be \code{NULL}).}
 
 \item{extract_model_data}{A function for fetching some variables (response,
 observation weights, offsets) from the original dataset (i.e., the dataset
@@ -205,6 +166,24 @@ with elements \code{y}, \code{weights}, and \code{offset}, each being a
 numeric vector containing the data for the response, the observation
 weights, and the offsets, respectively. An exception is that \code{y} may
 also be \code{NULL} (depending on argument \code{extract_y}).}
+
+\item{cvfun}{For K-fold cross-validation only. A function that, given a folds
+vector, fits a reference model per fold and returns the fitted object. May
+be \code{NULL} if \code{object} is \code{NULL}. Note that \code{cvfits}
+takes precedence over \code{cvfun}, i.e., if both are provided,
+\code{cvfits} is used.}
+
+\item{cvfits}{For K-fold cross-validation only. A list with one sublist
+called \code{"fits"} containing K-fold fitted objects from which reference
+models are created. The \code{cvfits} list (i.e., the superlist) needs to
+have attributes \code{"K"} and \code{"folds"}: \code{"K"} has to be a
+single integer giving the number of folds and \code{"folds"} has to be an
+integer vector giving the fold indices (one fold index per observation).
+Note that \code{cvfits} takes precedence over \code{cvfun}, i.e., if both
+are provided, \code{cvfits} is used.}
+
+\item{dis}{A vector of posterior draws for the dispersion parameter (if such
+a parameter exists; else \code{dis} may be \code{NULL}).}
 }
 \value{
 An object that can be passed to all the functions that take the

--- a/man/get-refmodel.Rd
+++ b/man/get-refmodel.Rd
@@ -32,8 +32,7 @@ init_refmodel(
   extract_model_data,
   cvfun = NULL,
   cvfits = NULL,
-  dis = NULL,
-  ...
+  dis = NULL
 )
 }
 \arguments{

--- a/man/get-refmodel.Rd
+++ b/man/get-refmodel.Rd
@@ -32,7 +32,8 @@ init_refmodel(
   extract_model_data,
   cvfun = NULL,
   cvfits = NULL,
-  dis = NULL
+  dis = NULL,
+  ...
 )
 }
 \arguments{

--- a/man/get-refmodel.Rd
+++ b/man/get-refmodel.Rd
@@ -29,7 +29,7 @@ init_refmodel(
   div_minimizer = NULL,
   proj_predfun = NULL,
   folds = NULL,
-  extract_model_data = NULL,
+  extract_model_data,
   cvfun = NULL,
   cvfits = NULL,
   dis = NULL,

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -228,9 +228,11 @@ test_that("init_refmodel(): `object` of class \"datafit\" works", {
 
 test_that("predict.refmodel(): `object` of class \"datafit\" fails", {
   for (tstsetup in names(datafits)) {
-    expect_error(predict(datafits[[tstsetup]], newdata = dat),
-                 "^Cannot make predictions with data reference only\\.$",
-                 info = tstsetup)
+    expect_error(
+      predict(datafits[[tstsetup]], newdata = dat),
+      "^Cannot make predictions for an `object` of class \"datafit\"\\.$",
+      info = tstsetup
+    )
   }
 })
 


### PR DESCRIPTION
This cleans up code related to reference models. For example, unnecessary arguments are removed, error and warning messages are improved/added, and especially the content of `init_refmodel()` is tidied up a bit so it gets easier to follow. This PR also serves as a preparation for more PRs to come which then fix some bugs.