### PR TITLE
Tests: Remove workaround for test failure on R-devel (> 4.1)

### DIFF
--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -277,7 +277,7 @@ refmodel_tester <- function(
     }
     if (!(has_grp &&
           as.numeric(R.version$major) >= 4 &&
-          as.numeric(R.version$minor) > 1)) {
+          as.numeric(R.version$minor) >= 2)) {
       # TODO: This causes a test failure on R-devel (> 4.1) which can't be
       # reproduced locally. Thus, this is skipped in this special case for now.
       expect_equal(refmod$mu, t(mu_expected), info = info_str)

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -275,13 +275,7 @@ refmodel_tester <- function(
     if (refmod$family$family != "gaussian") {
       mu_expected <- fam_orig$linkinv(mu_expected)
     }
-    if (!(has_grp &&
-          as.numeric(R.version$major) >= 4 &&
-          as.numeric(R.version$minor) >= 2)) {
-      # TODO: This causes a test failure on R-devel (> 4.1) which can't be
-      # reproduced locally. Thus, this is skipped in this special case for now.
-      expect_equal(refmod$mu, t(mu_expected), info = info_str)
-    }
+    expect_equal(refmod$mu, t(mu_expected), info = info_str)
   } else {
     if (refmod$family$family != "binomial") {
       expect_identical(refmod$mu, as.matrix(refmod$y), info = info_str)


### PR DESCRIPTION
This removes the workaround for the `mu_expected` test failing on R-devel (> 4.1). The failure was probably due to the new rstanarm version 2.21.3 where an offset issue was fixed. It's strange that rstanarm version 2.21.3 was available in the R-devel checks but not on CRAN, but I might have missed it on CRAN. It could also be possible that R-devel has access to packages which have been submitted to CRAN but not published yet.

See the commit messages for details.