### PR TITLE
Enhancements in the unit tests (no. 2)

### DIFF
--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -593,6 +593,15 @@ submodl_tester <- function(
           expect_length(submodl_totest[[!!j]]$w, nobsv)
         }
         expect_true(all(submodl_totest[[!!j]]$w > 0), info = info_str)
+        if (sub_fam == "gaussian") {
+          # Note: For non-Gaussian families, a comparison of
+          # `submodl_totest[[j]]$w` with `wobs_expected` doesn't make sense
+          # since `glm_ridge(<...>)$w` contains the weights of the
+          # pseudo-Gaussian observations as calculated in pseudo_data().
+          expect_equal(as.vector(submodl_totest[[!!j]]$w),
+                       wobs_expected %||% rep(1, nobsv),
+                       info = info_str)
+        }
 
         expect_s3_class(submodl_totest[[!!j]]$formula, "formula")
         if (!grepl(":", as.character(submodl_totest[[j]]$formula)[3])) {

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -70,6 +70,8 @@ extfam_tester <- function(extfam,
   # TODO: Add some mathematical checks (i.e., check that the calculations for
   # the objects listed in `extfam_nms_add` are mathematically correct).
 
+  # Output ------------------------------------------------------------------
+
   return(invisible(TRUE))
 }
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -745,8 +745,11 @@ if (run_cvvs) {
         # TODO (GAMMs): Fix this.
       } else if (pkg_crr == "brms" && packageVersion("brms") <= "2.16.3") {
         # For brms versions <= 2.16.3, there is a reproducibility issue when
-        # using K-fold CV in conjunction with a `brmsfit` reference model fit,
-        # so use LOO CV:
+        # using K-fold CV, so use LOO CV:
+        cvmeth <- cvmeth_tst["default_cvmeth"]
+      } else if (pkg_crr == "brms" && mod_crr == "gamm") {
+        # For GAMMs fitted by brms, there is a (random, i.e., only occasional)
+        # reproducibility issue when using K-fold CV, so use LOO CV:
         cvmeth <- cvmeth_tst["default_cvmeth"]
       } else {
         cvmeth <- cvmeth_tst["kfold"]

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -652,7 +652,7 @@ stats_common <- c("elpd", "mlpd", "mse", "rmse")
 stats_tst <- list(
   default_stats = list(),
   common_stats = list(stats = stats_common),
-  binom_stats = list(stats = c(stats_common, c("acc", "auc")))
+  binom_stats = list(stats = c(stats_common, "acc", "auc"))
 )
 type_tst <- c("mean", "lower", "upper", "se")
 

--- a/tests/testthat/test_div_minimizer.R
+++ b/tests/testthat/test_div_minimizer.R
@@ -13,7 +13,7 @@ test_that("`divmin` works", {
       var_crr <- mean(as.matrix(fits[[tstsetup]])[, "sigma"]^2) +
         (colMeans(mu_crr^2) - colMeans(mu_crr)^2)
     } else {
-      var_crr <- rep(0, nobsv)
+      var_crr <- rep(NA, nobsv)
     }
     args_fit_i$projpred_var <- matrix(var_crr)
     args_fit_i$projpred_regul <- regul_default

--- a/tests/testthat/test_div_minimizer.R
+++ b/tests/testthat/test_div_minimizer.R
@@ -1,6 +1,6 @@
 context("div_minimizer")
 
-test_that("`divmin` works", {
+test_that("divmin() works", {
   for (tstsetup in names(fits)) {
     args_fit_i <- args_fit[[tstsetup]]
     pkg_crr <- args_fit_i$pkg_nm
@@ -18,7 +18,7 @@ test_that("`divmin` works", {
     args_fit_i$projpred_var <- matrix(var_crr)
     args_fit_i$projpred_regul <- regul_default
 
-    if (args_fit_i$pkg_nm == "brms" && grepl("\\.with_wobs", tstsetup)) {
+    if (pkg_crr == "brms" && grepl("\\.with_wobs", tstsetup)) {
       args_fit_i$formula <- rm_addresp(args_fit_i$formula)
       args_fit_i$weights <- eval(args_fit_i$data)$wobs_col
     }

--- a/tests/testthat/test_methods_vsel.R
+++ b/tests/testthat/test_methods_vsel.R
@@ -257,7 +257,7 @@ test_that("`nterms_max` is capped to the maximum model size", {
 context("suggest_size()")
 
 test_that("`stat` of invalid length fails", {
-  stopifnot(length(stats_common) > 0)
+  stopifnot(length(stats_common) > 1)
   skip_if_not(run_vs)
   for (tstsetup in head(names(vss), 1)) {
     expect_error(

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -503,7 +503,18 @@ test_that("`seed` works (and restores the RNG state afterwards)", {
     rand_new <- runif(1) # Just to advance `.Random.seed[2]`.
     # Expected equality:
     expect_equal(cvvs_repr, cvvs_orig, info = tstsetup)
-    expect_equal(.Random.seed_repr2, .Random.seed_repr1, info = tstsetup)
+    if (args_cvvs_i$pkg_nm == "brms" &&
+        identical(args_cvvs_i$cv_method, "kfold") &&
+        packageVersion("future") >= "1.24.0") {
+      # From the `NEWS` of `future` v1.24.0:
+      # > Now future(..., seed = TRUE) forwards the RNG state in the calling R
+      # > session. Previously, it would leave it intact.
+      expect_false(isTRUE(all.equal(.Random.seed_repr2, .Random.seed_repr1)),
+                   info = tstsetup)
+      # TODO (brms/future): Is there a way around that?
+    } else {
+      expect_equal(.Random.seed_repr2, .Random.seed_repr1, info = tstsetup)
+    }
     # Expected inequality:
     expect_false(isTRUE(all.equal(rand_new, rand_orig)), info = tstsetup)
   }


### PR DESCRIPTION
These are some minor enhancements in the unit tests which can be (but don't need to be) merged before the new CRAN release. The most important change is commit 7e3e4091bb04a8eff7e2895174c262d2c4c2f633 which is a workaround to be able to run the snapshot tests (locally) without having to care about randomly updated results for the brms GAMM K-fold CV (see the initial comment of PR #277 and stan-dev/rstan#989). Commit 438ef82ea652155cb13b86165fe39dcc8dfc9e42 is also important when running the tests locally with the new **future** version 1.24.0.