### PR TITLE
Fix bug introduced by PR #196

### DIFF
--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -449,7 +449,9 @@ get_refmodel.stanreg <- function(object, ...) {
         !is.null(newdata) && length(fit$offset) > 0
     )
     if (!cond_no_offs) {
-      offs <- extract_model_data(fit, newdata = newdata)$offset
+      # Observation weights are not needed here, so use `wrhs = NULL` to avoid
+      # potential conflicts for a non-`NULL` default `wrhs`:
+      offs <- extract_model_data(fit, newdata = newdata, wrhs = NULL)$offset
       stopifnot(identical(nrow(linpred_out), length(offs)))
       linpred_out <- linpred_out - offs
     }
@@ -548,7 +550,9 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
       )
       # Since posterior_linpred() is supposed to include the offsets in its
       # result, subtract them here:
-      offs <- extract_model_data(fit, newdata = newdata)$offset
+      # Observation weights are not needed here, so use `wrhs = NULL` to avoid
+      # potential conflicts for a non-`NULL` default `wrhs`:
+      offs <- extract_model_data(fit, newdata = newdata, wrhs = NULL)$offset
       if (length(offs) > 0) {
         stopifnot(length(offs) %in% c(1L, nrow(linpred_out)))
         linpred_out <- linpred_out - offs


### PR DESCRIPTION
This fixes a bug in `predict.refmodel()` introduced by PR #196 (in those `"stanreg"` cases where `object$ref_predfun()` actually calls `object$extract_model_data()`; perhaps a similar bug existed for `"brmsfit"`s or custom reference models created by `init_refmodel()`). See the comment in the code for details.