### PR TITLE
Catch missing values

### DIFF
--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -611,6 +611,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   # Formula -----------------------------------------------------------------
 
   stopifnot(inherits(formula, "formula"))
+  data <- na.fail(data)
   formula <- expand_formula(formula, data)
   response_name <- extract_terms_response(formula)$response
   if (length(response_name) == 2) {


### PR DESCRIPTION
This fixes the second issue described at <https://discourse.mc-stan.org/t/error-in-get-refmodel-and-cv-varsel/26224>.

Now, missing values in the reference model's dataset are catched early in `init_refmodel()`. This also ensures that an appropriate error message is thrown. Previously (tested with the current CRAN version 2.0.2), the reference model was created successfully, but this caused opaque errors in downstream code such as `project()`.