### PR TITLE
Update `NEWS`, bump version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: projpred
 Encoding: UTF-8
 Title: Projection Predictive Feature Selection
-Version: 2.0.5.9000
-Date: 2021-09-21
+Version: 2.1.0
+Date: 2022-02-17
 Authors@R: c(person("Juho", "Piironen", role = c("aut"),
                     email = "juho.t.piironen@gmail.com"),
              person("Markus", "Paasiniemi", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,27 +13,33 @@
 * The fix for the offset issues (listed below under "Bug fixes") requires reference model fits of class `stanreg` (from package **rstanarm**) with offsets to have these offsets specified via an `offset()` term in the model formula (and not via argument `offset`).
 * Improved handling of errors when fitting multilevel submodels. (GitHub: #201)
 * Some defaults (like for `ndraws`, `nclusters`, `ndraws_pred`, and `nclusters_pred` mentioned above) have been changed from `NULL` to a user-visible value (and `NULL` is not allowed anymore).
-* Argument `data` of `get_refmodel.stanreg()` has been removed. (GitHub: <INSERT_PR_NUMBER_FOR_refmodel>)
-* The function passed to argument `div_minimizer` of `init_refmodel()` now always needs to return a `list` of submodels (see the documentation for details). Correspondingly, the function passed to argument `proj_predfun` of `init_refmodel()` can now always expect a `list` as input for argument `fit` (see the documentation for details). (GitHub: <INSERT_PR_NUMBER_FOR_divmin>)
-* The function passed to argument `proj_predfun` of `init_refmodel()` now always needs to return a matrix (see the documentation for details). (GitHub: <INSERT_PR_NUMBER_FOR_divmin>)
+* Argument `data` of `get_refmodel.stanreg()` has been removed. (GitHub: #219)
+* The function passed to argument `div_minimizer` of `init_refmodel()` now always needs to return a `list` of submodels (see the documentation for details). Correspondingly, the function passed to argument `proj_predfun` of `init_refmodel()` can now always expect a `list` as input for argument `fit` (see the documentation for details). (GitHub: #230)
+* The function passed to argument `proj_predfun` of `init_refmodel()` now always needs to return a matrix (see the documentation for details). (GitHub: #230)
+* The projection can be run in parallel now. However, we cannot recommend this for all kinds of platforms and all kinds of models. For more information, see the general package documentation available at ``?`projpred-package` ``. (GitHub: #235)
+* In case of the Student-*t* family, a warning is thrown when creating the reference model. The reason is that this family has not been tested thoroughly and might be implemented incorrectly (see GitHub issue #233). Use it at your own risk. (GitHub: #233, <INSERT_PR_NUMBER_FOR_warn_student_t>)
+* Subsampled LOO CV (offered by argument `nloo` of `cv_varsel()`) might be implemented incorrectly (see GitHub issue #94). Use it at your own risk. (GitHub: #94, <INSERT_PR_NUMBER_FOR_warn_subsampled_loo>)
 
 ## Minor changes
 
-* Improved documentation. (GitHub: especially <INSERT_PR_NUMBER_FOR_docs>)
-* Replaced the two former vignettes by a single new one. (GitHub: especially <INSERT_PR_NUMBER_FOR_upd_vignettes>)
-* Some error and warning messages have been improved and added. (GitHub: especially <INSERT_PR_NUMBER_FOR_refmodel>, <INSERT_PR_NUMBER_FOR_binom_fixes>, <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
+* Improved documentation. (GitHub: especially #233)
+* Replaced the two vignettes by a single one which also has new content. (GitHub: #237)
+* Updated the `README` file. (GitHub: <INSERT_PR_NUMBER_FOR_upd_readme>)
+* Some error and warning messages have been improved and added. (GitHub: especially #219, #221, #223)
 * For K-fold cross-validation, an internally hard-coded value of 5 for `nclusters_pred` was removed. (GitHub: commit 5062f2f)
 * Throw a proper error message for unsupported families. (GitHub: #140)
 * Show the README also on the CRAN website. (GitHub: #140)
 * `project()`: Warn if elements of `solution_terms` are not found in the reference model (and therefore ignored). (GitHub: #140)
 * `get_refmodel.default()` now passes arguments via the ellipsis (`...`) to `init_refmodel()`. (GitHub: #153, commit dd3716e)
 * Remove dependency on package **rngtools** (version 2.0.0 of **projpred** re-introduced this dependency after it was already removed in version 1.1.2). (GitHub: #189)
-* `init_refmodel()`: The default (`NULL`) for argument `extract_model_data` has been removed as it wasn't meaningful anyway. (GitHub: <INSERT_PR_NUMBER_FOR_refmodel>)
-* Argument `folds` of `init_refmodel()` has been removed as it was effectively unused. (GitHub: <INSERT_PR_NUMBER_FOR_folds_rm>)
-* Use the S3 system for `solution_terms()`. This allowed the introduction of a `solution_terms.projection()` method. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
-* `predict.refmodel()` now uses a default of `newdata = NULL`. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
-* **projpred**'s internal `div_minimizer` functions have been unified into a single `div_minimizer` which chooses an appropriate submodel fitter based on the formula of the submodel, not based on that of the reference model. Furthermore, the automatic handling of errors in the submodel fitters has been improved. (GitHub: <INSERT_PR_NUMBER_FOR_divmin>)
-* Improved the y-axis label in `plot.vsel()`.
+* `init_refmodel()`: The default (`NULL`) for argument `extract_model_data` has been removed as it wasn't meaningful anyway. (GitHub: #219)
+* Argument `folds` of `init_refmodel()` has been removed as it was effectively unused. (GitHub: #220)
+* Use the S3 system for `solution_terms()`. This allowed the introduction of a `solution_terms.projection()` method. (GitHub: #223)
+* `predict.refmodel()` now uses a default of `newdata = NULL`. (GitHub: #223)
+* Argument `weights` of `init_refmodel()`'s argument `proj_predfun` was removed. (GitHub: #163, #224)
+* **projpred**'s internal `div_minimizer` functions have been unified into a single `div_minimizer` which chooses an appropriate submodel fitter based on the formula of the submodel, not based on that of the reference model. Furthermore, the automatic handling of errors in the submodel fitters has been improved. (GitHub: #230)
+* Improved the y-axis label in `plot.vsel()`. (GitHub: #234)
+* Handle **rstanarm**'s GitHub issue #551. This implies that **projpred**'s default `cvfun` for `stanreg` fits will now always use *inner* parallelization in `rstanarm::kfold()` (i.e., across chains, not across CV folds), with `getOption("mc.cores", 1)` cores. We do so on all systems (not only Windows). (GitHub: <INSERT_PR_NUMBER_FOR_cvfun_rstanarm>)
 
 ### Bug fixes
 
@@ -72,17 +78,18 @@
 * Fix a bug in `cv_varsel()$pct_solution_terms_cv`. (GitHub: commit e529ec1, #188)
 * Fix GitHub issue #185. (GitHub: #193, #194)
 * Fix a bug in forward searches with interaction terms. (GitHub: #191)
-* Fix offset issues. (GitHub: #196, #203, <INSERT_PR_NUMBER_FOR_PR196_predict_fix>)
+* Fix offset issues. (GitHub: #196, #203, #228)
 * Fix a bug in `glm_elnet()` (the workhorse for L1 search), causing the grid for lambda to be constructed without taking observation weights into account. (GitHub: #198; note that the second part of #198 did not have any consequences for users)
-* Fix GitHub issue #136.
-* Fix a bug in `print.vsel()` causing argument `digits` to be ignored. (GitHub: <INSERT_PR_NUMBER_FOR_digits_fix>)
-* Fix a bug causing the default of argument `cv_search` in `varsel()` and `cv_varsel()` to be `TRUE` for `datafit`s, although it should be `FALSE` in that case. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
-* Fix a bug (`Error: Levels '<...>' of grouping factor '<...>' cannot be found in the fitted model. Consider setting argument 'allow_new_levels' to TRUE.`) when predicting from submodels which are GLMMs for `newdata` containing new levels for grouping factors. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
-* `predict.refmodel()`: Fix a bug for integer `ynew`. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
-* `predict.refmodel()`: Fix input checks for `offsetnew` and `weightsnew`. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
-* After all calls to `extract_model_data()`, the weights and offsets are now checked if they are of length 0 (and if yes, then they are set to vectors of ones and zeros, respectively). This is important for `extract_model_data()` functions which return weights and offsets of length 0 (see, e.g., `brms` version <= 2.16.1). (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
-* Handle `rstanarm`'s GitHub issue #546. (GitHub: <INSERT_PR_NUMBER_FOR_offs_gam_fix>)
-* Fix a bug causing the internal submodel fitter for GLMMs to not pass arguments `var` (the predictive variances) and `regul` (amount of ridge regularization) to the internal submodel fitter for GLMs. (GitHub: <INSERT_PR_NUMBER_FOR_divmin>)
+* Fix GitHub issue #136. (GitHub: #221)
+* Fix a bug in `print.vsel()` causing argument `digits` to be ignored. (GitHub: #222)
+* Fix a bug causing the default of argument `cv_search` in `varsel()` and `cv_varsel()` to be `TRUE` for `datafit`s, although it should be `FALSE` in that case. (GitHub: #223)
+* Fix a bug (`Error: Levels '<...>' of grouping factor '<...>' cannot be found in the fitted model. Consider setting argument 'allow_new_levels' to TRUE.`) when predicting from submodels which are GLMMs for `newdata` containing new levels for grouping factors. (GitHub: #223)
+* `predict.refmodel()`: Fix a bug for integer `ynew`. (GitHub: #223)
+* `predict.refmodel()`: Fix input checks for `offsetnew` and `weightsnew`. (GitHub: #223)
+* After all calls to `extract_model_data()`, the weights and offsets are now checked if they are of length 0 (and if yes, then they are set to vectors of ones and zeros, respectively). This is important for `extract_model_data()` functions which return weights and offsets of length 0 (see, e.g., `brms` version <= 2.16.1). (GitHub: #223)
+* Handle **rstanarm**'s GitHub issue #546. (GitHub: #227)
+* Fix a bug causing the internal submodel fitter for GLMMs to not pass arguments `var` (the predictive variances) and `regul` (amount of ridge regularization) to the internal submodel fitter for GLMs. (GitHub: #230)
+* Fix GitHub issue #210. (GitHub: #234)
 
 ## projpred 2.0.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -152,7 +152,7 @@
 
 We have fully rewritten the internals in several ways. Most importantly, we now leverage maximum likelihood estimation to third parties depending on the reference model's family. This allows a lot of flexibility and extensibility for various models. Functionality wise, the major updates since the last release are:
 
-* Added support for GLMMs and GAMMs via ```lme4``` and ```gamm4```.
+* Added support for GLMMs and GAMMs via **lme4** and **gamm4**.
 * Formula syntax support internally that allows for easier building upon projections.
 * Thanks to the above point, we save some computation by only considering sensible projections during forward search instead of fitting every possible submodel.
 * We have added a new argument ```search_terms``` that allows the user to specify custom unit building blocks of the projections. New vignette coming up.
@@ -178,11 +178,11 @@ This version contains only a few patches, no new features to the user.
 
 ## New features 
 
-* Added support for ```brms``` models. 
+* Added support for **brms** models. 
 
 ## Bug fixes
 
-* The program crashed with ```rstanarm``` models fitted with syntax like ```stan_glm(log(y) ~ log(x), ...)```, that is, it did not allow transformation for ```y```.
+* The program crashed with **rstanarm** models fitted with syntax like ```stan_glm(log(y) ~ log(x), ...)```, that is, it did not allow transformation for ```y```.
 
 # projpred 1.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -181,23 +181,18 @@ This version contains only a few patches, no new features to the user.
 * Added support for ```brms``` models. 
 
 ## Bug fixes
-* The program crashed with ```rstanarm``` models fitted with syntax like ```stan_glm(log(y) ~ log(x), ...)```, that is, it did not allow transformation for ```y```.
 
+* The program crashed with ```rstanarm``` models fitted with syntax like ```stan_glm(log(y) ~ log(x), ...)```, that is, it did not allow transformation for ```y```.
 
 # projpred 1.0.0
 
-## New features and improvements ###
+## New features and improvements
 
 * Changed the internals so that now all fit objects (such as rstanarm fits) are converted to ```refmodel```-objects using the generic ```get_refmodel```-function, and all the functions use only this object. This makes it much easier to use projpred with other reference models by writing them a new ```get_refmodel```-function. The syntax is now changed so that  ```varsel``` and ```cv_varsel``` both return an object that has similar structure always, and the reference model is stored into this object.
-
 * Added more examples to the vignette.
-
 * Added possibility to change the baseline in ```plot/summary```. Now it is possible to compare also to the best submodel found, not only to the reference model.
-
 * Bug fix: RMSE was previously computed wrong, this is now fixed.
-
 * Small changes: ```nloo = n``` by default in ```cv_varsel```. ```regul=1e-4``` now by default in all functions.
-
 
 # projpred 0.9.0
 
@@ -208,7 +203,6 @@ This version contains only a few patches, no new features to the user.
 ## Bug fixes
 
 * The projection with a nonzero regularization parameter value did not produce exactly correct result, although the difference to the correct result was often so small that user would not see the difference. Fixed this.
-
 
 # projpred 0.8.0 and earlier
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
-## projpred 2.0.5.9000
+# projpred 2.0.5.9000
 
-### Major (breaking) changes
+## Major (breaking) changes
 
 * The behavior of arguments `ndraws`, `nclusters`, `ndraws_pred`, and `nclusters_pred` in `varsel()`, `cv_varsel()`, and `project()` has been changed: Now, `ndraws` and `ndraws_pred` have non-`NULL` defaults and for `ndraws <= 20` or `ndraws_pred <= 20`, the value of `ndraws` or `ndraws_pred` is passed to `nclusters` or `nclusters_pred`, respectively (so that clustering is used). (GitHub: commits babe031, 4ef95d3, and ce7d1e0)
 * For `proj_linpred()` and `proj_predict()`, arguments `nterms`, `ndraws`, and `seed` have been removed to allow the user to pass them to `project()`. New arguments `filter_nterms`, `nresample_clusters`, and `.seed` have been introduced (see the documentation for details). (GitHub: #92, #135)
@@ -18,7 +18,7 @@
 * In case of the Student-*t* family, a warning is thrown when creating the reference model. The reason is that this family has not been tested thoroughly and might be implemented incorrectly (see GitHub issue #233). Use it at your own risk. (GitHub: #233, <INSERT_PR_NUMBER_FOR_warn_student_t>)
 * Subsampled LOO CV (offered by argument `nloo` of `cv_varsel()`) might be implemented incorrectly (see GitHub issue #94). Use it at your own risk. (GitHub: #94, <INSERT_PR_NUMBER_FOR_warn_subsampled_loo>)
 
-## Minor changes
+# Minor changes
 
 * Improved documentation. (GitHub: especially #233)
 * Replaced the two vignettes by a single one which also has new content. (GitHub: #237)
@@ -39,7 +39,7 @@
 * Improved the y-axis label in `plot.vsel()`. (GitHub: #234)
 * Handle **rstanarm**'s GitHub issue #551. This implies that **projpred**'s default `cvfun` for `stanreg` fits will now always use *inner* parallelization in `rstanarm::kfold()` (i.e., across chains, not across CV folds), with `getOption("mc.cores", 1)` cores. We do so on all systems (not only Windows). (GitHub: <INSERT_PR_NUMBER_FOR_cvfun_rstanarm>)
 
-### Bug fixes
+## Bug fixes
 
 * Fixed a bug when using weights or offsets e.g. in `proj_linpred()`. (GitHub: #114)
 * Fixed a bug causing `varsel()`/`make_formula` to fail with multidimensional interaction terms. (GitHub: #102, #103)
@@ -89,14 +89,14 @@
 * Fix a bug causing the internal submodel fitter for GLMMs to not pass arguments `var` (the predictive variances) and `regul` (amount of ridge regularization) to the internal submodel fitter for GLMs. (GitHub: #230)
 * Fix GitHub issue #210. (GitHub: #234)
 
-## projpred 2.0.5
+# projpred 2.0.5
 
-### Minor changes
+## Minor changes
 
 * For GLMMs, the column names of the matrix returned by the `as.matrix.projection()` method follow [**brms**](https://paul-buerkner.github.io/brms/)'s naming convention, also for the new columns introduced by **projpred** version 2.0.4 (see below). (GitHub: #82)
 * Internally, the seed is not fixed to a specific value when `NULL`. (GitHub: #84)
 
-### Bug fixes
+## Bug fixes
 
 * Fixed a bug raising an error when not projecting from a `vsel` object. (GitHub: #79, #80)
 * Fixed a bug in the calculation of the Gaussian deviance. (GitHub: #81)
@@ -111,7 +111,7 @@
 * Fixed an inconsistency in the dimensions of `proj_linpred()`'s output elements `pred` and `lpd` (for `integrated = FALSE`): Now, they are both S x N matrices, with S denoting the number of (possibly clustered) posterior draws and N denoting the number of observations. (GitHub: #107, #112)
 * Fixed a bug causing `proj_predict()`'s output matrix to be transposed in case of `nrow(newdata) == 1`. (GitHub: #112)
 
-## projpred 2.0.4
+# projpred 2.0.4
 
 * Added support for weighted LOO proportional-to-size subsampling based on Magnusson, M., Riis Andersen, M., Jonasson, J. and Vehtari, A. (2019). Leave-One-Out Cross-Validation for Large Data. In International Conference on Machine Learning.
 * Automatically explore both linear and smooths components in GAM models. This allows the user to gauge the impact of the smooth term against its linear counterpart. 
@@ -121,19 +121,19 @@
 * For group-level effects, the `as.matrix.projection()` method now also returns the estimated group-level effects themselves. (GitHub: #75)
 * For group-level effects, the `as.matrix.projection()` method now returns the variance components (population SD(s) and population correlation(s)) instead of the empirical SD(s) of the group-level effects. (GitHub: #74)
 
-### Bug fixes
+## Bug fixes
 
 * Fixed a bug in the handling of arguments `ndraws` and `nclusters` in `varsel()` and `cv_varsel()`. (GitHub: commit bbd0f0a)
 * Fixed a bug in `as.matrix.projection()` (causing incorrect column names for the returned matrix). (GitHub: #72, #73)
 
-## projpred 2.0.3
+# projpred 2.0.3
 
 * Minor fixes for stability, no new features.
 * The (internally set) default for argument `nclusters` of `varsel()` and `cv_varsel()` was increased from 1 to 10.
 * The (internally set) default for argument `nclusters_pred` of `varsel()` and `cv_varsel()` was increased from 5 to 400.
 * In `varsel()` and `cv_varsel()`, always perform clustering of the posterior draws (argument `ndraws` is effectively ignored). (GitHub: starting with commit 80b10dc)
 
-## projpred 2.0.2
+# projpred 2.0.2
 
 We have fully rewritten the internals in several ways. Most importantly, we now leverage maximum likelihood estimation to third parties depending on the reference model's family. This allows a lot of flexibility and extensibility for various models. Functionality wise, the major updates since the last release are:
 
@@ -143,35 +143,35 @@ We have fully rewritten the internals in several ways. Most importantly, we now 
 * We have added a new argument ```search_terms``` that allows the user to specify custom unit building blocks of the projections. New vignette coming up.
 * We have fully changed the way to define custom reference models. The user now provides projection fitting and prediction functions (more information in a new upcoming vignette).
 
-## projpred 1.1.4
+# projpred 1.1.4
 
 Better validation of function arguments.
 
-## projpred 1.1.3
+# projpred 1.1.3
 
 Added print methods for vsel and cvsel objects. Added AUC statistics for binomial family. A few additional minor patches.
 
-## projpred 1.1.2
+# projpred 1.1.2
 
 Removed the dependency on the **rngtools** package.
 
-## projpred 1.1.1
+# projpred 1.1.1
 
 This version contains only a few patches, no new features to the user.
 
-## projpred 1.1.0
+# projpred 1.1.0
 
-### New features 
+## New features 
 
 * Added support for ```brms``` models. 
 
-### Bug fixes
+## Bug fixes
 * The program crashed with ```rstanarm``` models fitted with syntax like ```stan_glm(log(y) ~ log(x), ...)```, that is, it did not allow transformation for ```y```.
 
 
-## projpred 1.0.0
+# projpred 1.0.0
 
-### New features and improvements ###
+## New features and improvements ###
 
 * Changed the internals so that now all fit objects (such as rstanarm fits) are converted to ```refmodel```-objects using the generic ```get_refmodel```-function, and all the functions use only this object. This makes it much easier to use projpred with other reference models by writing them a new ```get_refmodel```-function. The syntax is now changed so that  ```varsel``` and ```cv_varsel``` both return an object that has similar structure always, and the reference model is stored into this object.
 
@@ -184,17 +184,17 @@ This version contains only a few patches, no new features to the user.
 * Small changes: ```nloo = n``` by default in ```cv_varsel```. ```regul=1e-4``` now by default in all functions.
 
 
-## projpred 0.9.0
+# projpred 0.9.0
 
-### New features and improvements
+## New features and improvements
 
 * Added the ```cv_search``` argument for the main functions (```varsel```,```cv_varsel```,```project``` and the prediction functions). Now it is possible to make predictions also with those parameter estimates that were computed during the L1-penalized search. This change also allows the user to compute the Lasso-solution by providing the observed data as the 'reference fit' for init_refmodel. An example will be added to the vignette.
 
-### Bug fixes
+## Bug fixes
 
 * The projection with a nonzero regularization parameter value did not produce exactly correct result, although the difference to the correct result was often so small that user would not see the difference. Fixed this.
 
 
-## projpred 0.8.0 and earlier
+# projpred 0.8.0 and earlier
 
 Until this version, we did not keep record of the changes between different versions. Started to do this from version 0.9.0 onwards.

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * In the output of `proj_linpred()`, dimensions are not dropped anymore (i.e., output elements `pred` and `lpd` are always S x N matrices now). (GitHub: #143)
 * In case of `integrated = TRUE`, `proj_linpred()` now averages the LPD (across the projected posterior draws) instead of taking the LPD at the averaged linear predictors. (GitHub: #143)
 * If `newdata` does not contain the response variable, `proj_linpred()` now returns `NULL` for output element `lpd`. (GitHub: #143)
-* The fix for the offset issues (listed below under "Bug fixes") requires reference model fits of class `"stanreg"` (from package **rstanarm**) with offsets to have these offsets specified via an `offset()` term in the model formula (and not via argument `offset`).
+* The fix for the offset issues (listed below under "Bug fixes") requires reference model fits of class `stanreg` (from package **rstanarm**) with offsets to have these offsets specified via an `offset()` term in the model formula (and not via argument `offset`).
 * Improved handling of errors when fitting multilevel submodels. (GitHub: #201)
 * Some defaults (like for `ndraws`, `nclusters`, `ndraws_pred`, and `nclusters_pred` mentioned above) have been changed from `NULL` to a user-visible value (and `NULL` is not allowed anymore).
 * Argument `data` of `get_refmodel.stanreg()` has been removed. (GitHub: <INSERT_PR_NUMBER_FOR_refmodel>)
@@ -43,11 +43,11 @@
 * Fixed bugs for argument `nterms` of `proj_linpred()` and `proj_predict()`. (GitHub: #110)
 * Fixed an inconsistency for some intercept-only submodels. (GitHub: #119)
 * Fix a bug for `as.matrix.projection()` in case of 1 (clustered) draw after projection. (GitHub: #130)
-* For submodels of class `"subfit"`, make the column names of `as.matrix.projection()`'s output matrix consistent with other classes of submodels. (GitHub: #132)
+* For submodels of class `subfit`, make the column names of `as.matrix.projection()`'s output matrix consistent with other classes of submodels. (GitHub: #132)
 * Fix a bug for argument `nterms_max` of `plot.vsel()` if there is just the intercept-only submodel. (GitHub: #138)
 * Throw an appropriate error message when trying to apply an L1 search to an empty (i.e. intercept-only) reference model. (GitHub: #139)
 * Fix the list names of element `search_path` in, e.g., `varsel()`'s output. (GitHub: #140)
-* Fix a bug (error `unused argument`) when initializing the K reference models in a K-fold CV with CV fits not of class `"brmsfit"` or `"stanreg"`. (GitHub: #140)
+* Fix a bug (error `unused argument`) when initializing the K reference models in a K-fold CV with CV fits not of class `brmsfit` or `stanreg`. (GitHub: #140)
 * In `get_refmodel.default()`, remove old defunct arguments `fetch_data`, `wobs`, and `offset`. (GitHub: #140)
 * Fix a bug in `get_refmodel.stanreg()`. (GitHub: #142, #184)
 * Fix a possible bug related to `extract_model_data()`'s argument `extract_y` in `get_refmodel.default()`. (GitHub: #153, commit 39fece8)
@@ -66,8 +66,8 @@
 * Fix a bug in the default `proj_predfun()` for GLMMs. (GitHub: #174)
 * Fix GitHub issue #171.
 * Fix GitHub issue #172.
-* Fix a bug in the default `proj_predfun()` for `"datafit"`s. (GitHub: #177)
-* Fix the names of `summary.vsel()$selection` for `"vsel"` objects created by `varsel()`. (GitHub: #179)
+* Fix a bug in the default `proj_predfun()` for `datafit`s. (GitHub: #177)
+* Fix the names of `summary.vsel()$selection` for objects of class `vsel` created by `varsel()`. (GitHub: #179)
 * Fix forward search when `search_terms` are not consecutive in size. (GitHub: commit 34e24de)
 * Fix a bug in `cv_varsel()$pct_solution_terms_cv`. (GitHub: commit e529ec1, #188)
 * Fix GitHub issue #185. (GitHub: #193, #194)
@@ -76,7 +76,7 @@
 * Fix a bug in `glm_elnet()` (the workhorse for L1 search), causing the grid for lambda to be constructed without taking observation weights into account. (GitHub: #198; note that the second part of #198 did not have any consequences for users)
 * Fix GitHub issue #136.
 * Fix a bug in `print.vsel()` causing argument `digits` to be ignored. (GitHub: <INSERT_PR_NUMBER_FOR_digits_fix>)
-* Fix a bug causing the default of argument `cv_search` in `varsel()` and `cv_varsel()` to be `TRUE` for `"datafit"`s, although it should be `FALSE` in that case. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
+* Fix a bug causing the default of argument `cv_search` in `varsel()` and `cv_varsel()` to be `TRUE` for `datafit`s, although it should be `FALSE` in that case. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
 * Fix a bug (`Error: Levels '<...>' of grouping factor '<...>' cannot be found in the fitted model. Consider setting argument 'allow_new_levels' to TRUE.`) when predicting from submodels which are GLMMs for `newdata` containing new levels for grouping factors. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
 * `predict.refmodel()`: Fix a bug for integer `ynew`. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
 * `predict.refmodel()`: Fix input checks for `offsetnew` and `weightsnew`. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,3 @@
-# News
-
 ## projpred 2.0.5.9000
 
 ### Major (breaking) changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -155,7 +155,7 @@ We have fully rewritten the internals in several ways. Most importantly, we now 
 * Added support for GLMMs and GAMMs via **lme4** and **gamm4**.
 * Formula syntax support internally that allows for easier building upon projections.
 * Thanks to the above point, we save some computation by only considering sensible projections during forward search instead of fitting every possible submodel.
-* We have added a new argument ```search_terms``` that allows the user to specify custom unit building blocks of the projections. New vignette coming up.
+* We have added a new argument `search_terms` that allows the user to specify custom unit building blocks of the projections. New vignette coming up.
 * We have fully changed the way to define custom reference models. The user now provides projection fitting and prediction functions (more information in a new upcoming vignette).
 
 # projpred 1.1.4
@@ -182,23 +182,23 @@ This version contains only a few patches, no new features to the user.
 
 ## Bug fixes
 
-* The program crashed with **rstanarm** models fitted with syntax like ```stan_glm(log(y) ~ log(x), ...)```, that is, it did not allow transformation for ```y```.
+* The program crashed with **rstanarm** models fitted with syntax like `stan_glm(log(y) ~ log(x), ...)`, that is, it did not allow transformation for `y`.
 
 # projpred 1.0.0
 
 ## New features and improvements
 
-* Changed the internals so that now all fit objects (such as rstanarm fits) are converted to ```refmodel```-objects using the generic ```get_refmodel```-function, and all the functions use only this object. This makes it much easier to use projpred with other reference models by writing them a new ```get_refmodel```-function. The syntax is now changed so that  ```varsel``` and ```cv_varsel``` both return an object that has similar structure always, and the reference model is stored into this object.
+* Changed the internals so that now all fit objects (such as rstanarm fits) are converted to `refmodel`-objects using the generic `get_refmodel`-function, and all the functions use only this object. This makes it much easier to use projpred with other reference models by writing them a new `get_refmodel`-function. The syntax is now changed so that  `varsel` and `cv_varsel` both return an object that has similar structure always, and the reference model is stored into this object.
 * Added more examples to the vignette.
-* Added possibility to change the baseline in ```plot/summary```. Now it is possible to compare also to the best submodel found, not only to the reference model.
+* Added possibility to change the baseline in `plot/summary`. Now it is possible to compare also to the best submodel found, not only to the reference model.
 * Bug fix: RMSE was previously computed wrong, this is now fixed.
-* Small changes: ```nloo = n``` by default in ```cv_varsel```. ```regul=1e-4``` now by default in all functions.
+* Small changes: `nloo = n` by default in `cv_varsel`. `regul=1e-4` now by default in all functions.
 
 # projpred 0.9.0
 
 ## New features and improvements
 
-* Added the ```cv_search``` argument for the main functions (```varsel```,```cv_varsel```,```project``` and the prediction functions). Now it is possible to make predictions also with those parameter estimates that were computed during the L1-penalized search. This change also allows the user to compute the Lasso-solution by providing the observed data as the 'reference fit' for init_refmodel. An example will be added to the vignette.
+* Added the `cv_search` argument for the main functions (`varsel`,`cv_varsel`,`project` and the prediction functions). Now it is possible to make predictions also with those parameter estimates that were computed during the L1-penalized search. This change also allows the user to compute the Lasso-solution by providing the observed data as the 'reference fit' for init_refmodel. An example will be added to the vignette.
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # projpred 2.0.5.9000
 
-## Major (breaking) changes
+## Major changes
 
 * The behavior of arguments `ndraws`, `nclusters`, `ndraws_pred`, and `nclusters_pred` in `varsel()`, `cv_varsel()`, and `project()` has been changed: Now, `ndraws` and `ndraws_pred` have non-`NULL` defaults and for `ndraws <= 20` or `ndraws_pred <= 20`, the value of `ndraws` or `ndraws_pred` is passed to `nclusters` or `nclusters_pred`, respectively (so that clustering is used). (GitHub: commits babe031, 4ef95d3, and ce7d1e0)
 * For `proj_linpred()` and `proj_predict()`, arguments `nterms`, `ndraws`, and `seed` have been removed to allow the user to pass them to `project()`. New arguments `filter_nterms`, `nresample_clusters`, and `.seed` have been introduced (see the documentation for details). (GitHub: #92, #135)
@@ -12,18 +12,22 @@
 * Improved handling of errors when fitting multilevel submodels. (GitHub: #201)
 * Some defaults (like for `ndraws`, `nclusters`, `ndraws_pred`, and `nclusters_pred` mentioned above) have been changed from `NULL` to a user-visible value (and `NULL` is not allowed anymore).
 * Argument `data` of `get_refmodel.stanreg()` has been removed. (GitHub: #219)
-* The function passed to argument `div_minimizer` of `init_refmodel()` now always needs to return a `list` of submodels (see the documentation for details). Correspondingly, the function passed to argument `proj_predfun` of `init_refmodel()` can now always expect a `list` as input for argument `fit` (see the documentation for details). (GitHub: #230)
+* The function passed to argument `div_minimizer` of `init_refmodel()` now always needs to return a `list` of submodels (see the documentation for details). Correspondingly, the function passed to argument `proj_predfun` of `init_refmodel()` can now always expect a `list` as input for argument `fits` (see the documentation for details). (GitHub: #230)
 * The function passed to argument `proj_predfun` of `init_refmodel()` now always needs to return a matrix (see the documentation for details). (GitHub: #230)
 * The projection can be run in parallel now. However, we cannot recommend this for all kinds of platforms and all kinds of models. For more information, see the general package documentation available at ``?`projpred-package` ``. (GitHub: #235)
-* In case of the Student-*t* family, a warning is thrown when creating the reference model. The reason is that this family has not been tested thoroughly and might be implemented incorrectly (see GitHub issue #233). Use it at your own risk. (GitHub: #233, <INSERT_PR_NUMBER_FOR_warn_student_t>)
-* Subsampled LOO CV (offered by argument `nloo` of `cv_varsel()`) might be implemented incorrectly (see GitHub issue #94). Use it at your own risk. (GitHub: #94, <INSERT_PR_NUMBER_FOR_warn_subsampled_loo>)
+* Support for the `Student_t()` family is regarded as experimental. Therefore, a corresponding warning is thrown when creating the reference model. (GitHub: #233, #252)
+* Subsampled LOO CV (offered by argument `nloo` of `cv_varsel()`) is regarded as experimental. Therefore, a corresponding warning is thrown when calling `cv_varsel()` with `nloo < n` where `n` denotes the number of observations. (GitHub: #94, #252)
+* Support for additive models (i.e., GAMs and GAMMs) is regarded as experimental. Therefore, a corresponding warning is thrown when creating the reference model. (GitHub: #237, #252)
+* Support for the `Gamma()` family is regarded as experimental. Therefore, a corresponding warning is thrown when creating the reference model. (GitHub: paul-buerkner/brms#1255, #240, #252)
+* The previous behavior of `init_refmodel()` in case of argument `dis` being `NULL` (the default) was dangerous for custom reference models with a `family` having a dispersion parameter (in that case, `dis` values of all-zeros were used silently). The new behavior now requires a non-`NULL` argument `dis` in that case. (GitHub: #254)
+* Argument `cv_search` has been renamed to `refit_prj`. (GitHub: #154, #265)
 
 # Minor changes
 
 * Improved documentation. (GitHub: especially #233)
 * Replaced the two vignettes by a single one which also has new content. (GitHub: #237)
-* Updated the `README` file. (GitHub: <INSERT_PR_NUMBER_FOR_upd_readme>)
-* Some error and warning messages have been improved and added. (GitHub: especially #219, #221, #223)
+* Updated the `README` file. (GitHub: #245)
+* Some error and warning messages have been improved and added. (GitHub: especially #219, #221, #223, #252, #263)
 * For K-fold cross-validation, an internally hard-coded value of 5 for `nclusters_pred` was removed. (GitHub: commit 5062f2f)
 * Throw a proper error message for unsupported families. (GitHub: #140)
 * Show the README also on the CRAN website. (GitHub: #140)
@@ -34,10 +38,12 @@
 * Argument `folds` of `init_refmodel()` has been removed as it was effectively unused. (GitHub: #220)
 * Use the S3 system for `solution_terms()`. This allowed the introduction of a `solution_terms.projection()` method. (GitHub: #223)
 * `predict.refmodel()` now uses a default of `newdata = NULL`. (GitHub: #223)
-* Argument `weights` of `init_refmodel()`'s argument `proj_predfun` was removed. (GitHub: #163, #224)
+* Argument `weights` of `init_refmodel()`'s argument `proj_predfun` has been removed. (GitHub: #163, #224)
 * **projpred**'s internal `div_minimizer` functions have been unified into a single `div_minimizer` which chooses an appropriate submodel fitter based on the formula of the submodel, not based on that of the reference model. Furthermore, the automatic handling of errors in the submodel fitters has been improved. (GitHub: #230)
-* Improved the y-axis label in `plot.vsel()`. (GitHub: #234)
-* Handle **rstanarm**'s GitHub issue #551. This implies that **projpred**'s default `cvfun` for `stanreg` fits will now always use *inner* parallelization in `rstanarm::kfold()` (i.e., across chains, not across CV folds), with `getOption("mc.cores", 1)` cores. We do so on all systems (not only Windows). (GitHub: <INSERT_PR_NUMBER_FOR_cvfun_rstanarm>)
+* Improve the axis labels in `plot.vsel()`. (GitHub: #234, #270)
+* Handle **rstanarm**'s GitHub issue #551. This implies that **projpred**'s default `cvfun` for `stanreg` fits will now always use *inner* parallelization in `rstanarm::kfold()` (i.e., across chains, not across CV folds), with `getOption("mc.cores", 1)` cores. We do so on all systems (not only Windows). (GitHub: #249)
+* Argument `fit` of `init_refmodel()`'s argument `proj_predfun` was renamed to `fits`. This is a non-breaking change since all calls to `proj_predfun` in **projpred** have that argument unnamed. However, this cannot be guaranteed in the future, so we strongly encourage users with a custom `proj_predfun` to rename argument `fit` to `fits`. (GitHub: #263)
+* `init_refmodel()` has gained argument `cvrefbuilder` which may be a custom function for constructing the K reference models in a K-fold CV. (GitHub: #271)
 
 ## Bug fixes
 
@@ -88,6 +94,15 @@
 * Handle **rstanarm**'s GitHub issue #546. (GitHub: #227)
 * Fix a bug causing the internal submodel fitter for GLMMs to not pass arguments `var` (the predictive variances) and `regul` (amount of ridge regularization) to the internal submodel fitter for GLMs. (GitHub: #230)
 * Fix GitHub issue #210. (GitHub: #234)
+* Fix GitHub issue #242. (GitHub: #253)
+* Fix GitHub issue #244. (GitHub: #255)
+* Fix GitHub issue #243. (GitHub: #262)
+* Fix GitHub issue #213. (GitHub: #264)
+* Fix GitHub issue #215. (GitHub: #266)
+* Fix GitHub issue #212. (GitHub: #267)
+* Fix GitHub issue #156. (GitHub: #269)
+* Revert the behavior (introduced by version 2.0.5) of `init_refmodel()` if neither `cvfun` nor `cvfits` is provided: Do *not* raise an error since such an error is now thrown when trying to run K-fold CV (so a reference model which is never used for K-fold CV does not require `cvfits` or `cvfun`). (GitHub: #270)
+* If the data used for the reference model contains `NA`s, an appropriate error is now thrown. Previously, the reference model was created successfully, but this caused opaque errors in downstream code such as `project()`. (GitHub: #274)
 
 # projpred 2.0.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 * Support for the `Gamma()` family is regarded as experimental. Therefore, a corresponding warning is thrown when creating the reference model. (GitHub: paul-buerkner/brms#1255, #240, #252)
 * The previous behavior of `init_refmodel()` in case of argument `dis` being `NULL` (the default) was dangerous for custom reference models with a `family` having a dispersion parameter (in that case, `dis` values of all-zeros were used silently). The new behavior now requires a non-`NULL` argument `dis` in that case. (GitHub: #254)
 * Argument `cv_search` has been renamed to `refit_prj`. (GitHub: #154, #265)
+* `as.matrix.projection()` has gained a new argument `nm_scheme` which allows to choose the naming scheme for the column names of the returned matrix. The default (`"auto"`) follows the naming scheme of the reference model fit (and uses `"rstanarm"` if the reference model fit is of an unknown class). See also section "Major changes" for version 2.0.5 below. (GitHub: #279)
 
 ## Minor changes
 
@@ -44,6 +45,7 @@
 * Handle **rstanarm**'s GitHub issue #551. This implies that **projpred**'s default `cvfun` for `stanreg` fits will now always use *inner* parallelization in `rstanarm::kfold()` (i.e., across chains, not across CV folds), with `getOption("mc.cores", 1)` cores. We do so on all systems (not only Windows). (GitHub: #249)
 * Argument `fit` of `init_refmodel()`'s argument `proj_predfun` was renamed to `fits`. This is a non-breaking change since all calls to `proj_predfun` in **projpred** have that argument unnamed. However, this cannot be guaranteed in the future, so we strongly encourage users with a custom `proj_predfun` to rename argument `fit` to `fits`. (GitHub: #263)
 * `init_refmodel()` has gained argument `cvrefbuilder` which may be a custom function for constructing the K reference models in a K-fold CV. (GitHub: #271)
+* Allow arguments to be passed from `project()`, `varsel()`, and `cv_varsel()` to the divergence minimizer. (GitHub: #278)
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * In the output of `proj_linpred()`, dimensions are not dropped anymore (i.e., output elements `pred` and `lpd` are always S x N matrices now). (GitHub: #143)
 * In case of `integrated = TRUE`, `proj_linpred()` now averages the LPD (across the projected posterior draws) instead of taking the LPD at the averaged linear predictors. (GitHub: #143)
 * If `newdata` does not contain the response variable, `proj_linpred()` now returns `NULL` for output element `lpd`. (GitHub: #143)
-* The fix for the offset issues (listed below under "Bug fixes") requires reference model fits of class `"stanreg"` (from package `rstanarm`) with offsets to have these offsets specified via an `offset()` term in the model formula (and not via argument `offset`).
+* The fix for the offset issues (listed below under "Bug fixes") requires reference model fits of class `"stanreg"` (from package **rstanarm**) with offsets to have these offsets specified via an `offset()` term in the model formula (and not via argument `offset`).
 * Improved handling of errors when fitting multilevel submodels. (GitHub: #201)
 * Some defaults (like for `ndraws`, `nclusters`, `ndraws_pred`, and `nclusters_pred` mentioned above) have been changed from `NULL` to a user-visible value (and `NULL` is not allowed anymore).
 * Argument `data` of `get_refmodel.stanreg()` has been removed. (GitHub: <INSERT_PR_NUMBER_FOR_refmodel>)
@@ -27,12 +27,12 @@
 * Show the README also on the CRAN website. (GitHub: #140)
 * `project()`: Warn if elements of `solution_terms` are not found in the reference model (and therefore ignored). (GitHub: #140)
 * `get_refmodel.default()` now passes arguments via the ellipsis (`...`) to `init_refmodel()`. (GitHub: #153, commit dd3716e)
-* Remove dependency on package `rngtools` (version 2.0.0 of `projpred` re-introduced this dependency after it was already removed in version 1.1.2). (GitHub: #189)
+* Remove dependency on package **rngtools** (version 2.0.0 of **projpred** re-introduced this dependency after it was already removed in version 1.1.2). (GitHub: #189)
 * `init_refmodel()`: The default (`NULL`) for argument `extract_model_data` has been removed as it wasn't meaningful anyway. (GitHub: <INSERT_PR_NUMBER_FOR_refmodel>)
 * Argument `folds` of `init_refmodel()` has been removed as it was effectively unused. (GitHub: <INSERT_PR_NUMBER_FOR_folds_rm>)
 * Use the S3 system for `solution_terms()`. This allowed the introduction of a `solution_terms.projection()` method. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
 * `predict.refmodel()` now uses a default of `newdata = NULL`. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
-* `projpred`'s internal `div_minimizer` functions have been unified into a single `div_minimizer` which chooses an appropriate submodel fitter based on the formula of the submodel, not based on that of the reference model. Furthermore, the automatic handling of errors in the submodel fitters has been improved. (GitHub: <INSERT_PR_NUMBER_FOR_divmin>)
+* **projpred**'s internal `div_minimizer` functions have been unified into a single `div_minimizer` which chooses an appropriate submodel fitter based on the formula of the submodel, not based on that of the reference model. Furthermore, the automatic handling of errors in the submodel fitters has been improved. (GitHub: <INSERT_PR_NUMBER_FOR_divmin>)
 * Improved the y-axis label in `plot.vsel()`.
 
 ### Bug fixes
@@ -148,7 +148,7 @@ Added print methods for vsel and cvsel objects. Added AUC statistics for binomia
 
 ## projpred 1.1.2
 
-Removed the dependency on the ```rngtools``` package.
+Removed the dependency on the **rngtools** package.
 
 ## projpred 1.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# projpred 2.0.5.9000
+# projpred 2.1.0
 
 ## Major changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -106,9 +106,12 @@
 
 # projpred 2.0.5
 
-## Minor changes
+## Major changes
 
 * For GLMMs, the column names of the matrix returned by the `as.matrix.projection()` method follow [**brms**](https://paul-buerkner.github.io/brms/)'s naming convention, also for the new columns introduced by **projpred** version 2.0.4 (see below). (GitHub: #82)
+
+## Minor changes
+
 * Internally, the seed is not fixed to a specific value when `NULL`. (GitHub: #84)
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,8 @@
-
-
 # News
 
 ## projpred 2.0.5.9000
 
-### Major changes
+### Major (breaking) changes
 
 * The behavior of arguments `ndraws`, `nclusters`, `ndraws_pred`, and `nclusters_pred` in `varsel()`, `cv_varsel()`, and `project()` has been changed: Now, `ndraws` and `ndraws_pred` have non-`NULL` defaults and for `ndraws <= 20` or `ndraws_pred <= 20`, the value of `ndraws` or `ndraws_pred` is passed to `nclusters` or `nclusters_pred`, respectively (so that clustering is used). (GitHub: commits babe031, 4ef95d3, and ce7d1e0)
 * For `proj_linpred()` and `proj_predict()`, arguments `nterms`, `ndraws`, and `seed` have been removed to allow the user to pass them to `project()`. New arguments `filter_nterms`, `nresample_clusters`, and `.seed` have been introduced (see the documentation for details). (GitHub: #92, #135)
@@ -12,18 +10,30 @@
 * In the output of `proj_linpred()`, dimensions are not dropped anymore (i.e., output elements `pred` and `lpd` are always S x N matrices now). (GitHub: #143)
 * In case of `integrated = TRUE`, `proj_linpred()` now averages the LPD (across the projected posterior draws) instead of taking the LPD at the averaged linear predictors. (GitHub: #143)
 * If `newdata` does not contain the response variable, `proj_linpred()` now returns `NULL` for output element `lpd`. (GitHub: #143)
+* The fix for the offset issues (listed below under "Bug fixes") requires reference model fits of class `"stanreg"` (from package `rstanarm`) with offsets to have these offsets specified via an `offset()` term in the model formula (and not via argument `offset`).
+* Improved handling of errors when fitting multilevel submodels. (GitHub: #201)
+* Some defaults (like for `ndraws`, `nclusters`, `ndraws_pred`, and `nclusters_pred` mentioned above) have been changed from `NULL` to a user-visible value (and `NULL` is not allowed anymore).
+* Argument `data` of `get_refmodel.stanreg()` has been removed. (GitHub: <INSERT_PR_NUMBER_FOR_refmodel>)
+* The function passed to argument `div_minimizer` of `init_refmodel()` now always needs to return a `list` of submodels (see the documentation for details). Correspondingly, the function passed to argument `proj_predfun` of `init_refmodel()` can now always expect a `list` as input for argument `fit` (see the documentation for details). (GitHub: <INSERT_PR_NUMBER_FOR_divmin>)
+* The function passed to argument `proj_predfun` of `init_refmodel()` now always needs to return a matrix (see the documentation for details). (GitHub: <INSERT_PR_NUMBER_FOR_divmin>)
 
 ## Minor changes
 
-* Improved documentation.
-* Minor improvements of error messages.
+* Improved documentation. (GitHub: especially <INSERT_PR_NUMBER_FOR_docs>)
+* Replaced the two former vignettes by a single new one. (GitHub: especially <INSERT_PR_NUMBER_FOR_upd_vignettes>)
+* Some error and warning messages have been improved and added. (GitHub: especially <INSERT_PR_NUMBER_FOR_refmodel>, <INSERT_PR_NUMBER_FOR_binom_fixes>, <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
 * For K-fold cross-validation, an internally hard-coded value of 5 for `nclusters_pred` was removed. (GitHub: commit 5062f2f)
 * Throw a proper error message for unsupported families. (GitHub: #140)
 * Show the README also on the CRAN website. (GitHub: #140)
-* `project()`: Warn in case of `solution_terms` not being found in the reference model (and therefore getting ignored). (GitHub: #140)
-* Set defaults for `get_refmodel.default()`'s arguments `ref_predfun`, `proj_predfun`, and `div_minimizer`. (GitHub: #140)
-* Explicitly throw an error if argument `extract_model_data` of `get_refmodel.default()` is `NULL`. (GitHub: #140)
+* `project()`: Warn if elements of `solution_terms` are not found in the reference model (and therefore ignored). (GitHub: #140)
 * `get_refmodel.default()` now passes arguments via the ellipsis (`...`) to `init_refmodel()`. (GitHub: #153, commit dd3716e)
+* Remove dependency on package `rngtools` (version 2.0.0 of `projpred` re-introduced this dependency after it was already removed in version 1.1.2). (GitHub: #189)
+* `init_refmodel()`: The default (`NULL`) for argument `extract_model_data` has been removed as it wasn't meaningful anyway. (GitHub: <INSERT_PR_NUMBER_FOR_refmodel>)
+* Argument `folds` of `init_refmodel()` has been removed as it was effectively unused. (GitHub: <INSERT_PR_NUMBER_FOR_folds_rm>)
+* Use the S3 system for `solution_terms()`. This allowed the introduction of a `solution_terms.projection()` method. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
+* `predict.refmodel()` now uses a default of `newdata = NULL`. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
+* `projpred`'s internal `div_minimizer` functions have been unified into a single `div_minimizer` which chooses an appropriate submodel fitter based on the formula of the submodel, not based on that of the reference model. Furthermore, the automatic handling of errors in the submodel fitters has been improved. (GitHub: <INSERT_PR_NUMBER_FOR_divmin>)
+* Improved the y-axis label in `plot.vsel()`.
 
 ### Bug fixes
 
@@ -32,7 +42,6 @@
 * Fixed an indexing bug in `cv_varsel()` for models with a single predictor. (GitHub: #115)
 * Fixed bugs for argument `nterms` of `proj_linpred()` and `proj_predict()`. (GitHub: #110)
 * Fixed an inconsistency for some intercept-only submodels. (GitHub: #119)
-* Minor documentation fixes.
 * Fix a bug for `as.matrix.projection()` in case of 1 (clustered) draw after projection. (GitHub: #130)
 * For submodels of class `"subfit"`, make the column names of `as.matrix.projection()`'s output matrix consistent with other classes of submodels. (GitHub: #132)
 * Fix a bug for argument `nterms_max` of `plot.vsel()` if there is just the intercept-only submodel. (GitHub: #138)
@@ -40,9 +49,40 @@
 * Fix the list names of element `search_path` in, e.g., `varsel()`'s output. (GitHub: #140)
 * Fix a bug (error `unused argument`) when initializing the K reference models in a K-fold CV with CV fits not of class `"brmsfit"` or `"stanreg"`. (GitHub: #140)
 * In `get_refmodel.default()`, remove old defunct arguments `fetch_data`, `wobs`, and `offset`. (GitHub: #140)
-* Fix a bug in `get_refmodel.stanreg()`. (GitHub: #142)
+* Fix a bug in `get_refmodel.stanreg()`. (GitHub: #142, #184)
 * Fix a possible bug related to `extract_model_data()`'s argument `extract_y` in `get_refmodel.default()`. (GitHub: #153, commit 39fece8)
 * Fix a possible bug related to `extract_model_data()` in K-fold CV. (GitHub: #153, commit 4f32195)
+* Fix GitHub issue #161.
+* Fix GitHub issue #162.
+* Fix GitHub issue #164.
+* Fix GitHub issue #160.
+* Fix GitHub issue #159.
+* Fix GitHub issue #158.
+* Fix GitHub issue #157.
+* Fix GitHub issue #144.
+* Fix GitHub issue #146.
+* Fix GitHub issue #169.
+* Fix GitHub issue #167.
+* Fix a bug in the default `proj_predfun()` for GLMMs. (GitHub: #174)
+* Fix GitHub issue #171.
+* Fix GitHub issue #172.
+* Fix a bug in the default `proj_predfun()` for `"datafit"`s. (GitHub: #177)
+* Fix the names of `summary.vsel()$selection` for `"vsel"` objects created by `varsel()`. (GitHub: #179)
+* Fix forward search when `search_terms` are not consecutive in size. (GitHub: commit 34e24de)
+* Fix a bug in `cv_varsel()$pct_solution_terms_cv`. (GitHub: commit e529ec1, #188)
+* Fix GitHub issue #185. (GitHub: #193, #194)
+* Fix a bug in forward searches with interaction terms. (GitHub: #191)
+* Fix offset issues. (GitHub: #196, #203, <INSERT_PR_NUMBER_FOR_PR196_predict_fix>)
+* Fix a bug in `glm_elnet()` (the workhorse for L1 search), causing the grid for lambda to be constructed without taking observation weights into account. (GitHub: #198; note that the second part of #198 did not have any consequences for users)
+* Fix GitHub issue #136.
+* Fix a bug in `print.vsel()` causing argument `digits` to be ignored. (GitHub: <INSERT_PR_NUMBER_FOR_digits_fix>)
+* Fix a bug causing the default of argument `cv_search` in `varsel()` and `cv_varsel()` to be `TRUE` for `"datafit"`s, although it should be `FALSE` in that case. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
+* Fix a bug (`Error: Levels '<...>' of grouping factor '<...>' cannot be found in the fitted model. Consider setting argument 'allow_new_levels' to TRUE.`) when predicting from submodels which are GLMMs for `newdata` containing new levels for grouping factors. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
+* `predict.refmodel()`: Fix a bug for integer `ynew`. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
+* `predict.refmodel()`: Fix input checks for `offsetnew` and `weightsnew`. (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
+* After all calls to `extract_model_data()`, the weights and offsets are now checked if they are of length 0 (and if yes, then they are set to vectors of ones and zeros, respectively). This is important for `extract_model_data()` functions which return weights and offsets of length 0 (see, e.g., `brms` version <= 2.16.1). (GitHub: <INSERT_PR_NUMBER_FOR_misc_mods_fixes>)
+* Handle `rstanarm`'s GitHub issue #546. (GitHub: <INSERT_PR_NUMBER_FOR_offs_gam_fix>)
+* Fix a bug causing the internal submodel fitter for GLMMs to not pass arguments `var` (the predictive variances) and `regul` (amount of ridge regularization) to the internal submodel fitter for GLMs. (GitHub: <INSERT_PR_NUMBER_FOR_divmin>)
 
 ## projpred 2.0.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,7 @@
 * The previous behavior of `init_refmodel()` in case of argument `dis` being `NULL` (the default) was dangerous for custom reference models with a `family` having a dispersion parameter (in that case, `dis` values of all-zeros were used silently). The new behavior now requires a non-`NULL` argument `dis` in that case. (GitHub: #254)
 * Argument `cv_search` has been renamed to `refit_prj`. (GitHub: #154, #265)
 
-# Minor changes
+## Minor changes
 
 * Improved documentation. (GitHub: especially #233)
 * Replaced the two vignettes by a single one which also has new content. (GitHub: #237)


### PR DESCRIPTION
With this PR, I think projpred should be ready for a new CRAN release. I bumped the version number to 2.1.0, but if you consider the changes to be significant enough to justify a new major release (i.e., 3.0.0), you can change that of course.

Note that automated checking via Travis or GitHub Actions still seems to be deactivated (see issue #236). I have run `R CMD check` locally on my machine (Ubuntu 20.04.3 LTS) and it succeeded. I also checked with `devtools::check_win_devel()` and `devtools::check_win_release()`:

1. For the development R version (which is currently "R Under development (unstable) (2022-02-16 r81750 ucrt)"), I got a strange test failure which I have never gotten locally before.
2. For the release R version (which is currently "R version 4.1.2 (2021-11-01)"), the check succeeds.
3. For both win-builder R versions, I get several NOTEs concerning inaccessible URLs and DOIs. Most of the URLs are URLs created from DOIs and they are in fact accessible, so I don't think this is related to projpred. One URL is indeed inaccessible, namely <https://mc-stan.org/projpred/articles/projpred.html> which is the link to the new vignette on the pkgdown site (which will only be available after branch `gh-pages` has been updated, see below).

Given these check results, I think it would be good if someone could double-check if everything is ready for a CRAN release.

If possible, it would be great if the recommendations from [this "R Packages" book section](https://r-pkgs.org/release.html#post-release) (in particular, the creation of a version tag) could be followed after the CRAN release. Furthermore, after the CRAN release, I can create a PR for updating branch `gh-pages` (I have already prepared that locally), so the pkgdown site is in sync with the CRAN version of the package.