### PR TITLE
Convergence checker

### DIFF
--- a/R/extend_family.R
+++ b/R/extend_family.R
@@ -64,10 +64,25 @@ extend_family_binomial <- function(family) {
       }
       n <- rep.int(1, nobs)
       y[weights == 0] <- 0
+      if (any(y < 0 | y > 1)) {
+        stop("y values must be 0 <= y <= 1")
+      }
       mustart <- (weights * y + 0.5) / (weights + 1)
       m <- weights * y
+      if ("binomial" == "binomial" && any(abs(m - round(m)) >
+                                          0.001)) {
+        ### Deactivated because in general, this will be the case in 'projpred':
+        # warning(gettextf("non-integer #successes in a %s glm!",
+        #                  "binomial"), domain = NA)
+        ###
+      }
     }
     else if (NCOL(y) == 2) {
+      if ("binomial" == "binomial" && any(abs(y - round(y)) >
+                                          0.001)) {
+        warning(gettextf("non-integer counts in a %s glm!",
+                         "binomial"), domain = NA)
+      }
       n <- (y1 <- y[, 1L]) + y[, 2L]
       y <- y1 / n
       if (any(n0 <- n == 0)) {
@@ -75,6 +90,11 @@ extend_family_binomial <- function(family) {
       }
       weights <- weights * n
       mustart <- (n * y + 0.5) / (n + 1)
+    } else {
+      stop(gettextf(paste("for the '%s' family, y must be a vector of 0 and",
+                          "1's\nor a 2 column matrix where col 1 is no.",
+                          "successes and col 2 is no. failures"),
+                    "binomial"), domain = NA)
     }
   })
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -1076,7 +1076,7 @@ as.matrix.projection <- function(x, ...) {
   if (!all(sapply(x$sub_fit, inherits, what = get_as.matrix_cls_projpred()))) {
     # Throw an error because in this case, we probably need a new
     # as.matrix.<class_name>() method.
-    stop("This case should not occur. Please notify the package maintainer.")
+    stop("Unrecognized submodel fit. Please notify the package maintainer.")
   }
   res <- t(do.call(cbind, lapply(x$sub_fit, as.matrix)))
   if (x$family$family == "gaussian") res <- cbind(res, sigma = x$dis)

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -22,6 +22,8 @@ project_submodel <- function(solution_terms, p_ref, refmodel, family, intercept,
     projpred_regul = regul
   )
 
+  check_conv(sub_fit)
+
   return(.init_submodel(
     sub_fit = sub_fit, p_ref = p_ref, refmodel = refmodel,
     family = family, solution_terms = solution_terms, wobs = wobs,

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -22,7 +22,9 @@ project_submodel <- function(solution_terms, p_ref, refmodel, family, intercept,
     projpred_regul = regul
   )
 
-  check_conv(sub_fit)
+  if (isTRUE(getOption("projpred.check_conv", FALSE))) {
+    check_conv(sub_fit)
+  }
 
   return(.init_submodel(
     sub_fit = sub_fit, p_ref = p_ref, refmodel = refmodel,


### PR DESCRIPTION
This starts a function called `check_conv()` which checks the convergence of the submodel fitters. The idea behind this is that all those `suppressMessages()` and `suppressWarnings()` calls in the submodel fitters can hide important convergence issues to the user. On the other hand, the `suppressMessages()` and `suppressWarnings()` calls are needed to avoid flooding the user with one warning (or message) per projected draw. So such a convergence checker which is run after completion of the projection and which tries to aggregate the warnings from all projected draws could be a compromise between not throwing any warnings at all and throwing one warning per projected draw.

That convergence checker differentiates between a "gross" fail of convergence and rather mild warnings. I'm not sure if this differentiation indeed makes sense for all types of submodels. For multilevel models, it does (in my opinion), see the source code of `check_conv()`.

I'm currently lacking the time to finish this for all submodel types, but I thought it might not harm to add the current state of `check_conv()` as an internal feature which can be continued in the future. (It's internal because it needs to be turned on explicitly via the global option `projpred.check_conv` which is not documented yet.)