### PR TITLE
Enhancements in the unit tests

### DIFF
--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -624,7 +624,8 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   # Remove parentheses from the response:
   response_name <- gsub("[()]", "", response_name)
   formula <- update(formula, paste(response_name[1], "~ ."))
-  if (formula_contains_additive_terms(formula)) {
+  if (formula_contains_additive_terms(formula) &&
+      isTRUE(getOption("projpred.warn_additive_experimental", TRUE))) {
     warning("Support for additive models is still experimental.")
   }
 

--- a/tests/testthat/helpers/args.R
+++ b/tests/testthat/helpers/args.R
@@ -1,5 +1,5 @@
 # A helper function for picking only those elements from an argument list which
-# are not arguments in the narrower sense
+# are not arguments in the narrower sense.
 #
 # @param args_i A list of arguments.
 #
@@ -14,7 +14,7 @@ only_nonargs <- function(args_i) {
 }
 
 # A helper function for excluding elements from an argument list which are not
-# arguments in the narrower sense
+# arguments in the narrower sense.
 #
 # @param args_i A list of arguments.
 # @param nms_excl_add A character vector of element names which should also be
@@ -32,7 +32,7 @@ excl_nonargs <- function(args_i, nms_excl_add = character()) {
 }
 
 # A helper function for retrieving details about the actually used `ndraws` or
-# `nclusters` argument as well as about associated objects
+# `nclusters` argument as well as about associated objects.
 #
 # @param args_i A list of arguments supplied to a function with arguments
 #   `ndraws` and `nclusters` (project(), varsel(), etc.).

--- a/tests/testthat/helpers/formul_handlers.R
+++ b/tests/testthat/helpers/formul_handlers.R
@@ -1,6 +1,6 @@
 # A function to remove the "cbind" part from the response in a formula (in fact,
 # only relevant for formulas from "stanreg" fits with a binomial family
-# with > 1 trials, but doesn't harm to apply it on other formulas as well):
+# with > 1 trials, but it doesn't harm to apply it to other formulas as well):
 rm_cbind <- function(formul) {
   formul_chr <- as.character(formul)
   stopifnot(length(formul_chr) == 3)
@@ -11,7 +11,7 @@ rm_cbind <- function(formul) {
 }
 
 # A function to remove additional response information from a formula (in fact,
-# only relevant for formulas from "brmsfit"s, but doesn't harm to apply it on
+# only relevant for formulas from "brmsfit"s, but it doesn't harm to apply it to
 # other formulas as well):
 rm_addresp <- function(formul) {
   formul_chr <- as.character(formul)

--- a/tests/testthat/helpers/getters.R
+++ b/tests/testthat/helpers/getters.R
@@ -1,3 +1,4 @@
+# A function to retrieve the formula from a fit (`fit_obj`):
 get_formul_from_fit <- function(fit_obj) {
   formul_out <- formula(fit_obj)
   if (inherits(fit_obj, "brmsfit")) {
@@ -6,6 +7,8 @@ get_formul_from_fit <- function(fit_obj) {
   return(formul_out)
 }
 
+# A function to adapt a given dataset (`dat`) appropriately to a given formula
+# (`formul_crr`):
 get_dat_formul <- function(formul_crr, needs_adj, dat_crr = dat) {
   if (needs_adj) {
     formul_crr <- rm_cbind(formul_crr)
@@ -17,14 +20,15 @@ get_dat_formul <- function(formul_crr, needs_adj, dat_crr = dat) {
   return(dat_crr)
 }
 
+# A function to adapt a given dataset (`dat`) appropriately to a given "test
+# setup" (`tstsetup`):
 get_dat <- function(tstsetup, dat_crr = dat) {
   get_dat_formul(args_fit[[args_prj[[tstsetup]]$tstsetup_fit]]$formula,
                  needs_adj = grepl("\\.spclformul", tstsetup),
                  dat_crr = dat_crr)
 }
 
-# A function to get the possible length of the vector supplied to argument
-# `penalty`:
+# A function to get the elements which may be supplied to argument `penalty`:
 get_penal_possbl <- function(formul_crr) {
   trms_crr <- labels(terms(formul_crr))
   if (length(trms_crr) > 0 && any(grepl("xca\\.", trms_crr))) {

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -23,11 +23,11 @@ extfam_tester <- function(extfam,
   # Some minimal checks for `fam_orig`:
   expect_s3_class(fam_orig, "family")
   expect_type(fam_orig, "list")
-  fam_orig_nms <- fam_orig_nms_common <- c(
+  fam_orig_nms <- c(
     "family", "link", "linkfun", "linkinv", "variance", "dev.resids", "aic",
     "mu.eta", "initialize", "validmu", "valideta"
   )
-  expect_true(all(fam_orig_nms_common %in% names(fam_orig)), info = info_str)
+  expect_true("family" %in% names(fam_orig), info = info_str)
   if (fam_orig$family %in% c("binomial", "poisson")) {
     fam_orig_nms <- c(fam_orig_nms, "simulate")
   }

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -1,5 +1,5 @@
 # A helper function for testing the structure of an expected extended `"family"`
-# object
+# object.
 #
 # @param extfam An object of class `"family"` (at least expected so) which has
 #   been extended by projpred.
@@ -64,7 +64,8 @@ extfam_tester <- function(extfam,
   return(invisible(TRUE))
 }
 
-# A helper function for testing the structure of an expected `"refmodel"` object
+# A helper function for testing the structure of an expected `"refmodel"`
+# object.
 #
 # @param refmod An object of class `"refmodel"` (at least expected so).
 # @param is_datafit A single logical value indicating whether the reference
@@ -412,7 +413,7 @@ refmodel_tester <- function(
 }
 
 # A helper function for testing the structure of a list of fits (each fit must
-# not necessarily be of class `"subfit"`) for the same single submodel
+# not necessarily be of class `"subfit"`) for the same single submodel.
 #
 # @param submodl_totest The `submodl` object (a list of fits for a single
 #   submodel, with one fit per projected draw) to test.
@@ -755,7 +756,7 @@ submodl_tester <- function(
 }
 
 # A helper function for testing the structure of an expected `"projection"`
-# object
+# object.
 #
 # @param p An object of class `"projection"` (at least expected so).
 # @param solterms_expected Either a single numeric value giving the expected
@@ -895,7 +896,7 @@ projection_tester <- function(p,
 }
 
 # A helper function for testing the structure of an expected `"proj_list"`
-# object
+# object.
 #
 # @param p An object of (informal) class `"proj_list"` (at least expected so).
 # @param len_expected The expected length of `p`.
@@ -1027,7 +1028,7 @@ pp_tester <- function(pp,
   return(invisible(TRUE))
 }
 
-# A helper function for testing the structure of an expected `"vsel"` object
+# A helper function for testing the structure of an expected `"vsel"` object.
 #
 # @param vs An object of class `"vsel"` (at least expected so).
 # @param with_cv A single logical value indicating whether `vs` was created by
@@ -1365,7 +1366,7 @@ vsel_tester <- function(
 }
 
 # A helper function for testing the structure of an object as returned by
-# summary.vsel()
+# summary.vsel().
 #
 # @param smmry An object as returned by summary.vsel().
 # @param vsel_expected The `"vsel"` object which was used in the summary.vsel()
@@ -1434,7 +1435,7 @@ smmry_tester <- function(smmry, vsel_expected, nterms_max_expected = NULL,
 }
 
 # A helper function for testing the structure of a `data.frame` as returned by
-# summary.vsel() in its output element `selection`
+# summary.vsel() in its output element `selection`.
 #
 # @param smmry_sel A `data.frame` as returned by summary.vsel() in its output
 #   element `selection`.

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -20,7 +20,10 @@ extfam_tester <- function(extfam,
                           extfam_nms_add2 = character(),
                           from_brms = FALSE,
                           info_str) {
-  # Some minimal checks for `fam_orig`:
+  # General structure tests -------------------------------------------------
+
+  ## For `fam_orig` ---------------------------------------------------------
+
   expect_s3_class(fam_orig, "family")
   expect_type(fam_orig, "list")
   fam_orig_nms <- c(
@@ -33,13 +36,18 @@ extfam_tester <- function(extfam,
   }
   expect_named(fam_orig, fam_orig_nms, info = info_str)
 
-  # Now the checks for `extfam` (first starting with the general structure):
+  ## For `extfam` -----------------------------------------------------------
+
   extfam_nms_add <- c("kl", "dis_fun", "predvar", "ll_fun", "deviance", "ppd",
                       "is_extended", extfam_nms_add2)
   extfam_nms <- c(names(fam_orig), extfam_nms_add)
   expect_s3_class(extfam, "family")
   expect_type(extfam, "list")
   expect_named(extfam, extfam_nms, info = info_str)
+
+  # Detailed tests ----------------------------------------------------------
+
+  ## For `fam_orig` ---------------------------------------------------------
 
   fam_orig_ch <- structure(extfam[names(fam_orig)], class = "family")
   if (extfam$family == "binomial") {
@@ -52,10 +60,11 @@ extfam_tester <- function(extfam,
                      info = info_str)
   }
 
+  ## For `extfam` -----------------------------------------------------------
+
   for (el_nm in setdiff(extfam_nms_add, "is_extended")) {
     expect_type(extfam[[el_nm]], "closure")
   }
-
   expect_true(extfam$is_extended, info = info_str)
 
   # TODO: Add some mathematical checks (i.e., check that the calculations for

--- a/tests/testthat/helpers/unlist_cust.R
+++ b/tests/testthat/helpers/unlist_cust.R
@@ -1,4 +1,4 @@
-# A custom unlist() wrapper
+# A custom unlist() wrapper.
 #
 # @param x A list, at a deeper level containing an unnamed sublist or a named
 #   sublist containing the name given in `nm_stop`.
@@ -8,7 +8,6 @@
 # @return The recursively "unlisted" `x` (recursively up to the point where the
 #   next sublist is unnamed or contains an element with name given in
 #   `nm_stop`).
-#
 unlist_cust <- function(x, nm_stop = "mod_nm") {
   stopifnot(is.list(x) && length(x) > 0)
   if (is.null(names(x[[1]])) || nm_stop %in% names(x[[1]])) {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -826,6 +826,8 @@ args_prj <- lapply(tstsetups_prj_ref, function(tstsetup_ref) {
       )) ||
       (!run_more && mod_crr %in% c("glmm", "gam", "gamm"))
     ) {
+      # The `noclust` setting is important for the test "non-clustered
+      # projection does not require a seed" in `test_project.R`.
       ndr_ncl_pred <- ndr_ncl_pred_tst[c("noclust", "clust")]
     } else {
       ndr_ncl_pred <- ndr_ncl_pred_tst[c("clust")]

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -115,9 +115,9 @@ source(testthat::test_path("helpers", "getters.R"), local = TRUE)
 source(testthat::test_path("helpers", "formul_handlers.R"), local = TRUE)
 
 mod_nms <- setNames(nm = c("glm", "glmm", "gam", "gamm"))
-### Exclude additive models (GAMs and GAMMs) for now since their implementation
-### is currently only experimental:
-mod_nms <- setNames(nm = setdiff(mod_nms, c("gam", "gamm")))
+### Suppress the warning for additive models (GAMs and GAMMs) stating that their
+### implementation is currently only experimental:
+options(projpred.warn_additive_experimental = FALSE)
 ###
 
 fam_nms <- setNames(nm = c("gauss", "brnll", "binom", "poiss"))

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -39,9 +39,15 @@ run_brms <- identical(Sys.getenv("NOT_CRAN"), "true")
 #   least as long as they are listed in the `.Rbuildignore` file), so they would
 #   be re-created, which would throw a lot of test warnings (which could obscure
 #   potentially important warnings).
-run_snaps <- identical(Sys.getenv("NOT_CRAN"), "true") &&
-  !identical(toupper(Sys.getenv("CI")), "TRUE") &&
-  identical(Sys.getenv("_R_CHECK_FORCE_SUGGESTS_"), "")
+run_snaps <- Sys.getenv("RUN_SNAPS")
+if (identical(run_snaps, "")) {
+  run_snaps <- identical(Sys.getenv("NOT_CRAN"), "true") &&
+    !identical(toupper(Sys.getenv("CI")), "TRUE") &&
+    identical(Sys.getenv("_R_CHECK_FORCE_SUGGESTS_"), "")
+} else {
+  run_snaps <- as.logical(toupper(run_snaps))
+  stopifnot(isTRUE(run_snaps) || isFALSE(run_snaps))
+}
 if (run_snaps) {
   testthat_ed_max2 <- edition_get() <= 2
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -698,14 +698,7 @@ if (run_cvvs) {
   args_cvvs <- lapply(tstsetups_cvvs_ref, function(tstsetup_ref) {
     mod_crr <- args_ref[[tstsetup_ref]]$mod_nm
     fam_crr <- args_ref[[tstsetup_ref]]$fam_nm
-    if (mod_crr == "glm" && fam_crr == "gauss" &&
-        !grepl("\\.spclformul", tstsetup_ref)) {
-      # Here, we test the default `method` (which is L1 search here) as well
-      # as forward search:
-      meth <- meth_tst[c("default_meth", "forward")]
-    } else {
-      meth <- meth_tst["default_meth"]
-    }
+    meth <- meth_tst["default_meth"]
     if (grepl("\\.without_wobs", tstsetup_ref)) {
       if (mod_crr == "gamm" && fam_crr == "brnll") {
         # In this case, K-fold CV leads to an error in pwrssUpdate()

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -435,7 +435,11 @@ args_fit <- lapply(pkg_nms, function(pkg_nm) {
     if (mod_nm != "glm") {
       if (pkg_nm == "brms") {
         # For speed reasons, do not test all families:
-        fam_nms <- intersect(fam_nms, "binom")
+        if (mod_nm == "glmm") {
+          fam_nms <- intersect(fam_nms, "brnll")
+        } else {
+          fam_nms <- intersect(fam_nms, "binom")
+        }
       }
       # Because of issue #207:
       fam_nms <- setdiff(fam_nms, "poiss")
@@ -583,7 +587,7 @@ if (!run_more) {
     "rstanarm.gam.gauss.spclformul.with_wobs.without_offs",
     "rstanarm.gamm.brnll.stdformul.without_wobs.without_offs",
     "brms.glm.poiss.stdformul.with_wobs.with_offs",
-    "brms.glmm.binom.stdformul.without_wobs.with_offs",
+    "brms.glmm.brnll.stdformul.without_wobs.without_offs",
     # "brms.gam.binom.stdformul.without_wobs.with_offs",
     "brms.gamm.binom.stdformul.without_wobs.with_offs"
   )

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -494,12 +494,6 @@ args_fit <- lapply(pkg_nms, function(pkg_nm) {
           # the cbind() syntax (indirectly, because the number of trials is the
           # sum of the two columns)):
           wobss_nms <- "without_wobs"
-        } else if (pkg_nm == "rstanarm" && mod_nm == "glm" &&
-                   fam_nm == "gauss" && formul_nm != "spclformul") {
-          # Here, rstanarm:::kfold.stanreg() is applied, so we also need the
-          # model without observation weights (because
-          # rstanarm:::kfold.stanreg() doesn't support observation weights):
-          wobss_nms <- c("with_wobs", "without_wobs")
         } else {
           wobss_nms <- "with_wobs"
         }
@@ -650,11 +644,7 @@ refmods <- lapply(args_ref, function(args_ref_i) {
 ### varsel() --------------------------------------------------------------
 
 if (run_vs) {
-  # Exclude the case which was added for K-fold CV only:
-  tstsetups_vs_ref <- setNames(
-    nm = grep("\\.gauss\\..*\\.without_wobs", names(refmods), value = TRUE,
-              invert = TRUE)
-  )
+  tstsetups_vs_ref <- setNames(nm = names(refmods))
   args_vs <- lapply(tstsetups_vs_ref, function(tstsetup_ref) {
     mod_crr <- args_ref[[tstsetup_ref]]$mod_nm
     fam_crr <- args_ref[[tstsetup_ref]]$fam_nm
@@ -697,6 +687,9 @@ if (run_cvvs) {
     fam_crr <- args_ref[[tstsetup_ref]]$fam_nm
     meth <- meth_tst["default_meth"]
     if (grepl("\\.without_wobs", tstsetup_ref)) {
+      # In principle, we want to use K-fold CV here and LOO CV else because
+      # rstanarm:::kfold.stanreg() doesn't support observation weights. However,
+      # there are some special cases to take care of:
       if (mod_crr == "gamm" && fam_crr == "brnll") {
         # In this case, K-fold CV leads to an error in pwrssUpdate()
         # ("(maxstephalfit) PIRLS step-halvings failed to reduce deviance in
@@ -752,11 +745,7 @@ if (run_cvvs) {
 
 ### From "refmodel" -------------------------------------------------------
 
-# Exclude the case which was added for K-fold CV only:
-tstsetups_prj_ref <- setNames(
-  nm = grep("\\.glm\\.gauss\\.stdformul\\.without_wobs", names(refmods),
-            value = TRUE, invert = TRUE)
-)
+tstsetups_prj_ref <- setNames(nm = names(refmods))
 args_prj <- lapply(tstsetups_prj_ref, function(tstsetup_ref) {
   pkg_crr <- args_ref[[tstsetup_ref]]$pkg_nm
   mod_crr <- args_ref[[tstsetup_ref]]$mod_nm

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -203,8 +203,8 @@ nterms_z <- length(nlvl_ran) * 2L
 z_list <- lapply(nlvl_ran, function(nlvl_ran_i) {
   z <- gl(n = nlvl_ran_i, k = floor(nobsv / nlvl_ran_i), length = nobsv,
           labels = paste0("lvl", seq_len(nlvl_ran_i)))
-  r_icpts <- rnorm(nlvl_ran_i, sd = 0.8)
-  r_xco1 <- rnorm(nlvl_ran_i, sd = 0.8)
+  r_icpts <- rnorm(nlvl_ran_i, sd = 2.8)
+  r_xco1 <- rnorm(nlvl_ran_i, sd = 2.8)
   eta_z <- r_icpts[z] + r_xco1[z] * x_cont[, 1]
   return(nlist(z, eta_z, r_icpts, r_xco1))
 })

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -815,12 +815,17 @@ args_prj <- lapply(tstsetups_prj_ref, function(tstsetup_ref) {
     } else if (pkg_crr == "rstanarm" && mod_crr == "glm" &&
                fam_crr == "gauss" && solterms_nm_i == "empty") {
       ndr_ncl_pred <- ndr_ncl_pred_tst[c("noclust", "clust", "clust1")]
-    } else if ((pkg_crr == "rstanarm" && mod_crr == "glmm" &&
-                fam_crr == "brnll" && solterms_nm_i == "solterms_xz") ||
-               (pkg_crr == "rstanarm" && mod_crr == "gam" &&
-                fam_crr == "binom" && solterms_nm_i == "solterms_xs") ||
-               (pkg_crr == "rstanarm" && mod_crr == "gamm" &&
-                fam_crr == "brnll" && solterms_nm_i == "solterms_xsz")) {
+    } else if (
+      (run_more && (
+        (pkg_crr == "rstanarm" && mod_crr == "glmm" &&
+         fam_crr == "brnll" && solterms_nm_i == "solterms_xz") ||
+        (pkg_crr == "rstanarm" && mod_crr == "gam" &&
+         fam_crr == "binom" && solterms_nm_i == "solterms_xs") ||
+        (pkg_crr == "rstanarm" && mod_crr == "gamm" &&
+         fam_crr == "brnll" && solterms_nm_i == "solterms_xsz")
+      )) ||
+      (!run_more && mod_crr %in% c("glmm", "gam", "gamm"))
+    ) {
       ndr_ncl_pred <- ndr_ncl_pred_tst[c("noclust", "clust")]
     } else {
       ndr_ncl_pred <- ndr_ncl_pred_tst[c("clust")]

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -698,35 +698,26 @@ if (run_cvvs) {
   args_cvvs <- lapply(tstsetups_cvvs_ref, function(tstsetup_ref) {
     mod_crr <- args_ref[[tstsetup_ref]]$mod_nm
     fam_crr <- args_ref[[tstsetup_ref]]$fam_nm
-    if (mod_crr == "glm" && fam_crr == "gauss") {
-      if (!grepl("\\.spclformul", tstsetup_ref)) {
-        # Here, we test the default `method` (which is L1 search here) as well
-        # as forward search:
-        meth <- meth_tst[c("default_meth", "forward")]
-      } else {
-        meth <- meth_tst["default_meth"]
-      }
-      if (grepl("\\.without_wobs", tstsetup_ref)) {
-        # Here, we only test the "kfold" `cv_method`:
-        cvmeth <- cvmeth_tst["kfold"]
-      } else {
-        # Here, we only test the default `cv_method` (which is LOO CV):
-        cvmeth <- cvmeth_tst["default_cvmeth"]
-      }
+    if (mod_crr == "glm" && fam_crr == "gauss" &&
+        !grepl("\\.spclformul", tstsetup_ref)) {
+      # Here, we test the default `method` (which is L1 search here) as well
+      # as forward search:
+      meth <- meth_tst[c("default_meth", "forward")]
     } else {
       meth <- meth_tst["default_meth"]
-      if (grepl("\\.without_wobs", tstsetup_ref)) {
-        cvmeth <- cvmeth_tst["kfold"]
-        if (mod_crr == "gamm" && fam_crr == "brnll") {
-          # In this case, K-fold CV leads to an error in pwrssUpdate()
-          # ("(maxstephalfit) PIRLS step-halvings failed to reduce deviance in
-          # pwrssUpdate"). Therefore, use LOO CV:
-          cvmeth <- cvmeth_tst["default_cvmeth"]
-          # TODO (GAMMs): Fix this.
-        }
-      } else {
+    }
+    if (grepl("\\.without_wobs", tstsetup_ref)) {
+      if (mod_crr == "gamm" && fam_crr == "brnll") {
+        # In this case, K-fold CV leads to an error in pwrssUpdate()
+        # ("(maxstephalfit) PIRLS step-halvings failed to reduce deviance in
+        # pwrssUpdate"). Therefore, use LOO CV:
         cvmeth <- cvmeth_tst["default_cvmeth"]
+        # TODO (GAMMs): Fix this.
+      } else {
+        cvmeth <- cvmeth_tst["kfold"]
       }
+    } else {
+      cvmeth <- cvmeth_tst["default_cvmeth"]
     }
     lapply(meth, function(meth_i) {
       lapply(cvmeth, function(cvmeth_i) {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -401,12 +401,8 @@ for (obj_symb_chr in c(paste0("f_", fam_nms))) {
 }
 
 args_fit <- lapply(pkg_nms, function(pkg_nm) {
-  if (pkg_nm == "brms" && packageVersion("brms") <= "2.16.3") {
-    # For brms versions <= 2.16.3, there is a reproducibility issue in
-    # kfold.brmsfit(), so exclude model types for which K-fold CV could be run:
-    mod_nms <- intersect(mod_nms, "glm")
-  }
-
+  # Depending on the package used for fitting the reference model, `mod_nms`
+  # could be restricted here.
   mod_nms <- setNames(nm = mod_nms)
   lapply(mod_nms, function(mod_nm) {
     if (pkg_nm == "rstanarm") {
@@ -696,6 +692,7 @@ if (run_vs) {
 if (run_cvvs) {
   tstsetups_cvvs_ref <- setNames(nm = names(refmods))
   args_cvvs <- lapply(tstsetups_cvvs_ref, function(tstsetup_ref) {
+    pkg_crr <- args_ref[[tstsetup_ref]]$pkg_nm
     mod_crr <- args_ref[[tstsetup_ref]]$mod_nm
     fam_crr <- args_ref[[tstsetup_ref]]$fam_nm
     meth <- meth_tst["default_meth"]
@@ -706,6 +703,11 @@ if (run_cvvs) {
         # pwrssUpdate"). Therefore, use LOO CV:
         cvmeth <- cvmeth_tst["default_cvmeth"]
         # TODO (GAMMs): Fix this.
+      } else if (pkg_crr == "brms" && packageVersion("brms") <= "2.16.3") {
+        # For brms versions <= 2.16.3, there is a reproducibility issue when
+        # using K-fold CV in conjunction with a `brmsfit` reference model fit,
+        # so use LOO CV:
+        cvmeth <- cvmeth_tst["default_cvmeth"]
       } else {
         cvmeth <- cvmeth_tst["kfold"]
       }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -109,6 +109,10 @@ if (run_prll) {
     }
   }
 }
+# Run all test scripts (following this setup script) in a completely random RNG
+# state? (The tests should still pass then, because in all situations where RNG
+# is used, a specific seed is supposed to be set.):
+run_randRNG <- identical(Sys.getenv("NOT_CRAN"), "true")
 # Run tests for additive models (GAMs and GAMMs)?:
 run_additive <- TRUE
 
@@ -1100,3 +1104,9 @@ ndraws_default <- 20L # Adapt this if the default is changed.
 ndraws_pred_default <- 400L # Adapt this if the default is changed.
 nresample_clusters_default <- 1000L # Adapt this if the default is changed.
 regul_default <- 1e-4 # Adapt this if the default is changed.
+
+# Seed --------------------------------------------------------------------
+
+if (run_randRNG) {
+  set.seed(NULL)
+}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -812,7 +812,7 @@ args_prj <- lapply(tstsetups_prj_ref, function(tstsetup_ref) {
                     nlist(solterms_sz = c(solterms_s, solterms_z),
                           solterms_xsz = c(solterms_x, solterms_s, solterms_z)))
     }
-    if (fam_crr != "gauss") {
+    if (!run_more && fam_crr != "gauss") {
       solterms <- tail(solterms, 1)
     }
   } else {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -715,7 +715,7 @@ if (run_cvvs) {
       }
     } else {
       meth <- meth_tst["default_meth"]
-      if (mod_crr != "glm" && grepl("\\.without_wobs", tstsetup_ref)) {
+      if (grepl("\\.without_wobs", tstsetup_ref)) {
         cvmeth <- cvmeth_tst["kfold"]
         if (mod_crr == "gamm" && fam_crr == "brnll") {
           # In this case, K-fold CV leads to an error in pwrssUpdate()

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -852,8 +852,6 @@ prjs <- lapply(args_prj, function(args_prj_i) {
 
 ### From "vsel" -----------------------------------------------------------
 
-#### varsel() -------------------------------------------------------------
-
 # A helper function to create the argument list for project() for a given
 # character vector of test setups (referring to either `vss` or `cvvss`):
 cre_args_prj_vsel <- function(tstsetups_prj_vsel) {
@@ -879,6 +877,8 @@ cre_args_prj_vsel <- function(tstsetups_prj_vsel) {
     })
   })
 }
+
+#### varsel() -------------------------------------------------------------
 
 if (run_vs) {
   tstsetups_prj_vs <- setNames(
@@ -976,8 +976,6 @@ if (run_cvvs) {
 
 ## summary.vsel() ---------------------------------------------------------
 
-### varsel() --------------------------------------------------------------
-
 cre_args_smmry_vsel <- function(tstsetups_smmry_vsel) {
   vsel_type <- deparse(substitute(tstsetups_smmry_vsel))
   args_obj <- switch(vsel_type,
@@ -1014,6 +1012,8 @@ cre_args_smmry_vsel <- function(tstsetups_smmry_vsel) {
     })
   })
 }
+
+### varsel() --------------------------------------------------------------
 
 if (run_vs) {
   tstsetups_smmry_vs <- setNames(nm = unlist(lapply(mod_nms, function(mod_nm) {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -107,6 +107,8 @@ if (run_prll) {
     }
   }
 }
+# Run tests for additive models (GAMs and GAMMs)?:
+run_additive <- TRUE
 
 source(testthat::test_path("helpers", "unlist_cust.R"), local = TRUE)
 source(testthat::test_path("helpers", "testers.R"), local = TRUE)
@@ -115,10 +117,13 @@ source(testthat::test_path("helpers", "getters.R"), local = TRUE)
 source(testthat::test_path("helpers", "formul_handlers.R"), local = TRUE)
 
 mod_nms <- setNames(nm = c("glm", "glmm", "gam", "gamm"))
-### Suppress the warning for additive models (GAMs and GAMMs) stating that their
-### implementation is currently only experimental:
-options(projpred.warn_additive_experimental = FALSE)
-###
+if (run_additive) {
+  # Suppress the warning for additive models (GAMs and GAMMs) stating that their
+  # implementation is currently only experimental:
+  options(projpred.warn_additive_experimental = FALSE)
+} else {
+  mod_nms <- setNames(nm = setdiff(mod_nms, c("gam", "gamm")))
+}
 
 fam_nms <- setNames(nm = c("gauss", "brnll", "binom", "poiss"))
 

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -157,6 +157,7 @@ if (run_snaps) {
   test_that(paste(
     "as.matrix.projection() works for projections based on varsel() output"
   ), {
+    skip_if_not(run_vs)
     for (tstsetup in names(prjs_vs)) {
       if (args_prj_vs[[tstsetup]]$mod_nm == "gam") {
         # Skipping GAMs because of issue #150 and issue #151. Note that for
@@ -202,6 +203,7 @@ if (run_snaps) {
   test_that(paste(
     "as.matrix.projection() works for projections based on cv_varsel() output"
   ), {
+    skip_if_not(run_cvvs)
     for (tstsetup in names(prjs_cvvs)) {
       if (args_prj_cvvs[[tstsetup]]$mod_nm == "gam") {
         # Skipping GAMs because of issue #150 and issue #151. Note that for

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -41,13 +41,11 @@ if (!requireNamespace("glmnet", quietly = TRUE)) {
 ## Reference model --------------------------------------------------------
 ## (actually "datafit"s)
 
-# Exclude the rstanarm case which was added for K-fold CV only and also exclude
-# brms fits (since `datafit`s don't make use of a reference model fit, it
-# doesn't make a difference if rstanarm or brms is used as the basis here for
+# Exclude brms fits (since `datafit`s don't make use of a reference model fit,
+# it doesn't make a difference if rstanarm or brms is used as the basis here for
 # retrieving the formula, data, and family):
 args_datafit <- lapply(setNames(
-  nm = grep("^brms\\.|\\.glm\\.gauss\\.stdformul\\.without_wobs", names(fits),
-            value = TRUE, invert = TRUE)
+  nm = grep("^brms\\.", names(fits), value = TRUE, invert = TRUE)
 ), function(tstsetup_fit) {
   c(nlist(tstsetup_fit), only_nonargs(args_fit[[tstsetup_fit]]))
 })

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -594,6 +594,9 @@ test_that(paste(
   "L1-projection with data reference gives the same results as",
   "Lasso from glmnet."
 ), {
+  if (exists(".Random.seed", envir = .GlobalEnv)) {
+    rng_old <- get(".Random.seed", envir = .GlobalEnv)
+  }
   suppressWarnings(RNGversion("3.5.0"))
   set.seed(1235)
   n <- 100
@@ -747,4 +750,5 @@ test_that(paste(
     }
   }
   RNGversion(paste(R.Version()$major, R.Version()$minor, sep = "."))
+  if (exists("rng_old")) assign(".Random.seed", rng_old, envir = .GlobalEnv)
 })

--- a/tests/testthat/test_div_minimizer.R
+++ b/tests/testthat/test_div_minimizer.R
@@ -1,7 +1,6 @@
 context("div_minimizer")
 
-test_that("all div_minimizer()s work", {
-  divmin_fun <- "divmin"
+test_that("`divmin` works", {
   for (tstsetup in names(fits)) {
     args_fit_i <- args_fit[[tstsetup]]
     pkg_crr <- args_fit_i$pkg_nm
@@ -51,7 +50,7 @@ test_that("all div_minimizer()s work", {
     }
 
     divmin_res <- do.call(
-      divmin_fun,
+      divmin,
       args_fit_i[intersect(c("formula", "data", "family", "weights",
                              "projpred_var", "projpred_regul"),
                            names(args_fit_i))]

--- a/tests/testthat/test_glm_elnet.R
+++ b/tests/testthat/test_glm_elnet.R
@@ -11,6 +11,9 @@ if (!requireNamespace("glmnet", quietly = TRUE)) {
 # Needed to clean up the workspace afterwards (i.e, after this test file):
 ls_bu <- ls()
 
+if (exists(".Random.seed", envir = .GlobalEnv)) {
+  rng_old <- get(".Random.seed", envir = .GlobalEnv)
+}
 set.seed(1235)
 n <- 40
 nterms <- 10
@@ -212,5 +215,6 @@ test_that("glm_elnet with alpha=0 and glm_ridge give the same result.", {
   }
 })
 
+if (exists("rng_old")) assign(".Random.seed", rng_old, envir = .GlobalEnv)
 # Clean up the workspace:
 rm(list = setdiff(ls(), ls_bu))

--- a/tests/testthat/test_glm_ridge.R
+++ b/tests/testthat/test_glm_ridge.R
@@ -10,6 +10,9 @@ context("ridge")
 # Needed to clean up the workspace afterwards (i.e, after this test file):
 ls_bu <- ls()
 
+if (exists(".Random.seed", envir = .GlobalEnv)) {
+  rng_old <- get(".Random.seed", envir = .GlobalEnv)
+}
 set.seed(1235)
 n <- 40
 nterms <- 10
@@ -269,5 +272,6 @@ test_that("glm_ridge: poisson, log-link, no intercept, lambda = 0", {
 #                tolerance = tol)
 # })
 
+if (exists("rng_old")) assign(".Random.seed", rng_old, envir = .GlobalEnv)
 # Clean up the workspace:
 rm(list = setdiff(ls(), ls_bu))

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -54,16 +54,18 @@ test_that("rstanarm: special formulas work", {
 
     tstsetup_stdformul <- sub("\\.spclformul", ".stdformul", tstsetup)
     stopifnot(tstsetup_stdformul != tstsetup)
-    stopifnot(tstsetup_stdformul %in% names(fits))
-    mf_stdformul <- fits[[tstsetup_stdformul]]$model
-    nms_stdformul <- setdiff(
-      grep("y_|xco", names(mf_stdformul), value = TRUE),
-      "xco.1"
-    )
-
-    expect_equal(mf_spclformul[, setdiff(names(mf_spclformul), nms_spclformul)],
-                 mf_stdformul[, setdiff(names(mf_stdformul), nms_stdformul)],
-                 info = tstsetup)
+    if (tstsetup_stdformul %in% names(fits)) {
+      mf_stdformul <- fits[[tstsetup_stdformul]]$model
+      nms_stdformul <- setdiff(
+        grep("y_|xco", names(mf_stdformul), value = TRUE),
+        "xco.1"
+      )
+      expect_equal(mf_spclformul[, setdiff(names(mf_spclformul),
+                                           nms_spclformul)],
+                   mf_stdformul[, setdiff(names(mf_stdformul),
+                                          nms_stdformul)],
+                   info = tstsetup)
+    }
     # Check arithmetic expressions:
     for (nm_spclformul in nms_spclformul) {
       expect_equal(mf_spclformul[, nm_spclformul],

--- a/tests/testthat/test_proj_pred.R
+++ b/tests/testthat/test_proj_pred.R
@@ -868,6 +868,7 @@ test_that("`weightsnew` works", {
     pp_orig <- pps[[tstsetup]]
     if (!(args_prj[[tstsetup]]$pkg_nm == "brms" &&
           args_prj[[tstsetup]]$fam_nm == "binom")) {
+      # TODO (brms): Fix or document why this doesn't work for "brmsfit"s.
       pp_ones <- proj_predict(prjs[[tstsetup]],
                               newdata = dat_wobs_ones,
                               weightsnew = ~ wobs_col_ones,
@@ -885,6 +886,7 @@ test_that("`weightsnew` works", {
               info_str = tstsetup)
     if (!(args_prj[[tstsetup]]$pkg_nm == "brms" &&
           args_prj[[tstsetup]]$fam_nm == "binom")) {
+      # TODO (brms): Fix or document why this doesn't work for "brmsfit"s.
       ppw <- proj_predict(prjs[[tstsetup]],
                           newdata = dat_wobs_new,
                           weightsnew = ~ wobs_col_new,

--- a/tests/testthat/test_project.R
+++ b/tests/testthat/test_project.R
@@ -292,9 +292,6 @@ test_that("non-clustered projection does not require a seed", {
   # don't expect it to be necessary.
   tstsetups <- grep("\\.noclust$|\\.default_ndr_ncl$", names(prjs),
                     value = TRUE)
-  # Be completely random here (should not be necessary, though, when advancing
-  # `.Random.seed[2]` as done further below):
-  set.seed(NULL)
   for (tstsetup in tstsetups) {
     args_prj_i <- args_prj[[tstsetup]]
     p_orig <- prjs[[tstsetup]]

--- a/tests/testthat/test_project.R
+++ b/tests/testthat/test_project.R
@@ -239,15 +239,15 @@ test_that("invalid `nterms` fails", {
 # ndraws and nclusters ----------------------------------------------------
 
 test_that("invalid `ndraws` fails", {
-  tstsetups <- grep("\\.glm\\.gauss.*\\.solterms_x\\.default_ndr_ncl$",
-                    names(prjs), value = TRUE)
+  tstsetups <- head(grep("\\.glm\\.gauss.*\\.solterms_x\\.", names(prjs),
+                         value = TRUE), 1)
   for (tstsetup in tstsetups) {
     args_prj_i <- args_prj[[tstsetup]]
     expect_error(
       do.call(project, c(
         list(object = refmods[[args_prj_i$tstsetup_ref]],
              ndraws = NULL),
-        excl_nonargs(args_prj_i)
+        excl_nonargs(args_prj_i, nms_excl_add = c("ndraws", "nclusters"))
       )),
       "^!is\\.null\\(ndraws\\) is not TRUE$",
       info = tstsetup
@@ -259,8 +259,8 @@ test_that(paste(
   "`ndraws` and/or `nclusters` too big causes them to be cut off at the number",
   "of posterior draws in the reference model"
 ), {
-  tstsetups <- grep("\\.glm\\.gauss.*\\.solterms_x\\.default_ndr_ncl$",
-                    names(prjs), value = TRUE)
+  tstsetups <- head(grep("\\.glm\\.gauss.*\\.solterms_x\\.", names(prjs),
+                         value = TRUE), 1)
   for (tstsetup in tstsetups) {
     args_prj_i <- args_prj[[tstsetup]]
     S <- nrow(as.matrix(fits[[args_prj_i$tstsetup_fit]]))
@@ -270,7 +270,7 @@ test_that(paste(
           list(object = refmods[[args_prj_i$tstsetup_ref]],
                ndraws = ndraws_crr,
                nclusters = nclusters_crr),
-          excl_nonargs(args_prj_i)
+          excl_nonargs(args_prj_i, nms_excl_add = c("ndraws", "nclusters"))
         ))
         projection_tester(
           p,

--- a/tests/testthat/test_refmodel.R
+++ b/tests/testthat/test_refmodel.R
@@ -79,7 +79,7 @@ test_that("offsets specified via argument `offset` fail", {
 
 test_that(paste(
   "binomial family with 1-column response and weights which are not all ones",
-  "warns"
+  "errors"
 ), {
   dat_prop <- within(dat, {
     ybinprop_glm <- y_glm_binom / wobs_col
@@ -91,14 +91,14 @@ test_that(paste(
     chains = chains_tst, seed = seed_fit, iter = iter_tst, QR = TRUE,
     refresh = 0
   ))
-  expect_equal(
-    as.matrix(fit_binom_1col_wobs),
-    as.matrix(fits$rstanarm.glm.binom.stdformul.without_wobs.with_offs)
-  )
-  expect_error(
-    get_refmodel(fit_binom_1col_wobs),
-    paste("response must contain numbers of successes")
-  )
+  if ("rstanarm.glm.binom.stdformul.without_wobs.with_offs" %in% names(fits)) {
+    expect_equal(
+      as.matrix(fit_binom_1col_wobs),
+      as.matrix(fits$rstanarm.glm.binom.stdformul.without_wobs.with_offs)
+    )
+  }
+  expect_error(get_refmodel(fit_binom_1col_wobs),
+               "response must contain numbers of successes")
 })
 
 test_that("get_refmodel() is idempotent", {

--- a/tests/testthat/test_refmodel.R
+++ b/tests/testthat/test_refmodel.R
@@ -191,5 +191,20 @@ test_that(paste(
                  info = tstsetup)
     expect_false(isTRUE(all.equal(predref_ynew_resp, predref_link)),
                  info = tstsetup)
+
+    # Snapshots:
+    if (run_snaps) {
+      if (testthat_ed_max2) local_edition(3)
+      width_orig <- options(width = 145)
+      expect_snapshot({
+        print(tstsetup)
+        print(rlang::hash(predref_resp))
+        print(rlang::hash(predref_link))
+        print(rlang::hash(predref_ynew_resp))
+        print(rlang::hash(predref_ynew_link))
+      })
+      options(width = width_orig$width)
+      if (testthat_ed_max2) local_edition(2)
+    }
   }
 })

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -862,7 +862,7 @@ test_that(paste(
     K_crr <- args_cvvs_i$K
 
     # Refit `K_crr` times:
-    if (grepl("\\.glmm\\.", tstsetup) && packageVersion("brms") >= "2.16.4") {
+    if (grepl("\\.glmm\\.", tstsetup)) {
       # Perform a grouped K-fold CV to test an edge case where all observations
       # belonging to the same level of a variable with group-level effects are
       # in the same fold, so prediction is performed for new levels (see, e.g.,
@@ -882,12 +882,8 @@ test_that(paste(
                            folds = folds_vec)
 
     # Create `"refmodel"` object with `cvfits`:
-    if (packageVersion("brms") >= "2.16.4") {
-      refmod_crr <- get_refmodel(fit_crr, brms_seed = seed2_tst,
-                                 cvfits = kfold_obj)
-    } else {
-      refmod_crr <- get_refmodel(fit_crr, cvfits = kfold_obj)
-    }
+    refmod_crr <- get_refmodel(fit_crr, brms_seed = seed2_tst,
+                               cvfits = kfold_obj)
 
     # Run cv_varsel():
     cvvs_cvfits <- do.call(cv_varsel, c(

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -513,7 +513,10 @@ test_that("`seed` works (and restores the RNG state afterwards)", {
   # .get_refdist().
   skip_if_not(run_cvvs)
   # To save time:
-  tstsetups <- grep("\\.glm\\.gauss", names(cvvss), value = TRUE)
+  tstsetups <- union(
+    grep("\\.glm\\.gauss", names(cvvss), value = TRUE),
+    grep("^brms\\.(glmm|gamm)\\..*\\.kfold", names(cvvss), value = TRUE)
+  )
   for (tstsetup in tstsetups) {
     args_cvvs_i <- args_cvvs[[tstsetup]]
     cvvs_orig <- cvvss[[tstsetup]]

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -241,11 +241,7 @@ test_that(paste(
   for (tstsetup in tstsetups) {
     args_vs_i <- args_vs[[tstsetup]]
     m_max <- args_vs_i$nterms_max + 1L
-    if (identical(args_vs_i$method, "forward")) {
-      ncl_crr <- args_vs_i$nclusters
-    } else {
-      ncl_crr <- 1L
-    }
+    ncl_crr <- args_vs_i$nclusters
     ssq_regul_sel_alpha <- array(dim = c(length(regul_tst), m_max, ncl_crr))
     ssq_regul_sel_beta <- array(dim = c(length(regul_tst), m_max, ncl_crr))
     ssq_regul_prd <- array(dim = c(length(regul_tst), m_max))

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -57,29 +57,18 @@ test_that("`seed` works (and restores the RNG state afterwards)", {
     args_vs_i <- args_vs[[tstsetup]]
     vs_orig <- vss[[tstsetup]]
     rand_orig <- runif(1) # Just to advance `.Random.seed[2]`.
-    .Random.seed_new1 <- .Random.seed
-    vs_new <- do.call(varsel, c(
-      list(object = refmods[[args_vs_i$tstsetup_ref]],
-           seed = args_vs_i$seed + 1L),
-      excl_nonargs(args_vs_i, nms_excl_add = "seed")
-    ))
-    .Random.seed_new2 <- .Random.seed
-    rand_new <- runif(1) # Just to advance `.Random.seed[2]`.
     .Random.seed_repr1 <- .Random.seed
     vs_repr <- do.call(varsel, c(
       list(object = refmods[[args_vs_i$tstsetup_ref]]),
       excl_nonargs(args_vs_i)
     ))
     .Random.seed_repr2 <- .Random.seed
+    rand_new <- runif(1) # Just to advance `.Random.seed[2]`.
     # Expected equality:
     expect_equal(vs_repr, vs_orig, info = tstsetup)
-    expect_equal(.Random.seed_new2, .Random.seed_new1, info = tstsetup)
     expect_equal(.Random.seed_repr2, .Random.seed_repr1, info = tstsetup)
     # Expected inequality:
-    expect_false(isTRUE(all.equal(vs_new, vs_orig)), info = tstsetup)
     expect_false(isTRUE(all.equal(rand_new, rand_orig)), info = tstsetup)
-    expect_false(isTRUE(all.equal(.Random.seed_repr2, .Random.seed_new2)),
-                 info = tstsetup)
   }
 })
 
@@ -505,31 +494,18 @@ test_that("`seed` works (and restores the RNG state afterwards)", {
     args_cvvs_i <- args_cvvs[[tstsetup]]
     cvvs_orig <- cvvss[[tstsetup]]
     rand_orig <- runif(1) # Just to advance `.Random.seed[2]`.
-    .Random.seed_new1 <- .Random.seed
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
-    cvvs_new <- suppressWarnings(do.call(cv_varsel, c(
-      list(object = refmods[[args_cvvs_i$tstsetup_ref]],
-           seed = args_cvvs_i$seed + 1L),
-      excl_nonargs(args_cvvs_i, nms_excl_add = "seed")
-    )))
-    .Random.seed_new2 <- .Random.seed
-    rand_new <- runif(1) # Just to advance `.Random.seed[2]`.
     .Random.seed_repr1 <- .Random.seed
     cvvs_repr <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]]),
       excl_nonargs(args_cvvs_i)
     )))
     .Random.seed_repr2 <- .Random.seed
+    rand_new <- runif(1) # Just to advance `.Random.seed[2]`.
     # Expected equality:
     expect_equal(cvvs_repr, cvvs_orig, info = tstsetup)
-    expect_equal(.Random.seed_new2, .Random.seed_new1, info = tstsetup)
     expect_equal(.Random.seed_repr2, .Random.seed_repr1, info = tstsetup)
     # Expected inequality:
-    expect_false(isTRUE(all.equal(cvvs_new, cvvs_orig)), info = tstsetup)
     expect_false(isTRUE(all.equal(rand_new, rand_orig)), info = tstsetup)
-    expect_false(isTRUE(all.equal(.Random.seed_repr2, .Random.seed_new2)),
-                 info = tstsetup)
   }
 })
 

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -539,10 +539,8 @@ test_that("`seed` works (and restores the RNG state afterwards)", {
     .Random.seed_repr2 <- .Random.seed
     # Expected equality:
     expect_equal(cvvs_repr, cvvs_orig, info = tstsetup)
-    if (!identical(args_cvvs_i$cv_method, "kfold")) {
-      expect_equal(.Random.seed_new2, .Random.seed_new1, info = tstsetup)
-      expect_equal(.Random.seed_repr2, .Random.seed_repr1, info = tstsetup)
-    }
+    expect_equal(.Random.seed_new2, .Random.seed_new1, info = tstsetup)
+    expect_equal(.Random.seed_repr2, .Random.seed_repr1, info = tstsetup)
     # Expected inequality:
     expect_false(isTRUE(all.equal(cvvs_new, cvvs_orig)), info = tstsetup)
     expect_false(isTRUE(all.equal(rand_new, rand_orig)), info = tstsetup)

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -907,8 +907,16 @@ test_that(paste(
       list(object = refmod_crr),
       excl_nonargs(args_cvvs_i, nms_excl_add = "K")
     ))
+    # Test the reproducibility of ref_predfun() when applied to new observations
+    # (should be ensured by get_refmodel.brmsfit()'s internal `refprd_seed`):
+    runif(1)
+    cvvs_cvfits_repr <- do.call(cv_varsel, c(
+      list(object = refmod_crr),
+      excl_nonargs(args_cvvs_i, nms_excl_add = "K")
+    ))
 
     # Checks:
+    expect_identical(cvvs_cvfits, cvvs_cvfits_repr, info = tstsetup)
     vsel_tester(
       cvvs_cvfits,
       with_cv = TRUE,

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -727,7 +727,7 @@ test_that(paste(
   "models"
 ), {
   skip_if_not(run_cvvs)
-  tstsetups <- grep("^rstanarm.*\\.kfold", names(cvvss), value = TRUE)
+  tstsetups <- grep("^rstanarm\\..*\\.kfold", names(cvvss), value = TRUE)
   if (!run_cvfits_all) {
     tstsetups_tmp <- head(grep("\\.glmm\\.", tstsetups, value = TRUE), 1)
     if (length(tstsetups_tmp) == 0) {
@@ -842,7 +842,7 @@ test_that(paste(
 ), {
   skip_if_not(run_cvvs)
   skip_if_not(packageVersion("brms") >= "2.16.4")
-  tstsetups <- grep("^brms.*\\.kfold", names(cvvss), value = TRUE)
+  tstsetups <- grep("^brms\\..*\\.kfold", names(cvvss), value = TRUE)
   if (!run_cvfits_all) {
     tstsetups_tmp <- head(grep("\\.glmm\\.", tstsetups, value = TRUE), 1)
     if (length(tstsetups_tmp) == 0) {

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -900,7 +900,7 @@ test_that(paste(
     ))
 
     # Checks:
-    expect_identical(cvvs_cvfits, cvvs_cvfits_repr, info = tstsetup)
+    expect_equal(cvvs_cvfits, cvvs_cvfits_repr, info = tstsetup)
     vsel_tester(
       cvvs_cvfits,
       with_cv = TRUE,

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -827,10 +827,6 @@ test_that(paste(
       nclusters_pred_expected = args_cvvs_i$nclusters_pred,
       info_str = tstsetup
     )
-    # Note: Unfortunately, it is currently not possible to always ensure exactly
-    # the same seed when performing K-fold CV with `cvfits` or without `cvfits`.
-    # Therefore, the following checks for equality/inequality are quite
-    # restricted.
     # Expected equality for some components:
     # TODO: Currently, `check.environment = FALSE` is needed. The reason is
     # probably that in the divergence minimizers, the projpred-extended family
@@ -925,10 +921,6 @@ test_that(paste(
       nclusters_pred_expected = args_cvvs_i$nclusters_pred,
       info_str = tstsetup
     )
-    # Note: Unfortunately, it is currently not possible to always ensure exactly
-    # the same seed when performing K-fold CV with `cvfits` or without `cvfits`.
-    # Therefore, the following checks for equality/inequality are quite
-    # restricted.
     # Expected equality for some components:
     # TODO: Currently, `check.environment = FALSE` is needed. The reason is
     # probably that in the divergence minimizers, the projpred-extended family

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -633,7 +633,7 @@ test_that("`validate_search` works", {
   tstsetups <- grep("\\.default_cvmeth", names(cvvss), value = TRUE)
   if (!run_valsearch_always) {
     tstsetups <- grep("\\.glm\\.", tstsetups, value = TRUE)
-    tstsetups <- grep("\\.forward", tstsetups, value = TRUE, invert = TRUE)
+    tstsetups <- grep("\\.forward\\.", tstsetups, value = TRUE, invert = TRUE)
   }
   suggsize_cond <- setNames(rep(NA, length(tstsetups)), nm = tstsetups)
   for (tstsetup in tstsetups) {
@@ -676,6 +676,18 @@ test_that("`validate_search` works", {
     # Expected inequality for the exceptions (but note that the components from
     # `vsel_nms_cv_valsearch_opt` can be, but don't need to be differing):
     for (vsel_nm in setdiff(vsel_nms_cv_valsearch, vsel_nms_cv_valsearch_opt)) {
+      if (vsel_nm == "pct_solution_terms_cv" &&
+          all(cvvss[[tstsetup]][[vsel_nm]][
+            , colnames(cvvss[[tstsetup]][[vsel_nm]]) != "size", drop = FALSE
+          ] %in% c(0, 1))) {
+        # In this case, a comparison will most likely give the same
+        # `pct_solution_terms_cv` element for `validate_search = TRUE` and
+        # `validate_search = FALSE`. In fact, `pct_solution_terms_cv` could
+        # therefore be added to `vsel_nms_cv_valsearch_opt`, but most of the
+        # time, `pct_solution_terms_cv` will differ, so we don't include it in
+        # `vsel_nms_cv_valsearch_opt` and skip here:
+        next
+      }
       expect_false(isTRUE(all.equal(cvvs_valsearch[[vsel_nm]],
                                     cvvss[[tstsetup]][[vsel_nm]])),
                    info = paste(tstsetup, vsel_nm, sep = "__"))

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -769,8 +769,12 @@ test_that(paste(
       # belonging to the same level of a variable with group-level effects are
       # in the same fold, so prediction is performed for new levels (see, e.g.,
       # brms's GitHub issue #1286):
+      if (exists(".Random.seed", envir = .GlobalEnv)) {
+        rng_old <- get(".Random.seed", envir = .GlobalEnv)
+      }
       set.seed(seed2_tst) # Makes the construction of the CV folds reproducible.
       folds_vec <- loo::kfold_split_grouped(K = K_crr, x = dat$z.1)
+      if (exists("rng_old")) assign(".Random.seed", rng_old, envir = .GlobalEnv)
     } else {
       folds_vec <- cvfolds(nobsv, K = K_crr, seed = seed2_tst)
     }
@@ -880,8 +884,12 @@ test_that(paste(
       # belonging to the same level of a variable with group-level effects are
       # in the same fold, so prediction is performed for new levels (see, e.g.,
       # brms's GitHub issue #1286):
+      if (exists(".Random.seed", envir = .GlobalEnv)) {
+        rng_old <- get(".Random.seed", envir = .GlobalEnv)
+      }
       set.seed(seed2_tst) # Makes the construction of the CV folds reproducible.
       folds_vec <- loo::kfold_split_grouped(K = K_crr, x = dat$z.1)
+      if (exists("rng_old")) assign(".Random.seed", rng_old, envir = .GlobalEnv)
     } else {
       folds_vec <- cvfolds(nobsv, K = K_crr, seed = seed2_tst)
     }

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -515,6 +515,9 @@ test_that("`seed` works (and restores the RNG state afterwards)", {
   # To save time:
   tstsetups <- union(
     grep("\\.glm\\.gauss", names(cvvss), value = TRUE),
+    # Important for testing get_refmodel.brmsfit()'s internal `kfold_seed` (and
+    # also `refprd_seed` if we are lucky and get a fold which separates out at
+    # least one group):
     grep("^brms\\.(glmm|gamm)\\..*\\.kfold", names(cvvss), value = TRUE)
   )
   for (tstsetup in tstsetups) {

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -246,11 +246,6 @@ test_that(paste(
     } else {
       ncl_crr <- 1L
     }
-    if (!grepl("\\.spclformul", tstsetup)) {
-      tol_alpha <- 3e-1
-    } else {
-      tol_alpha <- 5e-1
-    }
     ssq_regul_sel_alpha <- array(dim = c(length(regul_tst), m_max, ncl_crr))
     ssq_regul_sel_beta <- array(dim = c(length(regul_tst), m_max, ncl_crr))
     ssq_regul_prd <- array(dim = c(length(regul_tst), m_max))
@@ -309,16 +304,6 @@ test_that(paste(
     # For the intercept-only model:
     for (nn in seq_len(dim(ssq_regul_sel_alpha)[3])) {
       expect_length(unique(ssq_regul_sel_alpha[, 1, !!nn]), 1)
-    }
-    # All other (i.e., not intercept-only) models:
-    for (j in seq_len(dim(ssq_regul_sel_alpha)[1])[-1]) {
-      for (m in seq_len(dim(ssq_regul_sel_alpha)[2])[-1]) {
-        for (nn in seq_len(dim(ssq_regul_sel_alpha)[3])) {
-          expect_equal(ssq_regul_sel_alpha[!!j, !!m, !!nn],
-                       ssq_regul_sel_alpha[j - 1, m, nn],
-                       tolerance = tol_alpha)
-        }
-      }
     }
     # For the intercept-only model:
     expect_true(all(is.na(ssq_regul_sel_beta[, 1, ])), info = tstsetup)

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -570,7 +570,7 @@ test_that(paste(
 
 test_that("setting `nloo` smaller than the number of observations works", {
   skip_if_not(run_cvvs)
-  nloo_tst <- nobsv - 1L
+  nloo_tst <- nobsv %/% 5L
   tstsetups <- grep("\\.glm\\.gauss\\..*\\.default_cvmeth", names(cvvss),
                     value = TRUE)
   for (tstsetup in tstsetups) {


### PR DESCRIPTION
This PR performs several improvements in the unit tests, notably adding a `run_more` switch which allowed to reduce the runtime considerably (by factor 3 to 4) while still maintaining coverage at almost the same level. Therefore, this switch is set to `FALSE` by default.

Note that when running the snapshot expectations (locally), there seems to be an occasional reproducibility issue for the **brms** GLMM K-fold CV. That issue probably already existed at the state of PR #271, but since it appears to occur randomly, I did not notice it earlier. I checked whether the issue is related to **projpred**, but it seems to be related to **rstan** and/or **brms**, so I don't think we can do much about it. I would create an issue on **rstan**'s or **brms**'s issue tracker, but the random occurrence makes reliable debugging impossible.

While trying to track down the source of that reproducibility issue, I created a switch `run_randRNG` which allows to run all test scripts in a completely random RNG state. (The tests should still pass even then because in all situations where the RNG is used, a specific seed is supposed to be set.)

Most of the other changes here are of rather minor nature, but all are related to the unit tests. See the commit messages for details.