### PR TITLE
More tests without offsets

### DIFF
--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -202,8 +202,10 @@ test_that(paste(
         # Since varsel() doesn't output object `p_sub`, use the linear predictor
         # here (instead of the coefficients themselves, which would only be
         # accessible from `p_sub`):
-        mu_jm_regul <- vs_regul$family$linkfun(vs_regul$summaries$sub[[m]]$mu) -
-          offs_tst
+        mu_jm_regul <- vs_regul$family$linkfun(vs_regul$summaries$sub[[m]]$mu)
+        if (grepl("\\.with_offs", tstsetup)) {
+          mu_jm_regul <- mu_jm_regul - offs_tst
+        }
         # In fact, `sum((mu - offset - intercept)^2)` would make more sense than
         # `var(mu - offset) = sum((mu - offset - mean(mu - offset))^2)` but
         # since varsel() doesn't output object `p_sub`, the intercept from the


### PR DESCRIPTION
This omits the offsets in some more tests (previously, only the workarounds for **rstanarm** GAM and GAMM fits lacked offsets) to avoid that the tests focus too much on scenarios where offsets are included (which they are rarely in practice).

**EDIT:** Coverage (calculated locally on a Windows system) hereby increases to 86.71% (in PR #229, we had 86.21% on Windows).