### PR TITLE
`newdata`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@
 * `init_refmodel()` has gained argument `cvrefbuilder` which may be a custom function for constructing the K reference models in a K-fold CV. (GitHub: #271)
 * Allow arguments to be passed from `project()`, `varsel()`, and `cv_varsel()` to the divergence minimizer. (GitHub: #278)
 * In `init_refmodel()`, any `contrasts` attributes of the dataset's columns are silently removed. (GitHub: #284)
+* `NA`s in data supplied to `newdata` arguments now trigger an error. (GitHub: #285)
 
 ## Bug fixes
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -131,6 +131,7 @@ proj_helper <- function(object, newdata,
     if (!inherits(newdata, c("matrix", "data.frame"))) {
       stop("newdata must be a data.frame or a matrix")
     }
+    newdata <- na.fail(newdata)
     y_nm <- extract_terms_response(projs[[1]]$refmodel$formula)$response
     # Note: At this point, even for the binomial family with > 1 trials, we
     # expect only one response column name (the one for the successes), as

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -302,7 +302,7 @@ predict.refmodel <- function(object, newdata = NULL, ynew = NULL,
   }
 
   ## ref_predfun returns eta = link(mu)
-  eta <- object$ref_predfun(object$fit, newdata) + offsetnew
+  eta <- object$ref_predfun(object$fit, newdata = newdata) + offsetnew
 
   if (is.null(ynew)) {
     pred <- if (type == "link") eta else object$family$linkinv(eta)

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -276,6 +276,9 @@ predict.refmodel <- function(object, newdata = NULL, ynew = NULL,
     stop("Argument `ynew` must be a numeric vector.")
   }
 
+  if (!is.null(newdata)) {
+    newdata <- na.fail(newdata)
+  }
   w_o <- object$extract_model_data(object$fit, newdata = newdata,
                                    wrhs = weightsnew, orhs = offsetnew)
   weightsnew <- w_o$weights

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -155,7 +155,8 @@
 #' * `object` accepts the reference model fit as given in argument `object` (but
 #' possibly re-fitted to a subset of the observations, as done in \eqn{K}-fold
 #' CV).
-#' * `newdata` accepts data for new observations (at least in the form of a
+#' * `newdata` accepts either `NULL` (for using the original dataset, typically
+#' stored in `object`) or data for new observations (at least in the form of a
 #' `data.frame`).
 #' * `wrhs` accepts at least either `NULL` (for using a vector of ones) or a
 #' right-hand side formula consisting only of the variable in `newdata`

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -277,7 +277,9 @@ predict.refmodel <- function(object, newdata = NULL, ynew = NULL,
     stop("Argument `ynew` must be a numeric vector.")
   }
 
-  if (!is.null(newdata)) {
+  if (is.null(newdata)) {
+    newdata <- object$fetch_data()
+  } else {
     newdata <- na.fail(newdata)
   }
   w_o <- object$extract_model_data(object$fit, newdata = newdata,

--- a/man-roxygen/args-newdata.R
+++ b/man-roxygen/args-newdata.R
@@ -1,7 +1,8 @@
 #' @param newdata Passed to argument `newdata` of the reference model's
 #'   `extract_model_data` function (see [init_refmodel()]). Provides the
 #'   predictor (and possibly also the response) data for the new (or old)
-#'   observations.
+#'   observations. May also be `NULL` (see argument `extract_model_data` of
+#'   [init_refmodel()]).
 #' @param offsetnew Passed to argument `orhs` of the reference model's
 #'   `extract_model_data` function (see [init_refmodel()]). Used to get the
 #'   offsets for the new (or old) observations.

--- a/man-roxygen/args-newdata.R
+++ b/man-roxygen/args-newdata.R
@@ -2,7 +2,7 @@
 #'   `extract_model_data` function (see [init_refmodel()]). Provides the
 #'   predictor (and possibly also the response) data for the new (or old)
 #'   observations. May also be `NULL` (see argument `extract_model_data` of
-#'   [init_refmodel()]).
+#'   [init_refmodel()]). If not `NULL`, any `NA`s will trigger an error.
 #' @param offsetnew Passed to argument `orhs` of the reference model's
 #'   `extract_model_data` function (see [init_refmodel()]). Used to get the
 #'   offsets for the new (or old) observations.

--- a/man/pred-projection.Rd
+++ b/man/pred-projection.Rd
@@ -35,7 +35,8 @@ passed to argument \code{object} of \code{\link[=project]{project()}}.}
 \item{newdata}{Passed to argument \code{newdata} of the reference model's
 \code{extract_model_data} function (see \code{\link[=init_refmodel]{init_refmodel()}}). Provides the
 predictor (and possibly also the response) data for the new (or old)
-observations.}
+observations. May also be \code{NULL} (see argument \code{extract_model_data} of
+\code{\link[=init_refmodel]{init_refmodel()}}).}
 
 \item{offsetnew}{Passed to argument \code{orhs} of the reference model's
 \code{extract_model_data} function (see \code{\link[=init_refmodel]{init_refmodel()}}). Used to get the

--- a/man/pred-projection.Rd
+++ b/man/pred-projection.Rd
@@ -36,7 +36,7 @@ passed to argument \code{object} of \code{\link[=project]{project()}}.}
 \code{extract_model_data} function (see \code{\link[=init_refmodel]{init_refmodel()}}). Provides the
 predictor (and possibly also the response) data for the new (or old)
 observations. May also be \code{NULL} (see argument \code{extract_model_data} of
-\code{\link[=init_refmodel]{init_refmodel()}}).}
+\code{\link[=init_refmodel]{init_refmodel()}}). If not \code{NULL}, any \code{NA}s will trigger an error.}
 
 \item{offsetnew}{Passed to argument \code{orhs} of the reference model's
 \code{extract_model_data} function (see \code{\link[=init_refmodel]{init_refmodel()}}). Used to get the

--- a/man/predict.refmodel.Rd
+++ b/man/predict.refmodel.Rd
@@ -22,7 +22,7 @@
 \code{extract_model_data} function (see \code{\link[=init_refmodel]{init_refmodel()}}). Provides the
 predictor (and possibly also the response) data for the new (or old)
 observations. May also be \code{NULL} (see argument \code{extract_model_data} of
-\code{\link[=init_refmodel]{init_refmodel()}}).}
+\code{\link[=init_refmodel]{init_refmodel()}}). If not \code{NULL}, any \code{NA}s will trigger an error.}
 
 \item{ynew}{If not \code{NULL}, then this needs to be a vector of new (or old)
 response values. See section "Value" below.}

--- a/man/predict.refmodel.Rd
+++ b/man/predict.refmodel.Rd
@@ -21,7 +21,8 @@
 \item{newdata}{Passed to argument \code{newdata} of the reference model's
 \code{extract_model_data} function (see \code{\link[=init_refmodel]{init_refmodel()}}). Provides the
 predictor (and possibly also the response) data for the new (or old)
-observations.}
+observations. May also be \code{NULL} (see argument \code{extract_model_data} of
+\code{\link[=init_refmodel]{init_refmodel()}}).}
 
 \item{ynew}{If not \code{NULL}, then this needs to be a vector of new (or old)
 response values. See section "Value" below.}

--- a/man/refmodel-init-get.Rd
+++ b/man/refmodel-init-get.Rd
@@ -219,7 +219,8 @@ where:
 \item \code{object} accepts the reference model fit as given in argument \code{object} (but
 possibly re-fitted to a subset of the observations, as done in \eqn{K}-fold
 CV).
-\item \code{newdata} accepts data for new observations (at least in the form of a
+\item \code{newdata} accepts either \code{NULL} (for using the original dataset, typically
+stored in \code{object}) or data for new observations (at least in the form of a
 \code{data.frame}).
 \item \code{wrhs} accepts at least either \code{NULL} (for using a vector of ones) or a
 right-hand side formula consisting only of the variable in \code{newdata}


### PR DESCRIPTION
This ensures that `NA`s in data supplied to `newdata` arguments trigger an error, as explained in the message of commit c217bccf70a0afb160e988a591035ab28302b626. This is also done for consistency with PR #274. Commit 91c99f0484b4d29b6a2b5923494e0ed9200d53df fixes a `newdata`-related bug. Some improvements in the docs related to `newdata` are performed, too.

If this is merged after the upcoming CRAN release, the version number for the `NEWS.md` change performed here needs to be adapted.