### PR TITLE
Remove `weights` from prediction

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -379,8 +379,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     for (k in seq_along(submodels)) {
       mu_k <- family$mu_fun(submodels[[k]]$sub_fit,
                             obs = inds,
-                            offset = refmodel$offset,
-                            weights = 1)
+                            offset = refmodel$offset)
       log_lik_sub <- t(family$ll_fun(
         mu_k, submodels[[k]]$dis,
         y[inds], refmodel$wobs[inds]
@@ -722,8 +721,8 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
   ref_predfun <- function(fit, newdata = default_data) {
     refmodel$ref_predfun(fit, newdata = newdata)
   }
-  proj_predfun <- function(fit, newdata = default_data, weights = NULL) {
-    refmodel$proj_predfun(fit, newdata = newdata, weights = weights)
+  proj_predfun <- function(fit, newdata = default_data) {
+    refmodel$proj_predfun(fit, newdata = newdata)
   }
   extract_model_data <- function(object, newdata = default_data, ...) {
     refmodel$extract_model_data(object = object, newdata = newdata, ...)

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -177,38 +177,29 @@ control_callback <- function(family, ...) {
 
 # helper function for linear_multilevel_proj_predfun to only pass
 # allow.new.levels if the fit is multilevel
-predict_multilevel_callback <- function(fit, newdata = NULL, weights = NULL) {
+predict_multilevel_callback <- function(fit, newdata = NULL) {
   if (inherits(fit, c("lmerMod", "glmerMod"))) {
-    return(predict(fit,
-                   newdata = newdata, allow.new.levels = TRUE,
-                   weights = weights))
+    return(predict(fit, newdata = newdata, allow.new.levels = TRUE))
   } else {
-    return(predict(fit, newdata = newdata, weights = weights))
+    return(predict(fit, newdata = newdata))
   }
 }
 
-linear_multilevel_proj_predfun <- function(fit, newdata = NULL,
-                                           weights = NULL) {
-  if (is.null(weights)) {
-    weights <- 1
-  }
+linear_multilevel_proj_predfun <- function(fit, newdata = NULL) {
   if (inherits(fit, "list")) {
     return(do.call(cbind, lapply(fit, function(fit) {
-      predict_multilevel_callback(fit, newdata, weights)
+      predict_multilevel_callback(fit, newdata)
     })))
   } else {
-    return(as.matrix(predict_multilevel_callback(fit, newdata, weights)))
+    return(as.matrix(predict_multilevel_callback(fit, newdata)))
   }
 }
 
-linear_proj_predfun <- function(fit, newdata = NULL, weights = NULL) {
-  if (is.null(weights)) {
-    weights <- 1
-  }
+linear_proj_predfun <- function(fit, newdata = NULL) {
   if (inherits(fit, "list")) {
     if (!is.null(newdata)) {
       return(do.call(cbind, lapply(fit, function(fit) {
-        predict(fit, newdata = newdata, weights = weights)
+        predict(fit, newdata = newdata)
       })))
     } else {
       return(do.call(cbind, lapply(fit, function(fit) {
@@ -218,25 +209,22 @@ linear_proj_predfun <- function(fit, newdata = NULL, weights = NULL) {
   }
   else {
     if (!is.null(newdata)) {
-      return(predict(fit, newdata = newdata, weights = weights))
+      return(predict(fit, newdata = newdata))
     } else {
       return(predict(fit))
     }
   }
 }
 
-additive_proj_predfun <- function(fit, newdata = NULL, weights = NULL) {
+additive_proj_predfun <- function(fit, newdata = NULL) {
   if (!is.null(newdata)) {
     newdata <- cbind(`(Intercept)` = rep(1, NROW(newdata)), newdata)
   }
-  return(linear_multilevel_proj_predfun(fit, newdata, weights))
+  return(linear_multilevel_proj_predfun(fit, newdata))
 }
 
 ## FIXME: find a way that allows us to remove this
-predict.subfit <- function(subfit, newdata = NULL, weights = NULL) {
-  if (is.null(weights)) {
-    weights <- rep(1, NROW(subfit$x))
-  }
+predict.subfit <- function(subfit, newdata = NULL) {
   beta <- subfit$beta
   alpha <- subfit$alpha
   x <- subfit$x
@@ -250,7 +238,6 @@ predict.subfit <- function(subfit, newdata = NULL, weights = NULL) {
     contrasts_arg <- get_contrasts_arg_list(subfit$formula, newdata)
     x <- model.matrix(delete.response(terms(subfit$formula)), newdata,
                       contrasts.arg = contrasts_arg)
-    ## x <- weights * x
     if (is.null(beta)) {
       return(as.matrix(rep(alpha, NROW(x))))
     } else {
@@ -259,7 +246,7 @@ predict.subfit <- function(subfit, newdata = NULL, weights = NULL) {
   }
 }
 
-predict.gamm4 <- function(fit, newdata = NULL, weights = NULL) {
+predict.gamm4 <- function(fit, newdata = NULL) {
   if (is.null(newdata)) {
     newdata <- model.frame(fit$mer)
   }
@@ -272,7 +259,7 @@ predict.gamm4 <- function(fit, newdata = NULL, weights = NULL) {
   mf <- gamm_struct$mf
 
   ## base pred only smooth and fixed effects
-  gamm_pred <- predict(fit$mer, newdata = mf, re.form = NA, weights = weights)
+  gamm_pred <- predict(fit$mer, newdata = mf, re.form = NA)
 
   ## gamm4 trick to replace dummy smooth variables with actual smooth terms
   sn <- names(ranef)

--- a/R/methods.R
+++ b/R/methods.R
@@ -182,8 +182,7 @@ proj_helper <- function(object, newdata,
       offsetnew <- rep(0, NROW(newdata))
     }
     mu <- proj$family$mu_fun(proj$sub_fit,
-                             newdata = newdata, offset = offsetnew,
-                             weights = weightsnew)
+                             newdata = newdata, offset = offsetnew)
 
     onesub_fun(proj, mu, weightsnew,
                offset = offsetnew, newdata = newdata,

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -113,7 +113,7 @@ project_submodel <- function(solution_terms, p_ref, refmodel, family, intercept,
     ref <- p_ref
   }
 
-  mu <- family$mu_fun(sub_fit, offset = refmodel$offset, weights = 1)
+  mu <- family$mu_fun(sub_fit, offset = refmodel$offset)
   dis <- family$dis_fun(ref, nlist(mu), ref$wobs)
   kl <- weighted.mean(family$kl(
     ref, nlist(weights = wobs),

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -41,7 +41,7 @@
 #' @param proj_predfun Prediction function for the linear predictor of a
 #'   submodel onto which the reference model is projected. May be \code{NULL}
 #'   for using an internal default. Otherwise, needs to have the prototype
-#'   \code{proj_predfun(fit, newdata = NULL, weights = NULL)} where:
+#'   \code{proj_predfun(fit, newdata = NULL)} where:
 #'   \itemize{
 #'     \item{\code{fit} accepts fit(s) of a submodel as returned by
 #'     \code{\link{project}} in its output element \code{sub_fit} (which in turn
@@ -51,9 +51,6 @@
 #'     \item{\code{newdata} accepts either \code{NULL} (for using the original
 #'     dataset, typically stored in \code{fit}) or data for new observations (at
 #'     least in the form of a \code{data.frame});}
-#'     \item{\code{weights} accepts either \code{NULL} (for using a vector of
-#'     ones) or weights for the new observations from \code{newdata} (at least
-#'     in the form of a numeric vector).}
 #'   }
 #'   Let \eqn{N} denote the number of observations and
 #'   \eqn{S_{\mbox{prj}}}{S_prj} the number of projected draws (corresponding to
@@ -596,18 +593,12 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     family <- extend_family(family)
   }
 
-  family$mu_fun <- function(fit, obs = NULL, newdata = NULL, offset = NULL,
-                            weights = NULL) {
+  family$mu_fun <- function(fit, obs = NULL, newdata = NULL, offset = NULL) {
     newdata <- fetch_data(data, obs = obs, newdata = newdata)
     if (is.null(offset)) {
       offset <- rep(0, nrow(newdata))
     }
-    if (is.null(weights)) {
-      weights <- rep(1, nrow(newdata))
-    }
-    suppressWarnings(family$linkinv(proj_predfun(fit,
-                                                 newdata = newdata,
-                                                 weights = weights) +
+    suppressWarnings(family$linkinv(proj_predfun(fit, newdata = newdata) +
                                       offset))
   }
 

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -6,8 +6,7 @@
     weights <- refmodel$wobs[test_points]
     mu <- family$mu_fun(sub_fit,
                         obs = test_points,
-                        offset = refmodel$offset[test_points],
-                        weights = weights)
+                        offset = refmodel$offset[test_points])
 
     y <- refmodel$y[test_points]
     y_test <- nlist(y, weights)

--- a/man/get-refmodel.Rd
+++ b/man/get-refmodel.Rd
@@ -111,7 +111,7 @@ argument \code{fit}.}
 \item{proj_predfun}{Prediction function for the linear predictor of a
 submodel onto which the reference model is projected. May be \code{NULL}
 for using an internal default. Otherwise, needs to have the prototype
-\code{proj_predfun(fit, newdata = NULL, weights = NULL)} where:
+\code{proj_predfun(fit, newdata = NULL)} where:
 \itemize{
   \item{\code{fit} accepts fit(s) of a submodel as returned by
   \code{\link{project}} in its output element \code{sub_fit} (which in turn
@@ -121,9 +121,6 @@ for using an internal default. Otherwise, needs to have the prototype
   \item{\code{newdata} accepts either \code{NULL} (for using the original
   dataset, typically stored in \code{fit}) or data for new observations (at
   least in the form of a \code{data.frame});}
-  \item{\code{weights} accepts either \code{NULL} (for using a vector of
-  ones) or weights for the new observations from \code{newdata} (at least
-  in the form of a numeric vector).}
 }
 Let \eqn{N} denote the number of observations and
 \eqn{S_{\mbox{prj}}}{S_prj} the number of projected draws (corresponding to


### PR DESCRIPTION
This fixes issue #163: The observation weights are removed from the prediction functions, as far as possible.