### PR TITLE
Seeds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 * The previous behavior of `init_refmodel()` in case of argument `dis` being `NULL` (the default) was dangerous for custom reference models with a `family` having a dispersion parameter (in that case, `dis` values of all-zeros were used silently). The new behavior now requires a non-`NULL` argument `dis` in that case. (GitHub: #254)
 * Argument `cv_search` has been renamed to `refit_prj`. (GitHub: #154, #265)
 * `as.matrix.projection()` has gained a new argument `nm_scheme` which allows to choose the naming scheme for the column names of the returned matrix. The default (`"auto"`) follows the naming scheme of the reference model fit (and uses `"rstanarm"` if the reference model fit is of an unknown class). See also section "Major changes" for version 2.0.5 below. (GitHub: #279)
+* `seed` (and `.seed`) arguments now have a default of `sample.int(.Machine$integer.max, 1)` instead of `NULL`. Furthermore, the value supplied to these arguments is now used to generate new seeds internally on-the-fly. In many cases, this will change results compared to older **projpred** versions. (GitHub: #286)
 
 ## Minor changes
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -188,7 +188,7 @@ cv_varsel.refmodel <- function(
                   refit_prj = refit_prj, nterms_max = nterms_max - 1,
                   penalty = penalty, verbose = verbose,
                   lambda_min_ratio = lambda_min_ratio, nlambda = nlambda,
-                  regul = regul, search_terms = search_terms, ...)
+                  regul = regul, search_terms = search_terms, seed = seed, ...)
   } else if (cv_method == "LOO") {
     sel <- sel_cv$sel
   }

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -687,17 +687,11 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
               omitted = cvfit$omitted))
 }
 
-# .loo_subsample <- function(n, nloo, pareto_k,
-#                            seed = sample.int(.Machine$integer.max, 1)) {
-#   ## decide which points to go through in the validation (i.e., which points
-#   ## belong to the semi random subsample of validation points)
-#
-#   # Set seed, but ensure the old RNG state is restored on exit:
-#   if (exists(".Random.seed", envir = .GlobalEnv)) {
-#     rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
-#     on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
-#   }
-#   set.seed(seed)
+# ## decide which points to go through in the validation (i.e., which points
+# ## belong to the semi random subsample of validation points)
+# .loo_subsample <- function(n, nloo, pareto_k) {
+#   # Note: A seed is not set here because this function is not exported and has
+#   # a calling stack at the beginning of which a seed is set.
 #
 #   resample <- function(x, ...) x[sample.int(length(x), ...)]
 #
@@ -731,20 +725,14 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
 #   return(nlist(inds, w))
 # }
 
-.loo_subsample_pps <- function(nloo, lppd,
-                               seed = sample.int(.Machine$integer.max, 1)) {
-  ## decide which points to go through in the validation based on
-  ## proportional-to-size subsampling as implemented in Magnusson, M., Riis
-  ## Andersen, M., Jonasson, J. and Vehtari, A. (2019). Leave-One-Out
-  ## Cross-Validation for Large Data. In International Conference on Machine
-  ## Learning.
-
-  # Set seed, but ensure the old RNG state is restored on exit:
-  if (exists(".Random.seed", envir = .GlobalEnv)) {
-    rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
-    on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
-  }
-  set.seed(seed)
+## decide which points to go through in the validation based on
+## proportional-to-size subsampling as implemented in Magnusson, M., Riis
+## Andersen, M., Jonasson, J. and Vehtari, A. (2019). Leave-One-Out
+## Cross-Validation for Large Data. In International Conference on Machine
+## Learning.
+.loo_subsample_pps <- function(nloo, lppd) {
+  # Note: A seed is not set here because this function is not exported and has a
+  # calling stack at the beginning of which a seed is set.
 
   if (nloo > length(lppd)) {
     stop("Argument `nloo` must not be larger than the number of observations.")

--- a/R/methods.R
+++ b/R/methods.R
@@ -248,8 +248,9 @@ compute_lpd <- function(ynew, mu, proj, weights) {
 proj_predict <- function(object, newdata = NULL,
                          offsetnew = NULL, weightsnew = NULL,
                          filter_nterms = NULL,
-                         nresample_clusters = 1000, .seed = NULL, ...) {
-  ## set random seed but ensure the old RNG state is restored on exit
+                         nresample_clusters = 1000,
+                         .seed = sample.int(.Machine$integer.max, 1), ...) {
+  # Set seed, but ensure the old RNG state is restored on exit:
   if (exists(".Random.seed", envir = .GlobalEnv)) {
     rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
     on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
@@ -458,7 +459,8 @@ plot.vsel <- function(
 #' @param ... Arguments passed to the internal function which is used for
 #'   bootstrapping (if applicable; see argument `stats`). Currently, relevant
 #'   arguments are `b` (the number of bootstrap samples, defaulting to `2000`)
-#'   and `seed` (see [set.seed()], defaulting to `NULL`).
+#'   and `seed` (see [set.seed()], defaulting to
+#'   `sample.int(.Machine$integer.max, 1)`).
 #'
 #' @examples
 #' if (requireNamespace("rstanarm", quietly = TRUE)) {
@@ -1169,10 +1171,10 @@ NULL
 
 #' @rdname cv-indices
 #' @export
-cvfolds <- function(n, K, seed = NULL) {
+cvfolds <- function(n, K, seed = sample.int(.Machine$integer.max, 1)) {
   .validate_num_folds(K, n)
 
-  ## set random seed but ensure the old RNG state is restored on exit
+  # Set seed, but ensure the old RNG state is restored on exit:
   if (exists(".Random.seed", envir = .GlobalEnv)) {
     rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
     on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
@@ -1188,11 +1190,12 @@ cvfolds <- function(n, K, seed = NULL) {
 
 #' @rdname cv-indices
 #' @export
-cv_ids <- function(n, K, out = c("foldwise", "indices"), seed = NULL) {
+cv_ids <- function(n, K, out = c("foldwise", "indices"),
+                   seed = sample.int(.Machine$integer.max, 1)) {
   .validate_num_folds(K, n)
   out <- match.arg(out)
 
-  # set random seed but ensure the old RNG state is restored on exit
+  # Set seed, but ensure the old RNG state is restored on exit:
   if (exists(".Random.seed", envir = .GlobalEnv)) {
     rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
     on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))

--- a/R/misc.R
+++ b/R/misc.R
@@ -176,7 +176,6 @@ bootstrap <- function(x, fun = mean, b = 2000,
 #   `!is.null(nclusters)`, then clustering is used and `ndraws` is ignored.
 # @param ndraws The desired number of draws. If `!is.null(nclusters)`, then
 #   clustering is used and `ndraws` is ignored.
-# @param seed The seed for (P)RNG (see `?set.seed`, for example).
 # @param thinning A single logical value indicating whether in the case where
 #   `ndraws` is used, the reference model's draws should be thinned or
 #   subsampled (without replacement).
@@ -201,7 +200,7 @@ bootstrap <- function(x, fun = mean, b = 2000,
 #   has length equal to the number of posterior draws and each value is an
 #   integer between 1 and \eqn{S_{\mbox{prj}}}{S_prj}.
 .get_refdist <- function(refmodel, ndraws = NULL, nclusters = NULL,
-                         thinning = TRUE, ...) {
+                         thinning = TRUE) {
   S <- NCOL(refmodel$mu) # number of draws in the reference model
   if (is.null(ndraws)) {
     ndraws <- S
@@ -213,10 +212,10 @@ bootstrap <- function(x, fun = mean, b = 2000,
       # special case, only one cluster
       cl <- rep(1, S)
       p_ref <- .get_p_clust(refmodel$family, refmodel$mu, refmodel$dis,
-                            wobs = refmodel$wobs, cl = cl, ...)
+                            wobs = refmodel$wobs, cl = cl)
     } else if (nclusters == NCOL(refmodel$mu)) {
       # number of clusters equal to the number of samples, so return the samples
-      return(.get_refdist(refmodel, ndraws = nclusters, ...))
+      return(.get_refdist(refmodel, ndraws = nclusters))
     } else {
       # several clusters
       if (nclusters > NCOL(refmodel$mu)) {
@@ -224,7 +223,7 @@ bootstrap <- function(x, fun = mean, b = 2000,
              "columns in mu.")
       }
       p_ref <- .get_p_clust(refmodel$family, refmodel$mu, refmodel$dis,
-                            wobs = refmodel$wobs, nclusters = nclusters, ...)
+                            wobs = refmodel$wobs, nclusters = nclusters)
     }
   } else {
     if (ndraws > NCOL(refmodel$mu)) {
@@ -234,7 +233,7 @@ bootstrap <- function(x, fun = mean, b = 2000,
     if (thinning) {
       s_ind <- round(seq(from = 1, to = S, length.out = ndraws))
     } else {
-      s_ind <- draws_subsample(S = S, ndraws = ndraws, ...)
+      s_ind <- draws_subsample(S = S, ndraws = ndraws)
     }
     cl <- rep(NA, S)
     cl[s_ind] <- c(1:ndraws)
@@ -253,16 +252,11 @@ bootstrap <- function(x, fun = mean, b = 2000,
 # Function for clustering the parameter draws:
 .get_p_clust <- function(family, mu, dis, nclusters = 10,
                          wobs = rep(1, dim(mu)[1]),
-                         wsample = rep(1, dim(mu)[2]), cl = NULL,
-                         seed = sample.int(.Machine$integer.max, 1)) {
+                         wsample = rep(1, dim(mu)[2]), cl = NULL) {
   # cluster the samples in the latent space if no clustering provided
   if (is.null(cl)) {
-    # Set seed, but ensure the old RNG state is restored on exit:
-    if (exists(".Random.seed", envir = .GlobalEnv)) {
-      rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
-      on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
-    }
-    set.seed(seed)
+    # Note: A seed is not set here because this function is not exported and has
+    # a calling stack at the beginning of which a seed is set.
 
     f <- family$linkfun(mu)
     out <- kmeans(t(f), nclusters, iter.max = 50)
@@ -314,14 +308,9 @@ bootstrap <- function(x, fun = mean, b = 2000,
   return(p)
 }
 
-draws_subsample <- function(S, ndraws,
-                            seed = sample.int(.Machine$integer.max, 1)) {
-  # Set seed, but ensure the old RNG state is restored on exit:
-  if (exists(".Random.seed", envir = .GlobalEnv)) {
-    rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
-    on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
-  }
-  set.seed(seed)
+draws_subsample <- function(S, ndraws) {
+  # Note: A seed is not set here because this function is not exported and has a
+  # calling stack at the beginning of which a seed is set.
 
   return(sample.int(S, size = ndraws))
 }

--- a/R/misc.R
+++ b/R/misc.R
@@ -201,15 +201,7 @@ bootstrap <- function(x, fun = mean, b = 2000,
 #   has length equal to the number of posterior draws and each value is an
 #   integer between 1 and \eqn{S_{\mbox{prj}}}{S_prj}.
 .get_refdist <- function(refmodel, ndraws = NULL, nclusters = NULL,
-                         seed = sample.int(.Machine$integer.max, 1),
-                         thinning = TRUE) {
-  # Set seed, but ensure the old RNG state is restored on exit:
-  if (exists(".Random.seed", envir = .GlobalEnv)) {
-    rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
-    on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
-  }
-  set.seed(seed)
-
+                         thinning = TRUE, ...) {
   S <- NCOL(refmodel$mu) # number of draws in the reference model
   if (is.null(ndraws)) {
     ndraws <- S
@@ -221,10 +213,10 @@ bootstrap <- function(x, fun = mean, b = 2000,
       # special case, only one cluster
       cl <- rep(1, S)
       p_ref <- .get_p_clust(refmodel$family, refmodel$mu, refmodel$dis,
-                            wobs = refmodel$wobs, cl = cl)
+                            wobs = refmodel$wobs, cl = cl, ...)
     } else if (nclusters == NCOL(refmodel$mu)) {
       # number of clusters equal to the number of samples, so return the samples
-      return(.get_refdist(refmodel, ndraws = nclusters))
+      return(.get_refdist(refmodel, ndraws = nclusters, ...))
     } else {
       # several clusters
       if (nclusters > NCOL(refmodel$mu)) {
@@ -232,7 +224,7 @@ bootstrap <- function(x, fun = mean, b = 2000,
              "columns in mu.")
       }
       p_ref <- .get_p_clust(refmodel$family, refmodel$mu, refmodel$dis,
-                            wobs = refmodel$wobs, nclusters = nclusters)
+                            wobs = refmodel$wobs, nclusters = nclusters, ...)
     }
   } else {
     if (ndraws > NCOL(refmodel$mu)) {
@@ -242,7 +234,7 @@ bootstrap <- function(x, fun = mean, b = 2000,
     if (thinning) {
       s_ind <- round(seq(from = 1, to = S, length.out = ndraws))
     } else {
-      s_ind <- sample(seq_len(S), size = ndraws)
+      s_ind <- draws_subsample(S = S, ndraws = ndraws, ...)
     }
     cl <- rep(NA, S)
     cl[s_ind] <- c(1:ndraws)
@@ -258,13 +250,20 @@ bootstrap <- function(x, fun = mean, b = 2000,
   return(p_ref)
 }
 
+# Function for clustering the parameter draws:
 .get_p_clust <- function(family, mu, dis, nclusters = 10,
                          wobs = rep(1, dim(mu)[1]),
-                         wsample = rep(1, dim(mu)[2]), cl = NULL) {
-  # Function for perfoming the clustering over the samples.
-  #
+                         wsample = rep(1, dim(mu)[2]), cl = NULL,
+                         seed = sample.int(.Machine$integer.max, 1)) {
   # cluster the samples in the latent space if no clustering provided
   if (is.null(cl)) {
+    # Set seed, but ensure the old RNG state is restored on exit:
+    if (exists(".Random.seed", envir = .GlobalEnv)) {
+      rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
+      on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
+    }
+    set.seed(seed)
+
     f <- family$linkfun(mu)
     out <- kmeans(t(f), nclusters, iter.max = 50)
     cl <- out$cluster # cluster indices for each sample
@@ -313,6 +312,18 @@ bootstrap <- function(x, fun = mean, b = 2000,
     cl = cl
   )
   return(p)
+}
+
+draws_subsample <- function(S, ndraws,
+                            seed = sample.int(.Machine$integer.max, 1)) {
+  # Set seed, but ensure the old RNG state is restored on exit:
+  if (exists(".Random.seed", envir = .GlobalEnv)) {
+    rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
+    on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
+  }
+  set.seed(seed)
+
+  return(sample(seq_len(S), size = ndraws))
 }
 
 .is_proj_list <- function(proj) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -56,8 +56,9 @@ auc <- function(x) {
 # Bootstrap an arbitrary quantity `fun` that takes the sample `x` as the first
 # input. Other arguments of `fun` can be passed by `...`. Example:
 # `boostrap(x, mean)`.
-bootstrap <- function(x, fun = mean, b = 2000, seed = NULL, ...) {
-  # set random seed but ensure the old RNG state is restored on exit
+bootstrap <- function(x, fun = mean, b = 2000,
+                      seed = sample.int(.Machine$integer.max, 1), ...) {
+  # Set seed, but ensure the old RNG state is restored on exit:
   if (exists(".Random.seed", envir = .GlobalEnv)) {
     rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
     on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
@@ -199,9 +200,10 @@ bootstrap <- function(x, fun = mean, b = 2000, seed = NULL, ...) {
 #   * `cl`: Cluster assignment for each posterior draw, that is, a vector that
 #   has length equal to the number of posterior draws and each value is an
 #   integer between 1 and \eqn{S_{\mbox{prj}}}{S_prj}.
-.get_refdist <- function(refmodel, ndraws = NULL, nclusters = NULL, seed = NULL,
+.get_refdist <- function(refmodel, ndraws = NULL, nclusters = NULL,
+                         seed = sample.int(.Machine$integer.max, 1),
                          thinning = TRUE) {
-  # set random seed but ensure the old RNG state is restored on exit
+  # Set seed, but ensure the old RNG state is restored on exit:
   if (exists(".Random.seed", envir = .GlobalEnv)) {
     rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
     on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
@@ -222,7 +224,7 @@ bootstrap <- function(x, fun = mean, b = 2000, seed = NULL, ...) {
                             wobs = refmodel$wobs, cl = cl)
     } else if (nclusters == NCOL(refmodel$mu)) {
       # number of clusters equal to the number of samples, so return the samples
-      return(.get_refdist(refmodel, ndraws = nclusters, seed = seed))
+      return(.get_refdist(refmodel, ndraws = nclusters))
     } else {
       # several clusters
       if (nclusters > NCOL(refmodel$mu)) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -323,7 +323,7 @@ draws_subsample <- function(S, ndraws,
   }
   set.seed(seed)
 
-  return(sample(seq_len(S), size = ndraws))
+  return(sample.int(S, size = ndraws))
 }
 
 .is_proj_list <- function(proj) {

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -147,7 +147,15 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
                             nterms_max = NULL, verbose = TRUE,
                             lambda_min_ratio = 1e-5, nlambda = 150,
                             thresh = 1e-6, regul = 1e-4, penalty = NULL,
-                            search_terms = NULL, seed = NULL, ...) {
+                            search_terms = NULL,
+                            seed = sample.int(.Machine$integer.max, 1), ...) {
+  # Set seed, but ensure the old RNG state is restored on exit:
+  if (exists(".Random.seed", envir = .GlobalEnv)) {
+    rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
+    on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
+  }
+  set.seed(seed)
+
   refmodel <- object
 
   ## fetch the default arguments or replace them by the user defined values
@@ -178,8 +186,8 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
   }
 
   ## reference distributions for selection and prediction after selection
-  p_sel <- .get_refdist(refmodel, ndraws, nclusters, seed = seed)
-  p_pred <- .get_refdist(refmodel, ndraws_pred, nclusters_pred, seed = seed)
+  p_sel <- .get_refdist(refmodel, ndraws, nclusters)
+  p_pred <- .get_refdist(refmodel, ndraws_pred, nclusters_pred)
 
   ## perform the selection
   opt <- nlist(lambda_min_ratio, nlambda, thresh, regul)

--- a/man/cv-indices.Rd
+++ b/man/cv-indices.Rd
@@ -6,9 +6,14 @@
 \alias{cv_ids}
 \title{Create cross-validation folds}
 \usage{
-cvfolds(n, K, seed = NULL)
+cvfolds(n, K, seed = sample.int(.Machine$integer.max, 1))
 
-cv_ids(n, K, out = c("foldwise", "indices"), seed = NULL)
+cv_ids(
+  n,
+  K,
+  out = c("foldwise", "indices"),
+  seed = sample.int(.Machine$integer.max, 1)
+)
 }
 \arguments{
 \item{n}{Number of observations.}

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -29,7 +29,7 @@ cv_varsel(object, ...)
   thresh = 1e-06,
   regul = 1e-04,
   validate_search = TRUE,
-  seed = NULL,
+  seed = sample.int(.Machine$integer.max, 1),
   search_terms = NULL,
   ...
 )

--- a/man/plot.vsel.Rd
+++ b/man/plot.vsel.Rd
@@ -54,7 +54,8 @@ terms of \code{stats[1]}), respectively.}
 \item{...}{Arguments passed to the internal function which is used for
 bootstrapping (if applicable; see argument \code{stats}). Currently, relevant
 arguments are \code{b} (the number of bootstrap samples, defaulting to \code{2000})
-and \code{seed} (see \code{\link[=set.seed]{set.seed()}}, defaulting to \code{NULL}).}
+and \code{seed} (see \code{\link[=set.seed]{set.seed()}}, defaulting to
+\code{sample.int(.Machine$integer.max, 1)}).}
 }
 \description{
 This is the \code{\link[=plot]{plot()}} method for \code{vsel} objects (returned by \code{\link[=varsel]{varsel()}} or

--- a/man/pred-projection.Rd
+++ b/man/pred-projection.Rd
@@ -24,7 +24,7 @@ proj_predict(
   weightsnew = NULL,
   filter_nterms = NULL,
   nresample_clusters = 1000,
-  .seed = NULL,
+  .seed = sample.int(.Machine$integer.max, 1),
   ...
 )
 }

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -11,7 +11,7 @@ project(
   refit_prj = TRUE,
   ndraws = 400,
   nclusters = NULL,
-  seed = NULL,
+  seed = sample.int(.Machine$integer.max, 1),
   regul = 1e-04,
   ...
 )

--- a/man/summary.vsel.Rd
+++ b/man/summary.vsel.Rd
@@ -65,7 +65,8 @@ terms of \code{stats[1]}), respectively.}
 \item{...}{Arguments passed to the internal function which is used for
 bootstrapping (if applicable; see argument \code{stats}). Currently, relevant
 arguments are \code{b} (the number of bootstrap samples, defaulting to \code{2000})
-and \code{seed} (see \code{\link[=set.seed]{set.seed()}}, defaulting to \code{NULL}).}
+and \code{seed} (see \code{\link[=set.seed]{set.seed()}}, defaulting to
+\code{sample.int(.Machine$integer.max, 1)}).}
 }
 \description{
 This is the \code{\link[=summary]{summary()}} method for \code{vsel} objects (returned by \code{\link[=varsel]{varsel()}} or

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -27,7 +27,7 @@ varsel(object, ...)
   regul = 1e-04,
   penalty = NULL,
   search_terms = NULL,
-  seed = NULL,
+  seed = sample.int(.Machine$integer.max, 1),
   ...
 )
 }

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -876,8 +876,7 @@ projection_tester <- function(p,
       on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
     }
     set.seed(seed_expected)
-    clust_ref <- .get_refdist(p$refmodel, nclusters = nprjdraws_expected,
-                              seed = sample.int(.Machine$integer.max, 1))
+    clust_ref <- .get_refdist(p$refmodel, nclusters = nprjdraws_expected)
   } else {
     clust_ref <- .get_refdist(p$refmodel, ndraws = nprjdraws_expected)
   }
@@ -1154,8 +1153,7 @@ vsel_tester <- function(
   set.seed(seed_expected)
   clust_ref <- .get_refdist(vs$refmodel,
                             ndraws = ndraws_expected,
-                            nclusters = nclusters_expected,
-                            seed = sample.int(.Machine$integer.max, 1))
+                            nclusters = nclusters_expected)
   nprjdraws_expected <- ncol(clust_ref$mu)
   if (!from_vsel_L1_search) {
     y_nm <- as.character(vs$refmodel$formula)[2]

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -871,13 +871,15 @@ projection_tester <- function(p,
   })
   sub_data_crr <- p$refmodel$fetch_data()
   if (p_type_expected) {
-    clust_ref <- .get_refdist(p$refmodel,
-                              nclusters = nprjdraws_expected,
-                              seed = seed_expected)
+    if (exists(".Random.seed", envir = .GlobalEnv)) {
+      rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
+      on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
+    }
+    set.seed(seed_expected)
+    clust_ref <- .get_refdist(p$refmodel, nclusters = nprjdraws_expected,
+                              seed = sample.int(.Machine$integer.max, 1))
   } else {
-    clust_ref <- .get_refdist(p$refmodel,
-                              ndraws = nprjdraws_expected,
-                              seed = seed_expected)
+    clust_ref <- .get_refdist(p$refmodel, ndraws = nprjdraws_expected)
   }
   for (i in seq_len(nprjdraws_expected)) {
     sub_data_crr[[y_nms[i]]] <- clust_ref$mu[, i]
@@ -1145,10 +1147,15 @@ vsel_tester <- function(
   expect_type(vs$search_path$submodls, "list")
   expect_length(vs$search_path$submodls, solterms_len_expected + 1)
   from_vsel_L1_search <- method_expected == "l1"
+  if (exists(".Random.seed", envir = .GlobalEnv)) {
+    rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
+    on.exit(assign(".Random.seed", rng_state_old, envir = .GlobalEnv))
+  }
+  set.seed(seed_expected)
   clust_ref <- .get_refdist(vs$refmodel,
                             ndraws = ndraws_expected,
                             nclusters = nclusters_expected,
-                            seed = seed_expected)
+                            seed = sample.int(.Machine$integer.max, 1))
   nprjdraws_expected <- ncol(clust_ref$mu)
   if (!from_vsel_L1_search) {
     y_nm <- as.character(vs$refmodel$formula)[2]

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -656,7 +656,7 @@ stats_tst <- list(
 )
 type_tst <- c("mean", "lower", "upper", "se")
 
-seed_tst <- 74345
+seed_tst <- 74341
 seed2_tst <- 866028
 seed3_tst <- 1208499
 

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -1,41 +1,5 @@
 context("miscellaneous")
 
-test_that(paste(
-  ".get_refdist(): `seed` works (and restores the RNG state afterwards)"
-), {
-  for (tstsetup in names(refmods)) {
-    .Random.seed_orig1 <- .Random.seed
-    refdist_orig <- .get_refdist(refmods[[tstsetup]], nclusters = 10,
-                                 seed = seed_tst)
-    .Random.seed_orig2 <- .Random.seed
-    rand_orig <- runif(1) # Just to advance `.Random.seed[2]`.
-    .Random.seed_new1 <- .Random.seed
-    refdist_new <- .get_refdist(refmods[[tstsetup]], nclusters = 10,
-                                seed = seed_tst + 1L)
-    .Random.seed_new2 <- .Random.seed
-    rand_new <- runif(1) # Just to advance `.Random.seed[2]`.
-    .Random.seed_repr1 <- .Random.seed
-    refdist_repr <- .get_refdist(refmods[[tstsetup]], nclusters = 10,
-                                 seed = seed_tst)
-    .Random.seed_repr2 <- .Random.seed
-    # Expected equality:
-    expect_equal(refdist_repr, refdist_orig, info = tstsetup)
-    expect_equal(.Random.seed_orig2, .Random.seed_orig1, info = tstsetup)
-    expect_equal(.Random.seed_new2, .Random.seed_new1, info = tstsetup)
-    expect_equal(.Random.seed_repr2, .Random.seed_repr1, info = tstsetup)
-    # Expected inequality:
-    expect_false(isTRUE(all.equal(refdist_new, refdist_orig)),
-                 info = tstsetup)
-    expect_false(isTRUE(all.equal(rand_new, rand_orig)), info = tstsetup)
-    expect_false(isTRUE(all.equal(.Random.seed_new2, .Random.seed_orig2)),
-                 info = tstsetup)
-    expect_false(isTRUE(all.equal(.Random.seed_repr2, .Random.seed_orig2)),
-                 info = tstsetup)
-    expect_false(isTRUE(all.equal(.Random.seed_repr2, .Random.seed_new2)),
-                 info = tstsetup)
-  }
-})
-
 test_that("rstanarm: special formulas work", {
   # Skip this on CRAN to avoid depending too strongly on rstanarm internals:
   skip_on_cran()

--- a/tests/testthat/test_project.R
+++ b/tests/testthat/test_project.R
@@ -305,8 +305,6 @@ test_that("non-clustered projection does not require a seed", {
 })
 
 test_that("`seed` works (and restores the RNG state afterwards)", {
-  # Note: Extensive tests for reproducibility may be found among the tests for
-  # .get_refdist().
   tstsetups <- grep("\\.glm\\.gauss.*\\.solterms_x\\.clust$", names(prjs),
                     value = TRUE)
   for (tstsetup in tstsetups) {

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -503,18 +503,7 @@ test_that("`seed` works (and restores the RNG state afterwards)", {
     rand_new <- runif(1) # Just to advance `.Random.seed[2]`.
     # Expected equality:
     expect_equal(cvvs_repr, cvvs_orig, info = tstsetup)
-    if (args_cvvs_i$pkg_nm == "brms" &&
-        identical(args_cvvs_i$cv_method, "kfold") &&
-        packageVersion("future") >= "1.24.0") {
-      # From the `NEWS` of `future` v1.24.0:
-      # > Now future(..., seed = TRUE) forwards the RNG state in the calling R
-      # > session. Previously, it would leave it intact.
-      expect_false(isTRUE(all.equal(.Random.seed_repr2, .Random.seed_repr1)),
-                   info = tstsetup)
-      # TODO (brms/future): Is there a way around that?
-    } else {
-      expect_equal(.Random.seed_repr2, .Random.seed_repr1, info = tstsetup)
-    }
+    expect_equal(.Random.seed_repr2, .Random.seed_repr1, info = tstsetup)
     # Expected inequality:
     expect_false(isTRUE(all.equal(rand_new, rand_orig)), info = tstsetup)
   }

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -48,8 +48,6 @@ test_that("invalid `method` fails", {
 })
 
 test_that("`seed` works (and restores the RNG state afterwards)", {
-  # Note: Extensive tests for reproducibility may be found among the tests for
-  # .get_refdist().
   skip_if_not(run_vs)
   # To save time:
   tstsetups <- grep("\\.glm\\.gauss\\.", names(vss), value = TRUE)
@@ -479,8 +477,6 @@ test_that("invalid `cv_method` fails", {
 })
 
 test_that("`seed` works (and restores the RNG state afterwards)", {
-  # Note: Extensive tests for reproducibility may be found among the tests for
-  # .get_refdist().
   skip_if_not(run_cvvs)
   # To save time:
   tstsetups <- union(


### PR DESCRIPTION
With this PR, the seed supplied to top-level (user-facing) functions is used to generate new seeds for downstream code on-the-fly. The main advantage of this is that PRNG-using code may be added more easily (which will be important for fixing issue #268) and it also helps to avoid using the same seed multiple times, where possible (see the message of commit 6ed82b6b043ce29c82c27ba77460267dd2e9898d).

Furthermore, `seed` (and `.seed`) arguments now have a default of `sample.int(.Machine$integer.max, 1)` instead of `NULL` which allows users to set a seed once at the beginning of their script and then use the default `seed` (and `.seed`) arguments.

If this is merged after the upcoming CRAN release, the version number for the `NEWS.md` change performed here needs to be adapted.