### PR TITLE
`condVar = FALSE` in `lme4::ranef()`

### DIFF
--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -463,7 +463,7 @@ predict.gamm4 <- function(fit, newdata = NULL) {
   random <- fit$random
   gamm_struct <- model.matrix.gamm4(delete.response(terms(formula)),
                                     random = random, data = newdata)
-  ranef <- lme4::ranef(fit$mer)
+  ranef <- lme4::ranef(fit$mer) # TODO (GAMMs): Add `, condVar = FALSE` here?
   b <- gamm_struct$b
   mf <- gamm_struct$mf
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -1006,7 +1006,7 @@ get_subparams.lmerMod <- function(x, ...) {
   )
 
   # Extract the group-level effects themselves:
-  group_ef <- unlist(lapply(lme4::ranef(x), function(ranef_df) {
+  group_ef <- unlist(lapply(lme4::ranef(x, condVar = FALSE), function(ranef_df) {
     ranef_mat <- as.matrix(ranef_df)
     setNames(
       as.vector(ranef_mat),


### PR DESCRIPTION
This specifies argument `condVar = FALSE` in `lme4::ranef()` calls to avoid unnecessary computations. For GAMMs, this is a "TODO" for now since I'm not sure whether it may be added without breaking downstream code.