### PR TITLE
Handle issue stan-dev/rstanarm#551 and other `cvfun` changes

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -722,8 +722,8 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
         })
       } else {
         stop(
-          "For a generic reference model, you must provide either cvfits or ",
-          "cvfun for K-fold cross-validation. See function init_refmodel."
+          "For a generic reference model, you must provide either `cvfits` or ",
+          "`cvfun` for K-fold cross-validation. See function init_refmodel()."
         )
       }
     }

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -499,8 +499,13 @@ get_refmodel.stanreg <- function(object, ...) {
   }
 
   cvfun <- function(folds) {
+    # Use `cores = 1` because of rstanarm issue #551. In fact, this issue only
+    # affects Windows systems, but since `cores = 1` leads to an *inner*
+    # parallelization (i.e., across chains, not across CV folds) with
+    # `stan_cores <- getOption("mc.cores", 1)` cores, this should also be
+    # suitable for other systems:
     rstanarm::kfold(object, K = max(folds), save_fits = TRUE,
-                    folds = folds)$fits[, "fit"]
+                    folds = folds, cores = 1)$fits[, "fit"]
   }
 
   # Miscellaneous -----------------------------------------------------------

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -498,9 +498,9 @@ get_refmodel.stanreg <- function(object, ...) {
     return(linpred_out)
   }
 
-  cvfun <- function(folds, ...) {
+  cvfun <- function(folds) {
     rstanarm::kfold(object, K = max(folds), save_fits = TRUE,
-                    folds = folds, ...)$fits[, "fit"]
+                    folds = folds)$fits[, "fit"]
   }
 
   # Miscellaneous -----------------------------------------------------------
@@ -670,7 +670,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     if (!proper_model) {
       # This is a dummy definition for cvfun(), but it will lead to standard CV
       # for `datafit`s; see cv_varsel() and .get_kfold():
-      cvfun <- function(folds, ...) {
+      cvfun <- function(folds) {
         lapply(seq_len(max(folds)), function(k) list())
       }
     } else if (is.null(cvfits)) {

--- a/vignettes/projpred.Rmd
+++ b/vignettes/projpred.Rmd
@@ -69,6 +69,7 @@ ncores <- parallel::detectCores(logical = FALSE)
 ### the code yourself):
 ncores <- min(ncores, 2L)
 ###
+options(mc.cores = ncores)
 refm_fit <- stan_glm(
   y ~ X1 + X2 + X3 + X4 + X5 + X6 + X7 + X8 + X9 + X10 + X11 + X12 + X13 + X14 +
     X15 + X16 + X17 + X18 + X19 + X20,
@@ -78,7 +79,7 @@ refm_fit <- stan_glm(
   ### Only for the sake of speed (not recommended in general):
   chains = 2, iter = 500,
   ###
-  cores = ncores, seed = 2052109, QR = TRUE, refresh = 0
+  seed = 2052109, QR = TRUE, refresh = 0
 )
 ```
 Usually, we would now have to check the convergence diagnostics (see, e.g., `?posterior::diagnostics` and `?posterior::default_convergence_measures`). However, due to the technical reasons for which we reduced `chains` and `iter`, we skip this step here.
@@ -262,7 +263,7 @@ refm_fit <- stan_glmer(
   r2 ~ btype + situ + mode + (btype + situ + mode | id),
   family = binomial(),
   data = VerbAgg,
-  cores = ncores, seed = 82616169, QR = TRUE, refresh = 0
+  seed = 82616169, QR = TRUE, refresh = 0
 )
 ```
 
@@ -277,7 +278,7 @@ refm_fit <- stan_gamm4(
   yield ~ year + topo + s(nitro, bv),
   family = gaussian(),
   data = lasrosas.corn,
-  cores = ncores, seed = 4919670, QR = TRUE, refresh = 0
+  seed = 4919670, QR = TRUE, refresh = 0
 )
 ```
 
@@ -289,7 +290,7 @@ refm_fit <- stan_gamm4(
   random = ~ (1 | row) + (1 | quadrat),
   family = binomial(),
   data = gumpertz.pepper,
-  cores = ncores, seed = 14209013, QR = TRUE, refresh = 0
+  seed = 14209013, QR = TRUE, refresh = 0
 )
 ```
 


### PR DESCRIPTION
This mainly handles issue stan-dev/rstanarm#551 by fixing `cores = 1` in `rstanarm::kfold()`. In fact, this issue only affects Windows systems, but since `cores = 1` in `rstanarm::kfold()` leads to an *inner* parallelization (i.e., across chains, not across CV folds) with `stan_cores <- getOption("mc.cores", 1)` cores, fixing `cores = 1` is also suitable for other systems.

Some other `cvfun`-related changes are performed, too.