### PR TITLE
Remove argument `folds`

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -747,7 +747,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
       object = fit, data = fetch_fold(),
       formula = refmodel$formula, family = refmodel$family,
       div_minimizer = refmodel$div_minimizer,
-      proj_predfun = proj_predfun, folds = seq_along(fold),
+      proj_predfun = proj_predfun,
       extract_model_data = extract_model_data
     )
   }

--- a/man/get-refmodel.Rd
+++ b/man/get-refmodel.Rd
@@ -28,7 +28,6 @@ init_refmodel(
   ref_predfun = NULL,
   div_minimizer = NULL,
   proj_predfun = NULL,
-  folds = NULL,
   extract_model_data,
   cvfun = NULL,
   cvfits = NULL,
@@ -136,9 +135,6 @@ the number of fits in \code{fit}). Then the return value of
   \item{a \eqn{N \times S_{\mbox{prj}}}{N x S_prj} matrix if
   \eqn{S_{\mbox{prj}} > 1}{S_prj > 1}.}
 }}
-
-\item{folds}{For K-fold cross-validation only. A vector of fold indices for
-each observation from \code{data}.}
 
 \item{extract_model_data}{A function for fetching some variables (response,
 observation weights, offsets) from the original dataset (i.e., the dataset

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -154,7 +154,7 @@ refmodel_tester <- function(
   refmod_nms <- c(
     "fit", "formula", "div_minimizer", "family", "mu", "dis", "y", "loglik",
     "intercept", "proj_predfun", "fetch_data", "wobs", "wsample", "offset",
-    "folds", "cvfun", "cvfits", "extract_model_data", "ref_predfun"
+    "cvfun", "cvfits", "extract_model_data", "ref_predfun"
   )
   refmod_class_expected <- "refmodel"
   if (is_datafit) {
@@ -388,9 +388,6 @@ refmodel_tester <- function(
   # expect_length(refmod$offset, nobsv_expected)
   ###
   expect_identical(refmod$offset, offs_expected, info = info_str)
-
-  # folds
-  expect_null(refmod$folds, info = info_str)
 
   # cvfun
   expect_type(refmod$cvfun, "closure")

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -20,6 +20,12 @@ run_valsearch_always <- FALSE
 run_cvfits_all <- FALSE
 # Run tests for "brmsfit"s?:
 run_brms <- FALSE # identical(Sys.getenv("NOT_CRAN"), "true")
+if (run_brms && packageVersion("brms") <= package_version("2.16.1")) {
+  warning("Deactivating the brms tests because brms version <= 2.16.1 calls ",
+          "init_refmodel() with the now omitted argument `folds`. Install a ",
+          "newer brms version to run the brms tests.")
+  run_brms <- FALSE
+}
 # Run snapshot tests (see, e.g., `?expect_snapshot` and
 # `vignette("snapshotting", package = "testthat")`)?:
 # Notes:
@@ -353,13 +359,9 @@ args_fit <- lapply(pkg_nms, function(pkg_nm) {
       # CV cannot be tested in that case.
     }
 
-    if ((pkg_nm == "rstanarm" && mod_nm %in% c("gam", "gamm")) ||
-        (pkg_nm == "brms" &&
-         packageVersion("brms") <= package_version("2.16.1"))) {
+    if (pkg_nm == "rstanarm" && mod_nm %in% c("gam", "gamm")) {
       # In the rstanarm "gam" and "gamm" case, the offsets are omitted because
       # of rstanarm issue #546 and rstanarm issue #253.
-      # In the brms case (up to (including) brms version 2.16.1), the offsets
-      # are omitted because of brms issue #1220.
       offss_nms <- "without_offs"
     } else {
       offss_nms <- "with_offs"


### PR DESCRIPTION
This removes argument `folds` from `init_refmodel()` because it was effectively unused and might have confused users. I didn't include this in the previous PR #219 because this might be a breaking change for users having argument `folds` stated explicitly in scripts. (Since I can't think of a situation where `folds` would really be needed, I don't suspect such usages of `folds` to be intentional, though.)