### PR TITLE
Pass arguments to divergence minimizer

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -158,7 +158,7 @@ cv_varsel.refmodel <- function(
       nclusters_pred = nclusters_pred, refit_prj = refit_prj, penalty = penalty,
       verbose = verbose, opt = opt, nloo = nloo,
       validate_search = validate_search, seed = seed,
-      search_terms = search_terms
+      search_terms = search_terms, ...
     )
   } else if (cv_method == "kfold") {
     sel_cv <- kfold_varsel(
@@ -166,7 +166,7 @@ cv_varsel.refmodel <- function(
       ndraws = ndraws, nclusters = nclusters, ndraws_pred = ndraws_pred,
       nclusters_pred = nclusters_pred, refit_prj = refit_prj, penalty = penalty,
       verbose = verbose, opt = opt, K = K, seed = seed,
-      search_terms = search_terms
+      search_terms = search_terms, ...
     )
   } else {
     stop(sprintf("Unknown `cv_method`: %s.", method))
@@ -183,7 +183,7 @@ cv_varsel.refmodel <- function(
                   refit_prj = refit_prj, nterms_max = nterms_max - 1,
                   penalty = penalty, verbose = verbose,
                   lambda_min_ratio = lambda_min_ratio, nlambda = nlambda,
-                  regul = regul, search_terms = search_terms, seed = seed)
+                  regul = regul, search_terms = search_terms, seed = seed, ...)
   } else if (cv_method == "LOO") {
     sel <- sel_cv$sel
   }
@@ -291,7 +291,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
                        nclusters, ndraws_pred, nclusters_pred, refit_prj,
                        penalty, verbose, opt, nloo = NULL,
                        validate_search = TRUE, seed = NULL,
-                       search_terms = NULL) {
+                       search_terms = NULL, ...) {
   ##
   ## Perform the validation of the searching process using LOO. validate_search
   ## indicates whether the selection is performed separately for each fold (for
@@ -371,7 +371,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     search_path <- select(
       method = method, p_sel = p_sel, refmodel = refmodel,
       nterms_max = nterms_max, penalty = penalty, verbose = FALSE, opt = opt,
-      search_terms = search_terms
+      search_terms = search_terms, ...
     )
 
     ## project onto the selected models and compute the prediction accuracy for
@@ -380,7 +380,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       search_path = search_path,
       nterms = c(0, seq_along(search_path$solution_terms)),
       p_ref = p_pred, refmodel = refmodel, regul = opt$regul,
-      refit_prj = refit_prj
+      refit_prj = refit_prj, ...
     )
 
     if (verbose) {
@@ -456,7 +456,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       search_path <- select(
         method = method, p_sel = p_sel, refmodel = refmodel,
         nterms_max = nterms_max, penalty = penalty, verbose = FALSE, opt = opt,
-        search_terms = search_terms
+        search_terms = search_terms, ...
       )
 
       ## project onto the selected models and compute the prediction accuracy
@@ -465,7 +465,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
         search_path = search_path,
         nterms = c(0, seq_along(search_path$solution_terms)),
         p_ref = p_pred, refmodel = refmodel, regul = opt$regul,
-        refit_prj = refit_prj
+        refit_prj = refit_prj, ...
       )
       summaries_sub <- .get_sub_summaries(
         submodels = submodels, test_points = c(i), refmodel = refmodel
@@ -519,7 +519,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
 kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
                          nclusters, ndraws_pred, nclusters_pred,
                          refit_prj, penalty, verbose, opt, K, seed = NULL,
-                         search_terms = NULL) {
+                         search_terms = NULL, ...) {
   # Fetch the K reference model fits (or fit them now if not already done) and
   # create objects of class `refmodel` from them (and also store the `omitted`
   # indices):
@@ -549,7 +549,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
     out <- select(
       method = method, p_sel = p_sel, refmodel = fold$refmodel,
       nterms_max = nterms_max, penalty = penalty, verbose = FALSE, opt = opt,
-      search_terms = search_terms
+      search_terms = search_terms, ...
     )
     if (verbose) {
       utils::setTxtProgressBar(pb, fold_index)
@@ -577,7 +577,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
       search_path = search_path,
       nterms = c(0, seq_along(search_path$solution_terms)),
       p_ref = p_pred, refmodel = fold$refmodel, regul = opt$regul,
-      refit_prj = refit_prj
+      refit_prj = refit_prj, ...
     )
     if (verbose && refit_prj) {
       utils::setTxtProgressBar(pb, fold_index)

--- a/R/project.R
+++ b/R/project.R
@@ -40,7 +40,7 @@
 #' @inheritParams varsel
 #' @param ... Arguments passed to [get_refmodel()] (if [get_refmodel()] is
 #'   actually used; see argument `object`) as well as to the divergence
-#'   minimizer.
+#'   minimizer (if `refit_prj` is `TRUE`).
 #'
 #' @details Arguments `ndraws` and `nclusters` are automatically truncated at
 #'   the number of posterior draws in the reference model (which is `1` for

--- a/R/project.R
+++ b/R/project.R
@@ -39,7 +39,8 @@
 #'   draws (if `!is.null(nclusters)`).
 #' @inheritParams varsel
 #' @param ... Arguments passed to [get_refmodel()] (if [get_refmodel()] is
-#'   actually used; see argument `object`).
+#'   actually used; see argument `object`) as well as to the divergence
+#'   minimizer.
 #'
 #' @details Arguments `ndraws` and `nclusters` are automatically truncated at
 #'   the number of posterior draws in the reference model (which is `1` for
@@ -224,7 +225,7 @@ project <- function(object, nterms = NULL, solution_terms = NULL,
       submodls = object$search_path$submodls
     ),
     nterms = nterms, p_ref = p_ref, refmodel = refmodel, regul = regul,
-    refit_prj = refit_prj
+    refit_prj = refit_prj, ...
   )
 
   # Output:

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -2,7 +2,8 @@
 # terms given in `solution_terms`. Note that "single submodel" does not refer to
 # a single fit (there are as many fits for this single submodel as there are
 # projected draws).
-project_submodel <- function(solution_terms, p_ref, refmodel, regul = 1e-4) {
+project_submodel <- function(solution_terms, p_ref, refmodel, regul = 1e-4,
+                             ...) {
   validparams <- .validate_wobs_wsample(refmodel$wobs, p_ref$weights, p_ref$mu)
   wobs <- validparams$wobs
   wsample <- validparams$wsample
@@ -18,7 +19,8 @@ project_submodel <- function(solution_terms, p_ref, refmodel, regul = 1e-4) {
     family = refmodel$family,
     weights = refmodel$wobs,
     projpred_var = p_ref$var,
-    projpred_regul = regul
+    projpred_regul = regul,
+    ...
   )
 
   if (isTRUE(getOption("projpred.check_conv", FALSE))) {
@@ -35,11 +37,11 @@ project_submodel <- function(solution_terms, p_ref, refmodel, regul = 1e-4) {
 # sizes `nterms`. Returns a list of submodels (each processed by
 # .init_submodel()).
 .get_submodels <- function(search_path, nterms, p_ref, refmodel, regul,
-                           refit_prj = FALSE) {
+                           refit_prj = FALSE, ...) {
   if (!refit_prj) {
     # In this case, simply fetch the already computed projections, so don't
     # project again.
-    fetch_submodel <- function(nterms) {
+    fetch_submodel <- function(nterms, ...) {
       validparams <- .validate_wobs_wsample(
         refmodel$wobs, search_path$p_sel$weights, search_path$p_sel$mu
       )
@@ -57,14 +59,14 @@ project_submodel <- function(solution_terms, p_ref, refmodel, regul = 1e-4) {
     }
   } else {
     # In this case, project again.
-    fetch_submodel <- function(nterms) {
+    fetch_submodel <- function(nterms, ...) {
       return(project_submodel(
         solution_terms = utils::head(search_path$solution_terms, nterms),
-        p_ref = p_ref, refmodel = refmodel, regul = regul
+        p_ref = p_ref, refmodel = refmodel, regul = regul, ...
       ))
     }
   }
-  return(lapply(nterms, fetch_submodel))
+  return(lapply(nterms, fetch_submodel, ...))
 }
 
 .validate_wobs_wsample <- function(ref_wobs, ref_wsample, ref_mu) {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -135,6 +135,7 @@
 #'     GLM fitter).
 #'     + `projpred_regul` accepts a single numeric value as supplied to argument
 #'     `regul` of [project()], for example.
+#'     + `...` accepts further arguments specified by the user.
 #'
 #' The return value of these functions needs to be:
 #' * `ref_predfun`: an \eqn{N \times S_{\mbox{ref}}}{N x S_ref} matrix.

--- a/R/search.R
+++ b/R/search.R
@@ -1,5 +1,5 @@
 search_forward <- function(p_ref, refmodel, nterms_max, verbose = TRUE, opt,
-                           search_terms = NULL) {
+                           search_terms = NULL, ...) {
   iq <- ceiling(quantile(seq_len(nterms_max), 1:10 / 10))
   if (is.null(search_terms)) {
     allterms <- split_formula(refmodel$formula, data = refmodel$fetch_data())
@@ -18,7 +18,7 @@ search_forward <- function(p_ref, refmodel, nterms_max, verbose = TRUE, opt,
       next
     full_cands <- lapply(cands, function(cand) c(chosen, cand))
     subL <- lapply(full_cands, project_submodel,
-                   p_ref = p_ref, refmodel = refmodel, regul = opt$regul)
+                   p_ref = p_ref, refmodel = refmodel, regul = opt$regul, ...)
 
     ## select best candidate
     imin <- which.min(sapply(subL, "[[", "kl"))

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -73,7 +73,9 @@
 #'   therefore, the results are not reproducible. See [set.seed()] for details.
 #'   Here, this seed is used for clustering the reference model's posterior
 #'   draws (if `!is.null(nclusters)`).
-#' @param ... Arguments passed to [get_refmodel()].
+#' @param ... Arguments passed to [get_refmodel()] as well as to the divergence
+#'   minimizer (during a forward search and also during the evaluation part, but
+#'   the latter only if `refit_prj` is `TRUE`).
 #'
 #' @details Arguments `ndraws`, `nclusters`, `nclusters_pred`, and `ndraws_pred`
 #'   are automatically truncated at the number of posterior draws in the
@@ -184,7 +186,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
   search_path <- select(
     method = method, p_sel = p_sel, refmodel = refmodel,
     nterms_max = nterms_max, penalty = penalty, verbose = verbose, opt = opt,
-    search_terms = search_terms
+    search_terms = search_terms, ...
   )
   solution_terms <- search_path$solution_terms
 
@@ -192,7 +194,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
   submodels <- .get_submodels(search_path = search_path,
                               nterms = c(0, seq_along(solution_terms)),
                               p_ref = p_pred, refmodel = refmodel,
-                              regul = regul, refit_prj = refit_prj)
+                              regul = regul, refit_prj = refit_prj, ...)
   sub <- .get_sub_summaries(
     submodels = submodels, test_points = seq_along(refmodel$y),
     refmodel = refmodel
@@ -251,7 +253,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
 }
 
 select <- function(method, p_sel, refmodel, nterms_max, penalty, verbose, opt,
-                   search_terms = NULL) {
+                   search_terms = NULL, ...) {
   ##
   ## Auxiliary function, performs variable selection with the given method,
   ## and returns the search_path, i.e., a list with the followint entries (the
@@ -271,7 +273,7 @@ select <- function(method, p_sel, refmodel, nterms_max, penalty, verbose, opt,
     return(search_path)
   } else if (method == "forward") {
     search_path <- search_forward(p_sel, refmodel, nterms_max, verbose, opt,
-                                  search_terms = search_terms)
+                                  search_terms = search_terms, ...)
     search_path$p_sel <- p_sel
     return(search_path)
   }

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -39,7 +39,9 @@ cv_varsel(object, ...)
 \code{\link[=init_refmodel]{init_refmodel()}}) or an object that can be passed to argument \code{object} of
 \code{\link[=get_refmodel]{get_refmodel()}}.}
 
-\item{...}{Arguments passed to \code{\link[=get_refmodel]{get_refmodel()}}.}
+\item{...}{Arguments passed to \code{\link[=get_refmodel]{get_refmodel()}} as well as to the divergence
+minimizer (during a forward search and also during the evaluation part, but
+the latter only if \code{refit_prj} is \code{TRUE}).}
 
 \item{method}{The method for the search part. Possible options are \code{"L1"} for
 L1 search and \code{"forward"} for forward search. If \code{NULL}, then \code{"forward"}

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -63,7 +63,7 @@ regularization to avoid numerical problems.}
 
 \item{...}{Arguments passed to \code{\link[=get_refmodel]{get_refmodel()}} (if \code{\link[=get_refmodel]{get_refmodel()}} is
 actually used; see argument \code{object}) as well as to the divergence
-minimizer.}
+minimizer (if \code{refit_prj} is \code{TRUE}).}
 }
 \value{
 If the projection is performed onto a single submodel (i.e.,

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -62,7 +62,8 @@ no need for regularization, but sometimes we need to add some
 regularization to avoid numerical problems.}
 
 \item{...}{Arguments passed to \code{\link[=get_refmodel]{get_refmodel()}} (if \code{\link[=get_refmodel]{get_refmodel()}} is
-actually used; see argument \code{object}).}
+actually used; see argument \code{object}) as well as to the divergence
+minimizer.}
 }
 \value{
 If the projection is performed onto a single submodel (i.e.,

--- a/man/refmodel-init-get.Rd
+++ b/man/refmodel-init-get.Rd
@@ -195,6 +195,7 @@ matrix of predictive variances (necessary for \pkg{projpred}'s internal
 GLM fitter).
 \item \code{projpred_regul} accepts a single numeric value as supplied to argument
 \code{regul} of \code{\link[=project]{project()}}, for example.
+\item \code{...} accepts further arguments specified by the user.
 }
 }
 

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -36,7 +36,9 @@ varsel(object, ...)
 \code{\link[=init_refmodel]{init_refmodel()}}) or an object that can be passed to argument \code{object} of
 \code{\link[=get_refmodel]{get_refmodel()}}.}
 
-\item{...}{Arguments passed to \code{\link[=get_refmodel]{get_refmodel()}}.}
+\item{...}{Arguments passed to \code{\link[=get_refmodel]{get_refmodel()}} as well as to the divergence
+minimizer (during a forward search and also during the evaluation part, but
+the latter only if \code{refit_prj} is \code{TRUE}).}
 
 \item{d_test}{For internal use only. A \code{list} providing information about the
 test set which is used for evaluating the predictive performance of the


### PR DESCRIPTION
This PR allows the user to pass arguments from `project()`, `varsel()`, and `cv_varsel()` to the divergence minimizer. This can be helpful if the submodel fitting routine (e.g., `lme4::glmer()`) needs special settings, e.g., because of problems during optimization.