### PR TITLE
GLM submodel fitter

### DIFF
--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -112,7 +112,8 @@ fit_glm_ridge_callback <- function(formula, data,
   return(sub)
 }
 
-# Alternative to fit_glm_ridge_callback():
+# Alternative to fit_glm_ridge_callback() (may be used via global option
+# `projpred.glm_fitter`):
 fit_glm_callback <- function(formula, family, projpred_var, projpred_regul,
                              ...) {
   ## make sure correct 'weights' can be found

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -246,8 +246,9 @@ fit_glmer_callback <- function(formula, family,
     }
   }, error = function(e) {
     if (grepl("No random effects", as.character(e))) {
-      # This case should not occur anymore, but leave it here for safety
-      # reasons.
+      # This case should not occur anymore (because divmin() should pick the
+      # correct submodel fitter based on the submodel's formula), but leave it
+      # here in case user-specified divergence minimizers make use of it.
       glm_fitter <- get(getOption("projpred.glm_fitter",
                                   "fit_glm_ridge_callback"),
                         mode = "function")

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -128,11 +128,10 @@ fit_glm_callback <- function(formula, family, projpred_var, projpred_regul,
               union(methods::formalArgs(stats::lm.fit),
                     methods::formalArgs(stats::lm.wfit)))
       )]
-      # Use suppressMessages(suppressWarnings()) here?:
-      return(do.call(stats::lm, c(
+      return(suppressMessages(suppressWarnings(do.call(stats::lm, c(
         list(formula = formula),
         dot_args
-      )))
+      )))))
     } else {
       # Exclude arguments from `...` which cannot be passed to stats::glm():
       dot_args <- list(...)
@@ -141,11 +140,10 @@ fit_glm_callback <- function(formula, family, projpred_var, projpred_regul,
         union(methods::formalArgs(stats::glm),
               methods::formalArgs(stats::glm.control))
       )]
-      # Use suppressMessages(suppressWarnings()) here?:
-      return(do.call(stats::glm, c(
+      return(suppressMessages(suppressWarnings(do.call(stats::glm, c(
         list(formula = formula, family = family),
         dot_args
-      )))
+      )))))
     }
   }, error = function(e) {
     # May be used to handle errors.

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -124,7 +124,9 @@ fit_glm_callback <- function(formula, family, projpred_var, projpred_regul,
       dot_args <- list(...)
       dot_args <- dot_args[intersect(
         names(dot_args),
-        methods::formalArgs(stats::lm)
+        union(methods::formalArgs(stats::lm),
+              union(methods::formalArgs(stats::lm.fit),
+                    methods::formalArgs(stats::lm.wfit)))
       )]
       # Use suppressMessages(suppressWarnings()) here?:
       return(do.call(stats::lm, c(
@@ -136,7 +138,8 @@ fit_glm_callback <- function(formula, family, projpred_var, projpred_regul,
       dot_args <- list(...)
       dot_args <- dot_args[intersect(
         names(dot_args),
-        methods::formalArgs(stats::glm)
+        union(methods::formalArgs(stats::glm),
+              methods::formalArgs(stats::glm.control))
       )]
       # Use suppressMessages(suppressWarnings()) here?:
       return(do.call(stats::glm, c(

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -115,10 +115,8 @@ fit_glm_ridge_callback <- function(formula, data,
 # Alternative to fit_glm_ridge_callback():
 fit_glm_callback <- function(formula, family, projpred_var, projpred_regul,
                              ...) {
-  ### Needed?:
-  # ## make sure correct 'weights' can be found
-  # environment(formula) <- environment()
-  ###
+  ## make sure correct 'weights' can be found
+  environment(formula) <- environment()
   tryCatch({
     if (family$family == "gaussian" && family$link == "identity") {
       # Exclude arguments from `...` which cannot be passed to stats::lm():


### PR DESCRIPTION
This re-introduces `fit_glm_callback()` as an alternative to `fit_glm_ridge_callback()`, but this time with an option for using it. This option is not documented yet, so currently, this is kind of an "internal" feature. I wanted to wait for some experience in using it before documenting this and thereby making this a "public" feature. Unit tests would also have to be added/adapted.

In the future, I think it could make sense to make `fit_glm_callback()` the default GLM submodel fitter and only use `fit_glm_ridge_callback()` when requested explicitly by the user (i.e., when `regul > 0`) or when necessary for other reasons (I guess the `Student_t()` family requires `fit_glm_ridge_callback()`). The reason is that in some preliminary tests, I discovered that `fit_glm_callback()` is faster than `fit_glm_ridge_callback()`.