### PR TITLE
rstanarm issue 542 fixed; handling of offsets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # projpred 2.1.1.9000
 
+## Minor changes
+
+* Account for changes concerning the handling of offsets in **rstanarm** version 2.21.3. In particular, issue stan-dev/rstanarm#542 was fixed in **rstanarm** 2.21.3.
+
 ## Bug fixes
 
 * Throw a more informative error message in case of special group-level terms which are currently not supported (in particular, nested ones).
@@ -10,7 +14,7 @@
 
 * Fix the order of the package authors.
 * Fix failing CRAN checks.
-* Add an input check for argument `solution_terms` of `project()` to fix a test failure on R versions > 4.1.
+* Add an input check for argument `solution_terms` of `project()` to fix a test failure in R versions >= 4.2.
 
 # projpred 2.1.0
 

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -539,7 +539,8 @@ get_refmodel.stanreg <- function(object, ...) {
     # posterior_linpred() excluded (`TRUE`) or included (`FALSE`) the offsets:
     cond_no_offs <- (
       fit$stan_function %in% c("stan_lmer", "stan_glmer") &&
-        !is.null(attr(terms(formula), "offset"))
+        !is.null(attr(terms(formula), "offset")) &&
+        utils::packageVersion("rstanarm") <= "2.21.2"
     ) || (
       fit$stan_function %in% c("stan_lm", "stan_glm") &&
         !is.null(newdata) && length(fit$offset) > 0

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -360,11 +360,10 @@ seed_fit <- 74345
 ### Formula ---------------------------------------------------------------
 
 # Notes:
-#   * Argument `offset` has an issue for rstanarm::stan_glmer() (see rstanarm
-#     issue #541). Instead, use offset() in the formula.
 #   * Argument `offset` is not supported by rstanarm::stan_gamm4(). Instead, use
-#     offset() in the formula. However, because of rstanarm issue #546 and
-#     rstanarm issue #253, omit the offsets in GAMs and GAMMs.
+#     offset() in the formula (like for all other models). However, because of
+#     rstanarm issue #546 and rstanarm issue #253, omit the offsets in GAMs and
+#     GAMMs.
 #   * In rstanarm::stan_gamm4(), multilevel terms are specified via argument
 #     `random`.
 

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -91,24 +91,10 @@ test_that("`d_test` works", {
       type = "test",
       offset = refmod_crr$offset
     )
-    # We expect a warning which in fact should be suppressed, though (see
-    # issue #162):
-    warn_expected <- if (pkg_crr == "rstanarm" &&
-                         mod_crr == "glm" &&
-                         grepl("\\.with_offs", tstsetup)) {
-      paste("^'offset' argument is NULL but it looks like you estimated the",
-            "model using an offset term\\.$")
-    } else {
-      NA
-    }
-    expect_warning(
-      vs_repr <- do.call(varsel, c(
-        list(object = refmod_crr, d_test = d_test_crr),
-        excl_nonargs(args_vs_i)
-      )),
-      warn_expected,
-      info = tstsetup
-    )
+    vs_repr <- do.call(varsel, c(
+      list(object = refmod_crr, d_test = d_test_crr),
+      excl_nonargs(args_vs_i)
+    ))
     meth_exp_crr <- args_vs_i$method
     if (is.null(meth_exp_crr)) {
       meth_exp_crr <- ifelse(mod_crr == "glm", "L1", "forward")
@@ -756,23 +742,10 @@ test_that(paste(
     refmod_crr <- get_refmodel(fit_crr, cvfits = kfold_obj)
 
     # Run cv_varsel():
-    # We expect a warning which in fact should be suppressed, though (see
-    # issue #162):
-    warn_expected <- if (mod_crr == "glm" &&
-                         grepl("\\.with_offs", tstsetup)) {
-      paste("^'offset' argument is NULL but it looks like you estimated the",
-            "model using an offset term\\.$")
-    } else {
-      NA
-    }
-    expect_warning(
-      cvvs_cvfits <- do.call(cv_varsel, c(
-        list(object = refmod_crr),
-        excl_nonargs(args_cvvs_i, nms_excl_add = "K")
-      )),
-      warn_expected,
-      info = tstsetup
-    )
+    cvvs_cvfits <- do.call(cv_varsel, c(
+      list(object = refmod_crr),
+      excl_nonargs(args_cvvs_i, nms_excl_add = "K")
+    ))
 
     # Checks:
     vsel_tester(


### PR DESCRIPTION
This accounts for the fact that stan-dev/rstanarm#542 has been fixed in the new rstanarm CRAN version 2.21.3. Apart from that, the handling of offsets in `get_refmodel.stanreg()`'s `ref_predfun` is simplified a lot, making it possible to use argument `offset` in **rstanarm**'s model fitting functions such as `stan_glm()`.