### PR TITLE
Naming scheme of `as.matrix.projection()`'s output columns

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -803,17 +803,21 @@ suggest_size.vsel <- function(
   return(suggested_size - 1) ## substract the intercept
 }
 
-replace_intercept_name <- function(nms, nm_scheme) {
+# Make the parameter name(s) for the intercept(s) adhere to the naming scheme
+# `nm_scheme`:
+mknms_icpt <- function(nms, nm_scheme) {
   if (nm_scheme == "brms") {
     nms <- gsub("\\(Intercept\\)", "Intercept", nms)
   }
   return(nms)
 }
 
+# Replace the names of an object containing population-level effects so that
+# these names adhere to the naming scheme `nm_scheme`:
 replace_population_names <- function(population_effects, nm_scheme) {
   if (nm_scheme == "brms") {
     # Use brms's naming convention:
-    names(population_effects) <- replace_intercept_name(
+    names(population_effects) <- mknms_icpt(
       names(population_effects),
       nm_scheme = nm_scheme
     )
@@ -822,10 +826,12 @@ replace_population_names <- function(population_effects, nm_scheme) {
   return(population_effects)
 }
 
-replace_VarCorr_names <- function(nms, nm_scheme, coef_nms) {
+# Make the parameter names for variance components adhere to the naming scheme
+# `nm_scheme`:
+mknms_VarCorr <- function(nms, nm_scheme, coef_nms) {
   if (nm_scheme == "brms") {
     grp_nms <- names(coef_nms)
-    nms <- replace_intercept_name(nms, nm_scheme = nm_scheme)
+    nms <- mknms_icpt(nms, nm_scheme = nm_scheme)
 
     # We will have to move the substrings "sd\\." and "cor\\." up front (i.e. in
     # front of the group name), so make sure that they don't occur in the group
@@ -845,7 +851,7 @@ replace_VarCorr_names <- function(nms, nm_scheme, coef_nms) {
     )
     # Replace dots between coefficient names by double underscores:
     for (coef_nms_i in coef_nms) {
-      coef_nms_i <- replace_intercept_name(coef_nms_i, nm_scheme = nm_scheme)
+      coef_nms_i <- mknms_icpt(coef_nms_i, nm_scheme = nm_scheme)
       nms <- gsub(
         paste0(
           "(",
@@ -865,14 +871,16 @@ replace_VarCorr_names <- function(nms, nm_scheme, coef_nms) {
   return(nms)
 }
 
-replace_ranef_names <- function(nms, nm_scheme, coef_nms) {
+# Make the parameter names for group-level effects adhere to the naming scheme
+# `nm_scheme`:
+mknms_ranef <- function(nms, nm_scheme, coef_nms) {
   if (nm_scheme == "brms") {
-    nms <- replace_intercept_name(nms, nm_scheme = nm_scheme)
+    nms <- mknms_icpt(nms, nm_scheme = nm_scheme)
     nms <- paste0("r_", nms)
     for (coef_nms_idx in seq_along(coef_nms)) {
       group_nm_i <- names(coef_nms)[coef_nms_idx]
       coef_nms_i <- coef_nms[[coef_nms_idx]]
-      coef_nms_i <- replace_intercept_name(coef_nms_i, nm_scheme = nm_scheme)
+      coef_nms_i <- mknms_icpt(coef_nms_i, nm_scheme = nm_scheme)
       # Put the part following the group name in square brackets, reorder its
       # two subparts (coefficient name and group level) and separate them by
       # comma:
@@ -967,7 +975,7 @@ get_subparams.lmerMod <- function(x, ...) {
     }
     return(vc_out)
   }))
-  names(group_vc) <- replace_VarCorr_names(
+  names(group_vc) <- mknms_VarCorr(
     names(group_vc),
     coef_nms = lapply(group_vc_raw, rownames),
     ...
@@ -986,7 +994,7 @@ get_subparams.lmerMod <- function(x, ...) {
             })
     )
   }))
-  names(group_ef) <- replace_ranef_names(
+  names(group_ef) <- mknms_ranef(
     names(group_ef),
     coef_nms = lapply(group_vc_raw, rownames),
     ...

--- a/R/methods.R
+++ b/R/methods.R
@@ -838,32 +838,29 @@ mknms_VarCorr <- function(nms, nm_scheme, coef_nms) {
   ))))
   if (nm_scheme == "brms") {
     nms <- mknms_icpt(nms, nm_scheme = nm_scheme)
+    # Escape special characters in the group names and collapse them with "|":
+    grp_nms_esc <- paste(gsub("\\)", "\\\\)",
+                              gsub("\\(", "\\\\(",
+                                   gsub("\\.", "\\\\.", grp_nms))),
+                         collapse = "|")
     # Move the substrings "\\.sd\\." and "\\.cor\\." up front (i.e. in front of
     # the group name), replace their dots, and replace the dot following the
     # group name by double underscores:
-    nms <- sub(
-      paste0(
-        "(",
-        paste(gsub("\\.", "\\\\.", grp_nms),
-              collapse = "|"),
-        ")\\.(sd|cor)\\."
-      ),
-      "\\2_\\1__",
-      nms
-    )
-    # Replace dots between coefficient names by double underscores:
+    nms <- sub(paste0("(", grp_nms_esc, ")\\.(sd|cor)\\."),
+               "\\2_\\1__",
+               nms)
     for (coef_nms_i in coef_nms) {
       coef_nms_i <- mknms_icpt(coef_nms_i, nm_scheme = nm_scheme)
-      nms <- gsub(
-        paste0(
-          "(",
-          paste(gsub("\\.", "\\\\.", coef_nms_i),
-                collapse = "|"),
-          ")\\."
-        ),
-        "\\1__",
-        nms
-      )
+      # Escape special characters in the coefficient names and collapse them
+      # with "|":
+      coef_nms_i_esc <- paste(gsub("\\)", "\\\\)",
+                                   gsub("\\(", "\\\\(",
+                                        gsub("\\.", "\\\\.", coef_nms_i))),
+                              collapse = "|")
+      # Replace dots between coefficient names by double underscores:
+      nms <- gsub(paste0("(", coef_nms_i_esc, ")\\."),
+                  "\\1__",
+                  nms)
     }
   } else if (nm_scheme == "rstanarm") {
     for (coef_nms_i in coef_nms) {

--- a/R/methods.R
+++ b/R/methods.R
@@ -836,7 +836,7 @@ mknms_VarCorr <- function(nms, nm_scheme, coef_nms) {
     # We will have to move the substrings "sd\\." and "cor\\." up front (i.e. in
     # front of the group name), so make sure that they don't occur in the group
     # names:
-    stopifnot(!any(grepl("sd\\.|cor\\.", grp_nms)))
+    stopifnot(!any(grepl("\\.sd\\.|\\.cor\\.", grp_nms)))
     # Move the substrings "sd\\." and "cor\\." up front and replace the dot
     # following the group name by double underscores:
     nms <- sub(

--- a/R/methods.R
+++ b/R/methods.R
@@ -849,25 +849,23 @@ mknms_VarCorr <- function(nms, nm_scheme, coef_nms) {
     nms <- sub(paste0("(", grp_nms_esc, ")\\.(sd|cor)\\."),
                "\\2_\\1__",
                nms)
-    for (coef_nms_i in coef_nms) {
+  }
+  for (coef_nms_i in coef_nms) {
+    if (nm_scheme == "brms") {
       coef_nms_i <- mknms_icpt(coef_nms_i, nm_scheme = nm_scheme)
-      # Escape special characters in the coefficient names and collapse them
-      # with "|":
-      coef_nms_i_esc <- paste(gsub("\\)", "\\\\)",
-                                   gsub("\\(", "\\\\(",
-                                        gsub("\\.", "\\\\.", coef_nms_i))),
-                              collapse = "|")
+    }
+    # Escape special characters in the coefficient names and collapse them
+    # with "|":
+    coef_nms_i_esc <- paste(gsub("\\)", "\\\\)",
+                                 gsub("\\(", "\\\\(",
+                                      gsub("\\.", "\\\\.", coef_nms_i))),
+                            collapse = "|")
+    if (nm_scheme == "brms") {
       # Replace dots between coefficient names by double underscores:
       nms <- gsub(paste0("(", coef_nms_i_esc, ")\\."),
                   "\\1__",
                   nms)
-    }
-  } else if (nm_scheme == "rstanarm") {
-    for (coef_nms_i in coef_nms) {
-      coef_nms_i_esc <- paste(gsub("\\)", "\\\\)",
-                                   gsub("\\(", "\\\\(",
-                                        gsub("\\.", "\\\\.", coef_nms_i))),
-                              collapse = "|")
+    } else if (nm_scheme == "rstanarm") {
       # For the substring "\\.sd\\.":
       nms <- sub(paste0("\\.sd\\.(", coef_nms_i_esc, ")$"),
                  ":\\1,\\1",
@@ -879,6 +877,8 @@ mknms_VarCorr <- function(nms, nm_scheme, coef_nms) {
         nms
       )
     }
+  }
+  if (nm_scheme == "rstanarm") {
     nms <- paste0("Sigma[", nms, "]")
   }
   return(nms)

--- a/R/methods.R
+++ b/R/methods.R
@@ -1017,7 +1017,8 @@ get_subparams.gamm4 <- function(x, ...) {
 #'   as elements of a `list`).
 #' @param nm_scheme The naming scheme for the columns of the output matrix.
 #'   Either `"auto"`, `"rstanarm"`, or `"brms"`, where `"auto"` chooses
-#'   `"rstanarm"` or `"brms"` based on the class of the reference model fit.
+#'   `"rstanarm"` or `"brms"` based on the class of the reference model fit (and
+#'   uses `"rstanarm"` if the reference model fit is of an unknown class).
 #' @param ... Currently ignored.
 #'
 #' @return An \eqn{S_{\mbox{prj}} \times Q}{S_prj x Q} matrix of projected
@@ -1082,10 +1083,10 @@ as.matrix.projection <- function(x, nm_scheme = "auto", ...) {
             "clusters might have different weights.")
   }
   if (identical(nm_scheme, "auto")) {
-    if (inherits(x$refmodel$fit, "stanreg")) {
-      nm_scheme <- "rstanarm"
-    } else if (inherits(x$refmodel$fit, "brmsfit")) {
+    if (inherits(x$refmodel$fit, "brmsfit")) {
       nm_scheme <- "brms"
+    } else {
+      nm_scheme <- "rstanarm"
     }
   }
   stopifnot(nm_scheme %in% c("rstanarm", "brms"))

--- a/R/methods.R
+++ b/R/methods.R
@@ -803,26 +803,104 @@ suggest_size.vsel <- function(
   return(suggested_size - 1) ## substract the intercept
 }
 
-replace_intercept_name <- function(names) {
-  return(gsub(
-    "\\(Intercept\\)",
-    "Intercept",
-    names
-  ))
+replace_intercept_name <- function(names, nm_scheme) {
+  if (nm_scheme == "brms") {
+    names <- gsub("\\(Intercept\\)", "Intercept", names)
+  }
+  return(names)
 }
 
-replace_population_names <- function(population_effects) {
-  # Use brms's naming convention:
-  names(population_effects) <- replace_intercept_name(names(population_effects))
-  names(population_effects) <- paste0("b_", names(population_effects))
+replace_population_names <- function(population_effects, nm_scheme) {
+  if (nm_scheme == "brms") {
+    # Use brms's naming convention:
+    names(population_effects) <- replace_intercept_name(
+      names(population_effects),
+      nm_scheme = nm_scheme
+    )
+    names(population_effects) <- paste0("b_", names(population_effects))
+  }
   return(population_effects)
+}
+
+replace_VarCorr_names <- function(nms, nm_scheme, coef_nms) {
+  if (nm_scheme == "brms") {
+    grp_nms <- names(coef_nms)
+    nms <- replace_intercept_name(nms, nm_scheme = nm_scheme)
+
+    # We will have to move the substrings "sd\\." and "cor\\." up front (i.e. in
+    # front of the group name), so make sure that they don't occur in the group
+    # names:
+    stopifnot(!any(grepl("sd\\.|cor\\.", grp_nms)))
+    # Move the substrings "sd\\." and "cor\\." up front and replace the dot
+    # following the group name by double underscores:
+    nms <- sub(
+      paste0(
+        "(",
+        paste(gsub("\\.", "\\\\.", grp_nms),
+              collapse = "|"),
+        ")\\.(sd|cor)\\."
+      ),
+      "\\2_\\1__",
+      nms
+    )
+    # Replace dots between coefficient names by double underscores:
+    for (coef_nms_i in coef_nms) {
+      coef_nms_i <- replace_intercept_name(coef_nms_i, nm_scheme = nm_scheme)
+      nms <- gsub(
+        paste0(
+          "(",
+          paste(gsub("\\.", "\\\\.", coef_nms_i),
+                collapse = "|"),
+          ")\\."
+        ),
+        "\\1__",
+        nms
+      )
+    }
+  } else if (nm_scheme == "rstanarm") {
+    nms <- sub("\\.sd\\.(.*)$", ":\\1,\\1", nms)
+    nms <- sub("\\.cor\\.(.*)\\.(.*)$", ":\\2,\\1", nms)
+    nms <- paste0("Sigma[", nms, "]")
+  }
+  return(nms)
+}
+
+replace_ranef_names <- function(nms, nm_scheme, coef_nms) {
+  if (nm_scheme == "brms") {
+    nms <- replace_intercept_name(nms, nm_scheme = nm_scheme)
+    nms <- paste0("r_", nms)
+    for (coef_nms_idx in seq_along(coef_nms)) {
+      group_nm_i <- names(coef_nms)[coef_nms_idx]
+      coef_nms_i <- coef_nms[[coef_nms_idx]]
+      coef_nms_i <- replace_intercept_name(coef_nms_i, nm_scheme = nm_scheme)
+      # Put the part following the group name in square brackets, reorder its
+      # two subparts (coefficient name and group level) and separate them by
+      # comma:
+      nms <- sub(
+        paste0(
+          "(",
+          gsub("\\.", "\\\\.", group_nm_i),
+          ")\\.(",
+          paste(gsub("\\.", "\\\\.", coef_nms_i),
+                collapse = "|"),
+          ")\\.(.*)$"
+        ),
+        "\\1[\\3,\\2]",
+        nms
+      )
+    }
+  } else if (nm_scheme == "rstanarm") {
+    nms <- sub("^(.*)\\.(.*)\\.", "\\2 \\1:", nms)
+    nms <- paste0("b[", nms, "]")
+  }
+  return(nms)
 }
 
 #' @keywords internal
 #' @export
 coef.subfit <- function(object, ...) {
   return(with(object, c(
-    "Intercept" = alpha,
+    "(Intercept)" = alpha,
     setNames(beta, colnames(x))
   )))
 }
@@ -837,7 +915,7 @@ get_subparams <- function(x, ...) {
 #' @export
 get_subparams.lm <- function(x, ...) {
   return(coef(x) %>%
-           replace_population_names())
+           replace_population_names(...))
 }
 
 #' @keywords internal
@@ -856,7 +934,7 @@ get_subparams.glm <- function(x, ...) {
 #' @export
 get_subparams.lmerMod <- function(x, ...) {
   population_effects <- lme4::fixef(x) %>%
-    replace_population_names()
+    replace_population_names(...)
 
   # Extract variance components:
   group_vc_raw <- lme4::VarCorr(x)
@@ -889,41 +967,11 @@ get_subparams.lmerMod <- function(x, ...) {
     }
     return(vc_out)
   }))
-
-  # Use brms's naming convention:
-  names(group_vc) <- replace_intercept_name(names(group_vc))
-
-  # We will have to move the substrings "sd\\." and "cor\\." up front (i.e. in
-  # front of the group name), so make sure that they don't occur in the group
-  # names:
-  stopifnot(!any(grepl("sd\\.|cor\\.", names(group_vc_raw))))
-  # Move the substrings "sd\\." and "cor\\." up front and replace the dot
-  # following the group name by double underscores:
-  names(group_vc) <- sub(
-    paste0(
-      "(",
-      paste(gsub("\\.", "\\\\.", names(group_vc_raw)),
-            collapse = "|"),
-      ")\\.(sd|cor)\\."
-    ),
-    "\\2_\\1__",
-    names(group_vc)
+  names(group_vc) <- replace_VarCorr_names(
+    names(group_vc),
+    coef_nms = lapply(group_vc_raw, rownames),
+    ...
   )
-  # Replace dots between coefficient names by double underscores:
-  coef_nms <- lapply(group_vc_raw, rownames)
-  for (coef_nms_i in coef_nms) {
-    coef_nms_i <- replace_intercept_name(coef_nms_i)
-    names(group_vc) <- gsub(
-      paste0(
-        "(",
-        paste(gsub("\\.", "\\\\.", coef_nms_i),
-              collapse = "|"),
-        ")\\."
-      ),
-      "\\1__",
-      names(group_vc)
-    )
-  }
 
   # Extract the group-level effects themselves:
   group_ef <- unlist(lapply(lme4::ranef(x), function(ranef_df) {
@@ -938,29 +986,11 @@ get_subparams.lmerMod <- function(x, ...) {
             })
     )
   }))
-
-  # Use brms's naming convention:
-  names(group_ef) <- replace_intercept_name(names(group_ef))
-  names(group_ef) <- paste0("r_", names(group_ef))
-  for (coef_nms_idx in seq_along(coef_nms)) {
-    group_nm_i <- names(coef_nms)[coef_nms_idx]
-    coef_nms_i <- coef_nms[[coef_nms_idx]]
-    coef_nms_i <- replace_intercept_name(coef_nms_i)
-    # Put the part following the group name in square brackets, reorder its two
-    # subparts (coefficient name and group level) and separate them by comma:
-    names(group_ef) <- sub(
-      paste0(
-        "(",
-        gsub("\\.", "\\\\.", group_nm_i),
-        ")\\.(",
-        paste(gsub("\\.", "\\\\.", coef_nms_i),
-              collapse = "|"),
-        ")\\.(.*)$"
-      ),
-      "\\1[\\3,\\2]",
-      names(group_ef)
-    )
-  }
+  names(group_ef) <- replace_ranef_names(
+    names(group_ef),
+    coef_nms = lapply(group_vc_raw, rownames),
+    ...
+  )
 
   return(c(population_effects, group_vc, group_ef))
 }
@@ -985,6 +1015,9 @@ get_subparams.gamm4 <- function(x, ...) {
 #'
 #' @param x An object of class `projection` (returned by [project()], possibly
 #'   as elements of a `list`).
+#' @param nm_scheme The naming scheme for the columns of the output matrix.
+#'   Either `"auto"`, `"rstanarm"`, or `"brms"`, where `"auto"` chooses
+#'   `"rstanarm"` or `"brms"` based on the class of the reference model fit.
 #' @param ... Currently ignored.
 #'
 #' @return An \eqn{S_{\mbox{prj}} \times Q}{S_prj x Q} matrix of projected
@@ -1039,7 +1072,7 @@ get_subparams.gamm4 <- function(x, ...) {
 #'
 #' @method as.matrix projection
 #' @export
-as.matrix.projection <- function(x, ...) {
+as.matrix.projection <- function(x, nm_scheme = "auto", ...) {
   if (inherits(x$refmodel, "datafit")) {
     stop("as.matrix.projection() does not work for objects based on ",
          "\"datafit\"s.")
@@ -1048,7 +1081,15 @@ as.matrix.projection <- function(x, ...) {
     warning("Note that projection was performed using clustering and the ",
             "clusters might have different weights.")
   }
-  res <- do.call(rbind, lapply(x$submodl, get_subparams))
+  if (identical(nm_scheme, "auto")) {
+    if (inherits(x$refmodel$fit, "stanreg")) {
+      nm_scheme <- "rstanarm"
+    } else if (inherits(x$refmodel$fit, "brmsfit")) {
+      nm_scheme <- "brms"
+    }
+  }
+  stopifnot(nm_scheme %in% c("rstanarm", "brms"))
+  res <- do.call(rbind, lapply(x$submodl, get_subparams, nm_scheme = nm_scheme))
   if (x$refmodel$family$family == "gaussian") res <- cbind(res, sigma = x$dis)
   return(res)
 }

--- a/R/methods.R
+++ b/R/methods.R
@@ -803,11 +803,11 @@ suggest_size.vsel <- function(
   return(suggested_size - 1) ## substract the intercept
 }
 
-replace_intercept_name <- function(names, nm_scheme) {
+replace_intercept_name <- function(nms, nm_scheme) {
   if (nm_scheme == "brms") {
-    names <- gsub("\\(Intercept\\)", "Intercept", names)
+    nms <- gsub("\\(Intercept\\)", "Intercept", nms)
   }
-  return(names)
+  return(nms)
 }
 
 replace_population_names <- function(population_effects, nm_scheme) {

--- a/man/as.matrix.projection.Rd
+++ b/man/as.matrix.projection.Rd
@@ -12,7 +12,8 @@ as elements of a \code{list}).}
 
 \item{nm_scheme}{The naming scheme for the columns of the output matrix.
 Either \code{"auto"}, \code{"rstanarm"}, or \code{"brms"}, where \code{"auto"} chooses
-\code{"rstanarm"} or \code{"brms"} based on the class of the reference model fit.}
+\code{"rstanarm"} or \code{"brms"} based on the class of the reference model fit (and
+uses \code{"rstanarm"} if the reference model fit is of an unknown class).}
 
 \item{...}{Currently ignored.}
 }

--- a/man/as.matrix.projection.Rd
+++ b/man/as.matrix.projection.Rd
@@ -4,11 +4,15 @@
 \alias{as.matrix.projection}
 \title{Extract projected parameter draws}
 \usage{
-\method{as.matrix}{projection}(x, ...)
+\method{as.matrix}{projection}(x, nm_scheme = "auto", ...)
 }
 \arguments{
 \item{x}{An object of class \code{projection} (returned by \code{\link[=project]{project()}}, possibly
 as elements of a \code{list}).}
+
+\item{nm_scheme}{The naming scheme for the columns of the output matrix.
+Either \code{"auto"}, \code{"rstanarm"}, or \code{"brms"}, where \code{"auto"} chooses
+\code{"rstanarm"} or \code{"brms"} based on the class of the reference model fit.}
 
 \item{...}{Currently ignored.}
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -797,26 +797,26 @@ args_prj <- lapply(tstsetups_prj_ref, function(tstsetup_ref) {
   pkg_crr <- args_ref[[tstsetup_ref]]$pkg_nm
   mod_crr <- args_ref[[tstsetup_ref]]$mod_nm
   fam_crr <- args_ref[[tstsetup_ref]]$fam_nm
+  if (grepl("\\.spclformul", tstsetup_ref)) {
+    solterms_x <- solterms_spcl
+  }
   solterms <- nlist(empty = character(), solterms_x)
-  if (!grepl("\\.spclformul", tstsetup_ref)) {
-    if (mod_crr %in% c("glmm", "gamm")) {
-      solterms <- c(solterms,
-                    nlist(solterms_z, solterms_xz = c(solterms_x, solterms_z)))
-    }
-    if (mod_crr %in% c("gam", "gamm")) {
-      solterms <- c(solterms,
-                    nlist(solterms_s, solterms_xs = c(solterms_x, solterms_s)))
-    }
-    if (mod_crr == "gamm") {
-      solterms <- c(solterms,
-                    nlist(solterms_sz = c(solterms_s, solterms_z),
-                          solterms_xsz = c(solterms_x, solterms_s, solterms_z)))
-    }
-    if (!run_more && fam_crr != "gauss") {
-      solterms <- tail(solterms, 1)
-    }
-  } else {
-    solterms <- nlist(solterms_spcl)
+  if (mod_crr %in% c("glmm", "gamm")) {
+    solterms <- c(solterms,
+                  nlist(solterms_z, solterms_xz = c(solterms_x, solterms_z)))
+  }
+  if (mod_crr %in% c("gam", "gamm")) {
+    solterms <- c(solterms,
+                  nlist(solterms_s, solterms_xs = c(solterms_x, solterms_s)))
+  }
+  if (mod_crr == "gamm") {
+    solterms <- c(solterms,
+                  nlist(solterms_sz = c(solterms_s, solterms_z),
+                        solterms_xsz = c(solterms_x, solterms_s, solterms_z)))
+  }
+  if (!run_more &&
+      (fam_crr != "gauss" || grepl("\\.spclformul", tstsetup_ref))) {
+    solterms <- tail(solterms, 1)
   }
   lapply(setNames(nm = names(solterms)), function(solterms_nm_i) {
     if (pkg_crr == "rstanarm" && mod_crr == "glm" &&

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -18,6 +18,7 @@ test_that("as.matrix.projection() works", {
     tstsetup_ref <- args_prj[[tstsetup]]$tstsetup_ref
     mod_crr <- args_prj[[tstsetup]]$mod_nm
     fam_crr <- args_prj[[tstsetup]]$fam_nm
+    pkg_crr <- args_prj[[tstsetup]]$pkg_nm
     solterms <- args_prj[[tstsetup]]$solution_terms
     ndr_ncl <- ndr_ncl_dtls(args_prj[[tstsetup]])
 
@@ -38,8 +39,12 @@ test_that("as.matrix.projection() works", {
       npars_fam <- character()
     }
 
+    icpt_nm <- "Intercept"
+    if (pkg_crr == "rstanarm") {
+      icpt_nm <- paste0("(", icpt_nm, ")")
+    }
     colnms_prjmat_expect <- c(
-      "Intercept",
+      icpt_nm,
       grep("\\|", grep("x(co|ca)\\.[[:digit:]]", solterms, value = TRUE),
            value = TRUE, invert = TRUE)
     )
@@ -71,7 +76,9 @@ test_that("as.matrix.projection() works", {
         }))
       )
     }
-    colnms_prjmat_expect <- paste0("b_", colnms_prjmat_expect)
+    if (pkg_crr == "brms") {
+      colnms_prjmat_expect <- paste0("b_", colnms_prjmat_expect)
+    }
     if ("(1 | z.1)" %in% solterms) {
       colnms_prjmat_expect <- c(colnms_prjmat_expect, "sd_z.1__Intercept")
       colnms_prjmat_expect <- c(

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -29,7 +29,7 @@ test_that("as.matrix.projection() works", {
     } else {
       warn_prjmat_expect <- NA
     }
-    expect_warning(m <- as.matrix(prjs[[tstsetup]], nm_scheme = "brms"),
+    expect_warning(m <- as.matrix(prjs[[tstsetup]]),
                    warn_prjmat_expect, info = tstsetup)
 
     if (fam_crr == "gauss") {
@@ -188,7 +188,7 @@ if (run_snaps) {
         prjs_vs_l <- list(prjs_vs_l)
       }
       res_vs <- lapply(prjs_vs_l, function(prjs_vs_i) {
-        expect_warning(m <- as.matrix(prjs_vs_i, nm_scheme = "brms"),
+        expect_warning(m <- as.matrix(prjs_vs_i),
                        warn_prjmat_expect, info = tstsetup)
         expect_snapshot({
           print(tstsetup)
@@ -234,7 +234,7 @@ if (run_snaps) {
         prjs_cvvs_l <- list(prjs_cvvs_l)
       }
       res_cvvs <- lapply(prjs_cvvs_l, function(prjs_cvvs_i) {
-        expect_warning(m <- as.matrix(prjs_cvvs_i, nm_scheme = "brms"),
+        expect_warning(m <- as.matrix(prjs_cvvs_i),
                        warn_prjmat_expect, info = tstsetup)
         expect_snapshot({
           print(tstsetup)

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -80,22 +80,45 @@ test_that("as.matrix.projection() works", {
       colnms_prjmat_expect <- paste0("b_", colnms_prjmat_expect)
     }
     if ("(1 | z.1)" %in% solterms) {
-      colnms_prjmat_expect <- c(colnms_prjmat_expect, "sd_z.1__Intercept")
-      colnms_prjmat_expect <- c(
-        colnms_prjmat_expect,
-        paste0("r_z.1[lvl", seq_len(nlvl_ran[1]), ",Intercept]")
-      )
+      if (pkg_crr == "brms") {
+        colnms_prjmat_expect <- c(colnms_prjmat_expect, "sd_z.1__Intercept")
+        colnms_prjmat_expect <- c(
+          colnms_prjmat_expect,
+          paste0("r_z.1[lvl", seq_len(nlvl_ran[1]), ",Intercept]")
+        )
+      } else if (pkg_crr == "rstanarm") {
+        colnms_prjmat_expect <- c(colnms_prjmat_expect,
+                                  "Sigma[z.1:(Intercept),(Intercept)]")
+        colnms_prjmat_expect <- c(
+          colnms_prjmat_expect,
+          paste0("b[(Intercept) z.1:lvl", seq_len(nlvl_ran[1]), "]")
+        )
+      }
     }
     if ("(xco.1 | z.1)" %in% solterms) {
-      colnms_prjmat_expect <- c(colnms_prjmat_expect, "sd_z.1__xco.1")
-      colnms_prjmat_expect <- c(
-        colnms_prjmat_expect,
-        paste0("r_z.1[lvl", seq_len(nlvl_ran[1]), ",xco.1]")
-      )
+      if (pkg_crr == "brms") {
+        colnms_prjmat_expect <- c(colnms_prjmat_expect, "sd_z.1__xco.1")
+        colnms_prjmat_expect <- c(
+          colnms_prjmat_expect,
+          paste0("r_z.1[lvl", seq_len(nlvl_ran[1]), ",xco.1]")
+        )
+      } else if (pkg_crr == "rstanarm") {
+        colnms_prjmat_expect <- c(colnms_prjmat_expect,
+                                  "Sigma[z.1:xco.1,xco.1]")
+        colnms_prjmat_expect <- c(
+          colnms_prjmat_expect,
+          paste0("b[xco.1 z.1:lvl", seq_len(nlvl_ran[1]), "]")
+        )
+      }
     }
     if (all(c("(1 | z.1)", "(xco.1 | z.1)") %in% solterms)) {
-      colnms_prjmat_expect <- c(colnms_prjmat_expect,
-                                "cor_z.1__Intercept__xco.1")
+      if (pkg_crr == "brms") {
+        colnms_prjmat_expect <- c(colnms_prjmat_expect,
+                                  "cor_z.1__Intercept__xco.1")
+      } else if (pkg_crr == "rstanarm") {
+        colnms_prjmat_expect <- c(colnms_prjmat_expect,
+                                  "Sigma[z.1:xco.1,(Intercept)]")
+      }
     }
     s_nms <- sub("\\)$", "",
                  sub("^s\\(", "",

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -29,7 +29,7 @@ test_that("as.matrix.projection() works", {
     } else {
       warn_prjmat_expect <- NA
     }
-    expect_warning(m <- as.matrix(prjs[[tstsetup]]),
+    expect_warning(m <- as.matrix(prjs[[tstsetup]], nm_scheme = "brms"),
                    warn_prjmat_expect, info = tstsetup)
 
     if (fam_crr == "gauss") {
@@ -188,7 +188,7 @@ if (run_snaps) {
         prjs_vs_l <- list(prjs_vs_l)
       }
       res_vs <- lapply(prjs_vs_l, function(prjs_vs_i) {
-        expect_warning(m <- as.matrix(prjs_vs_i),
+        expect_warning(m <- as.matrix(prjs_vs_i, nm_scheme = "brms"),
                        warn_prjmat_expect, info = tstsetup)
         expect_snapshot({
           print(tstsetup)
@@ -234,7 +234,7 @@ if (run_snaps) {
         prjs_cvvs_l <- list(prjs_cvvs_l)
       }
       res_cvvs <- lapply(prjs_cvvs_l, function(prjs_cvvs_i) {
-        expect_warning(m <- as.matrix(prjs_cvvs_i),
+        expect_warning(m <- as.matrix(prjs_cvvs_i, nm_scheme = "brms"),
                        warn_prjmat_expect, info = tstsetup)
         expect_snapshot({
           print(tstsetup)

--- a/tests/testthat/test_project.R
+++ b/tests/testthat/test_project.R
@@ -381,7 +381,7 @@ test_that("for GLMs, `regul` has an expected effect", {
       } else {
         warn_prjmat_expect <- NA
       }
-      expect_warning(prjmat <- as.matrix(prj_regul),
+      expect_warning(prjmat <- as.matrix(prj_regul, nm_scheme = "brms"),
                      warn_prjmat_expect, info = tstsetup)
 
       # Reduce to only those columns which are necessary here:

--- a/vignettes/projpred.Rmd
+++ b/vignettes/projpred.Rmd
@@ -173,7 +173,7 @@ For more accurate results, we could have increased argument `ndraws` of `project
 
 Next, we create a matrix containing the projected posterior draws stored in the depths of `project()`'s output:
 ```{r}
-prj_mat <- as.matrix(prj)
+prj_mat <- as.matrix(prj, nm_scheme = "brms")
 ```
 This matrix is all we need for post-selection inference. It can be used like any matrix of draws from MCMC procedures, except that it doesn't reflect a typical posterior distribution, but rather a projected posterior distribution, i.e., the distribution arising from the deterministic projection of the reference model's posterior distribution onto the parameter space of the final submodel.
 

--- a/vignettes/projpred.Rmd
+++ b/vignettes/projpred.Rmd
@@ -173,7 +173,7 @@ For more accurate results, we could have increased argument `ndraws` of `project
 
 Next, we create a matrix containing the projected posterior draws stored in the depths of `project()`'s output:
 ```{r}
-prj_mat <- as.matrix(prj, nm_scheme = "brms")
+prj_mat <- as.matrix(prj)
 ```
 This matrix is all we need for post-selection inference. It can be used like any matrix of draws from MCMC procedures, except that it doesn't reflect a typical posterior distribution, but rather a projected posterior distribution, i.e., the distribution arising from the deterministic projection of the reference model's posterior distribution onto the parameter space of the final submodel.
 
@@ -204,12 +204,7 @@ Note that we only visualize the *1-dimensional* marginals of the projected poste
 For comparison, consider the marginal posteriors of the corresponding parameters in the reference model:
 ```{r}
 refm_mat <- as.matrix(refm_fit)
-pars_nms_refm <- c(
-  "(Intercept)",
-  sub("^b_", "", grep("^b_X", colnames(prj_mat), value = TRUE)),
-  "sigma"
-)
-mcmc_intervals(refm_mat, pars = pars_nms_refm) +
+mcmc_intervals(refm_mat, pars = colnames(prj_mat)) +
   ggplot2::coord_cartesian(xlim = c(-1.5, 1.6))
 ```
 


### PR DESCRIPTION
This makes the scheme for naming the columns (i.e., the parameters) of `as.matrix.projection()`'s output matrix dependent on the package used for fitting the reference model: For brms reference models, brms's naming scheme is used; for rstanarm reference models, rstanarm's naming scheme is used. If the reference model fit is of unknown class, rstanarm's naming scheme is used. The user can also set the naming scheme manually, using `as.matrix.projection()`'s new argument `nm_scheme`.

This was already mentioned in [this comment in issue #152](https://github.com/stan-dev/projpred/issues/152#issue-918920675) and was now requested by @avehtari.