### PR TITLE
Extend tests

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -364,11 +364,9 @@ args_fit <- lapply(pkg_nms, function(pkg_nm) {
     lapply(fam_nms, function(fam_nm) {
       y_chr <- paste("y", mod_nm, fam_nm, sep = "_")
 
-      if (fam_nm == "gauss" && pkg_nm != "brms" &&
-          !(pkg_nm == "rstanarm" && mod_nm == "gamm")) {
-        # Here, we also test a special formula (the brms case is excluded for
-        # speed reasons; the rstanarm "gamm" case is excluded because of
-        # rstanarm issue #545):
+      if (fam_nm == "gauss" && !(pkg_nm == "rstanarm" && mod_nm == "gamm")) {
+        # Here, we also test a special formula (the rstanarm "gamm" case is
+        # excluded because of rstanarm issue #545):
         formul_nms <- c("stdformul", "spclformul")
       } else {
         formul_nms <- "stdformul"


### PR DESCRIPTION
This extends the tests, e.g., to GAMs and GAMMs as well as to `"brmsfit"`s. See the commit messages and the corresponding comments in the code for details. Coverage (calculated locally) hereby increases to 85.90% (in PR #217, we had 79.82%).

**EDIT:** On Windows, I get a coverage of 86.21% at the state of this PR. I don't know where the difference compared to the other system (a Linux system) is coming from; this might be related to internals of the **covr** package.