### PR TITLE
`search_terms`: Fix a bug, improve documentation, refactoring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,10 +3,14 @@
 ## Minor changes
 
 * Account for changes concerning the handling of offsets in **rstanarm** version 2.21.3. In particular, issue stan-dev/rstanarm#542 was fixed in **rstanarm** 2.21.3.
+* Improve the documentation for argument `search_terms` of `varsel()` and `cv_varsel()`. (GitHub: #155, #308)
+* In case of user-specified (non-`NULL`) `search_terms`, `method = NULL` is internally changed to `method = "forward"` and `method = "L1"` throws a warning. This is done because `search_terms` only takes effect in case of a forward search. (GitHub: #155, #308)
+* Internally, the intercept is now always included in `search_terms`. This is necessary to prevent a bug described below. (GitHub: #308)
 
 ## Bug fixes
 
 * Throw a more informative error message in case of special group-level terms which are currently not supported (in particular, nested ones).
+* Previously, using a `search_terms` vector which excluded the intercept in conjunction with `refit_prj = FALSE` (the latter in `project()`, `varsel()`, or `cv_varsel()`) led to incorrect submodels being fetched from the search or to an error while doing so. This has been fixed now by internally forcing the inclusion of the intercept in `search_terms`. (GitHub: #308)
 
 # projpred 2.1.1
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -138,6 +138,8 @@ cv_varsel.refmodel <- function(
   set.seed(seed)
 
   refmodel <- object
+  # Needed to avoid a warning when calling varsel() later:
+  search_terms_usr <- search_terms
   ## resolve the arguments similar to varsel
   args <- parse_args_varsel(
     refmodel = refmodel, method = method, refit_prj = refit_prj,
@@ -189,7 +191,8 @@ cv_varsel.refmodel <- function(
                   refit_prj = refit_prj, nterms_max = nterms_max - 1,
                   penalty = penalty, verbose = verbose,
                   lambda_min_ratio = lambda_min_ratio, nlambda = nlambda,
-                  regul = regul, search_terms = search_terms, seed = seed, ...)
+                  regul = regul, search_terms = search_terms_usr, seed = seed,
+                  ...)
   } else if (cv_method == "LOO") {
     sel <- sel_cv$sel
   }

--- a/R/formula.R
+++ b/R/formula.R
@@ -648,8 +648,6 @@ select_possible_terms_size <- function(chosen, terms, size) {
   }
 
   valid_submodels <- lapply(terms, function(x) {
-    current <- count_terms_chosen(chosen)
-    increment <- size - current
     ## if we are adding a linear term whose smooth is already
     ## included, we reject it
     terms <- extract_terms_response(make_formula(c(chosen)))
@@ -666,9 +664,8 @@ select_possible_terms_size <- function(chosen, terms, size) {
     ## if model is straight redundant
     not_redundant <- (
       count_terms_chosen(c(chosen, x), duplicates = TRUE) -
-        current -
         length(dups)
-    ) == increment
+    ) == size
     ## if already_chosen is not NA it means we have already chosen the linear
     ## term
     if (not_redundant) {

--- a/R/formula.R
+++ b/R/formula.R
@@ -738,24 +738,6 @@ is_next_submodel_redundant <- function(current, new) {
   }
 }
 
-## Utility to remove redundant models to consider
-## @param refmodel The reference model's formula.
-## @param chosen A list of included terms at a given point of the search.
-## @return a vector of incremental non redundant submodels for all the possible
-##   terms included.
-reduce_models <- function(chosen) {
-  Reduce(
-    function(chosen, x) {
-      if (is_next_submodel_redundant(chosen, x)) {
-        chosen
-      } else {
-        c(chosen, x)
-      }
-    },
-    chosen
-  )
-}
-
 ## Helper function to evaluate right hand side formulas in a context
 ## @param formula Formula to evaluate.
 ## @param data Data with which to evaluate.

--- a/R/formula.R
+++ b/R/formula.R
@@ -671,9 +671,9 @@ select_possible_terms_size <- function(chosen, terms, size) {
           x <- paste0("(", x, ")")
         }
       }
-      x
+      return(x)
     } else {
-      NA
+      return(NA)
     }
   })
   valid_submodels <- unlist(valid_submodels[!is.na(valid_submodels)])

--- a/R/formula.R
+++ b/R/formula.R
@@ -661,14 +661,9 @@ select_possible_terms_size <- function(chosen, terms, size) {
     linear <- terms_new$individual_terms
     dups <- setdiff(linear[!is.na(match(linear, additive))], chosen)
 
-    ## if model is straight redundant
-    not_redundant <- (
-      count_terms_chosen(c(chosen, x), duplicates = TRUE) -
-        length(dups)
-    ) == size
-    ## if already_chosen is not NA it means we have already chosen the linear
-    ## term
-    if (not_redundant) {
+    size_crr <- count_terms_chosen(c(chosen, x), duplicates = TRUE) -
+      length(dups)
+    if (size_crr == size) {
       if (length(dups) > 0) {
         tt <- terms(formula(paste("~", x, "-", paste(dups, collapse = "-"))))
         x <- setdiff(attr(tt, "term.labels"), chosen)

--- a/R/search.R
+++ b/R/search.R
@@ -33,8 +33,13 @@ search_forward <- function(p_ref, refmodel, nterms_max, verbose = TRUE, opt,
     }
   }
 
-  ## reduce chosen to a list of non-redundant accumulated models
-  return(list(solution_terms = setdiff(reduce_models(chosen), "1"),
+  # For `solution_terms`, `reduce_models(chosen)` used to be used instead of
+  # `chosen`. However, `reduce_models(chosen)` and `chosen` should be identical
+  # at this place because select_possible_terms_size() already avoids redundant
+  # models. Thus, use `chosen` here because it matches `submodels` (this
+  # matching is necessary because later in .get_submodels()'s `!refit_prj` case,
+  # `submodls` is indexed with integers which are based on `solution_terms`):
+  return(list(solution_terms = setdiff(chosen, "1"),
               submodls = submodels))
 }
 

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -64,9 +64,10 @@
 #'   no need for regularization, but sometimes we need to add some
 #'   regularization to avoid numerical problems.
 #' @param search_terms Only relevant for forward search. A custom character
-#'   vector of terms to consider for the search. The intercept (`"1"`) needs to
-#'   be included explicitly. The default considers all the terms in the
-#'   reference model's formula.
+#'   vector of terms to consider for the search. The intercept (`"1"`) is always
+#'   included internally via `union()`, so there's no difference between
+#'   including it explicitly or omitting it. The default `search_terms`
+#'   considers all the terms in the reference model's formula.
 #' @param verbose A single logical value indicating whether to print out
 #'   additional information during the computations.
 #' @param seed Pseudorandom number generation (PRNG) seed by which the same
@@ -299,6 +300,7 @@ parse_args_varsel <- function(refmodel, method, refit_prj, nterms_max,
     search_terms <- split_formula(refmodel$formula,
                                   data = refmodel$fetch_data())
   }
+  search_terms <- union("1", search_terms)
   has_group_features <- formula_contains_group_terms(refmodel$formula)
   has_additive_features <- formula_contains_additive_terms(refmodel$formula)
 
@@ -337,11 +339,7 @@ parse_args_varsel <- function(refmodel, method, refit_prj, nterms_max,
     nclusters <- 1
   }
 
-  if (length(search_terms) > 0) {
-    max_nv_possible <- count_terms_chosen(search_terms, duplicates = TRUE)
-  } else {
-    max_nv_possible <- count_terms_in_formula(refmodel$formula)
-  }
+  max_nv_possible <- count_terms_chosen(search_terms, duplicates = TRUE)
   if (is.null(nterms_max)) {
     nterms_max <- 19
   }

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -335,7 +335,7 @@ parse_args_varsel <- function(refmodel, method, refit_prj, nterms_max,
     nclusters <- 1
   }
 
-  if (!is.null(search_terms)) {
+  if (length(search_terms) > 0) {
     max_nv_possible <- count_terms_chosen(search_terms, duplicates = TRUE)
   } else {
     max_nv_possible <- count_terms_in_formula(refmodel$formula)

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -14,9 +14,9 @@
 #'   test set which is used for evaluating the predictive performance of the
 #'   reference model. If not provided, the training set is used.
 #' @param method The method for the search part. Possible options are `"L1"` for
-#'   L1 search and `"forward"` for forward search. If `NULL`, then `"forward"`
-#'   is used if the reference model has multilevel or additive terms and `"L1"`
-#'   otherwise. See also section "Details" below.
+#'   L1 search and `"forward"` for forward search. If `NULL`, then internally,
+#'   `"L1"` is used, except if the reference model has multilevel or additive
+#'   terms or if `!is.null(search_terms)`. See also section "Details" below.
 #' @param refit_prj A single logical value indicating whether to fit the
 #'   submodels along the solution path again (`TRUE`) or to retrieve their fits
 #'   from the search part (`FALSE`) before using those (re-)fits in the
@@ -90,7 +90,8 @@
 #'
 #'   For argument `method`, there are some restrictions: For a reference model
 #'   with multilevel or additive formula terms, only the forward search is
-#'   available.
+#'   available. Furthermore, argument `search_terms` requires a forward search
+#'   to take effect.
 #'
 #'   L1 search is faster than forward search, but forward search may be more
 #'   accurate. Furthermore, forward search may find a sparser model with

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -64,10 +64,12 @@
 #'   no need for regularization, but sometimes we need to add some
 #'   regularization to avoid numerical problems.
 #' @param search_terms Only relevant for forward search. A custom character
-#'   vector of terms to consider for the search. The intercept (`"1"`) is always
-#'   included internally via `union()`, so there's no difference between
-#'   including it explicitly or omitting it. The default `search_terms`
-#'   considers all the terms in the reference model's formula.
+#'   vector of predictor term blocks to consider for the search. Section
+#'   "Details" below describes more precisely what "predictor term block" means.
+#'   The intercept (`"1"`) is always included internally via `union()`, so
+#'   there's no difference between including it explicitly or omitting it. The
+#'   default `search_terms` considers all the terms in the reference model's
+#'   formula.
 #' @param verbose A single logical value indicating whether to print out
 #'   additional information during the computations.
 #' @param seed Pseudorandom number generation (PRNG) seed by which the same
@@ -102,6 +104,31 @@
 #'   An L1 search may select interaction terms before the corresponding main
 #'   terms are selected. If this is undesired, choose the forward search
 #'   instead.
+#'
+#'   The elements of the `search_terms` character vector don't need to be
+#'   individual predictor terms. Instead, they can be building blocks consisting
+#'   of several predictor terms connected by the `+` symbol. To understand how
+#'   these building blocks works, it is important to know how \pkg{projpred}'s
+#'   forward search works: It starts with an empty vector `chosen` which will
+#'   later contain already selected predictor terms. Then, the search iterates
+#'   over model sizes \eqn{j \in \{1, ..., J\}}{j = 1, ..., J}. The candidate
+#'   models at model size \eqn{j} are constructed from those elements from
+#'   `search_terms` which yield model size \eqn{j} when combined with the
+#'   `chosen` predictor terms. Note that sometimes, there may be no candidate
+#'   models for model size \eqn{j}. Also note that internally, `search_terms` is
+#'   expanded to include the intercept (`"1"`), so the first step of the search
+#'   (model size 1) always consists of the intercept-only model as the only
+#'   candidate.
+#'
+#'   As a `search_terms` example, consider a reference model with formula `y ~
+#'   x1 + x2 + x3`. Then, to ensure that `x1` is always included in the
+#'   candidate models, specify `search_terms = c("x1", "x1 + x2", "x1 + x3",
+#'   "x1 + x2 + x3")`. This search would start with `y ~ 1` as the only
+#'   candidate at model size 1. At model size 2, `y ~ x1` would be the only
+#'   candidate. At model size 3, `y ~ x1 + x2` and `y ~ x1 + x3` would be the
+#'   two candidates. At the last model size of 4, `y ~ x1 + x2 + x3` would be
+#'   the only candidate. As another example, to exclude `x1` from the search,
+#'   specify `search_terms = c("x2", "x3", "x2 + x3")`.
 #'
 #' @return An object of class `vsel`. The elements of this object are not meant
 #'   to be accessed directly but instead via helper functions (see the vignette

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -285,15 +285,13 @@ select <- function(method, p_sel, refmodel, nterms_max, penalty, verbose, opt,
   }
 }
 
+## Auxiliary function for parsing the input arguments for varsel.
+## The arguments specified by the user (or the function calling this function)
+## are treated as they are, but if some are not given, then this function
+## fills them in with the default values. The purpose of this function is to
+## avoid repeating the same code both in varsel and cv_varsel.
 parse_args_varsel <- function(refmodel, method, refit_prj, nterms_max,
                               nclusters, search_terms) {
-  ##
-  ## Auxiliary function for parsing the input arguments for varsel.
-  ## The arguments specified by the user (or the function calling this function)
-  ## are treated as they are, but if some are not given, then this function
-  ## fills them in with the default values. The purpose of this function is to
-  ## avoid repeating the same code both in varsel and cv_varsel.
-  ##
   if (is.null(search_terms)) {
     search_terms <- split_formula(refmodel$formula,
                                   data = refmodel$fetch_data())

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -63,9 +63,10 @@
 #'   projecting onto (i.e., fitting) submodels which are GLMs. Usually there is
 #'   no need for regularization, but sometimes we need to add some
 #'   regularization to avoid numerical problems.
-#' @param search_terms A custom character vector of terms to consider for the
-#'   search. The intercept (`"1"`) needs to be included explicitly. The default
-#'   considers all the terms in the reference model's formula.
+#' @param search_terms Only relevant for forward search. A custom character
+#'   vector of terms to consider for the search. The intercept (`"1"`) needs to
+#'   be included explicitly. The default considers all the terms in the
+#'   reference model's formula.
 #' @param verbose A single logical value indicating whether to print out
 #'   additional information during the computations.
 #' @param seed Pseudorandom number generation (PRNG) seed by which the same

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -195,13 +195,14 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
     nterms_max = nterms_max, penalty = penalty, verbose = verbose, opt = opt,
     search_terms = search_terms, ...
   )
-  solution_terms <- search_path$solution_terms
 
   ## statistics for the selected submodels
-  submodels <- .get_submodels(search_path = search_path,
-                              nterms = c(0, seq_along(solution_terms)),
-                              p_ref = p_pred, refmodel = refmodel,
-                              regul = regul, refit_prj = refit_prj, ...)
+  submodels <- .get_submodels(
+    search_path = search_path,
+    nterms = c(0, seq_along(search_path$solution_terms)),
+    p_ref = p_pred, refmodel = refmodel, regul = regul, refit_prj = refit_prj,
+    ...
+  )
   sub <- .get_sub_summaries(
     submodels = submodels, test_points = seq_along(refmodel$y),
     refmodel = refmodel

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -44,9 +44,9 @@ minimizer (during a forward search and also during the evaluation part, but
 the latter only if \code{refit_prj} is \code{TRUE}).}
 
 \item{method}{The method for the search part. Possible options are \code{"L1"} for
-L1 search and \code{"forward"} for forward search. If \code{NULL}, then \code{"forward"}
-is used if the reference model has multilevel or additive terms and \code{"L1"}
-otherwise. See also section "Details" below.}
+L1 search and \code{"forward"} for forward search. If \code{NULL}, then internally,
+\code{"L1"} is used, except if the reference model has multilevel or additive
+terms or if \code{!is.null(search_terms)}. See also section "Details" below.}
 
 \item{cv_method}{The CV method, either \code{"LOO"} or \code{"kfold"}. In the \code{"LOO"}
 case, a Pareto-smoothed importance sampling leave-one-out CV (PSIS-LOO CV)
@@ -178,7 +178,8 @@ linearly.
 
 For argument \code{method}, there are some restrictions: For a reference model
 with multilevel or additive formula terms, only the forward search is
-available.
+available. Furthermore, argument \code{search_terms} requires a forward search
+to take effect.
 
 L1 search is faster than forward search, but forward search may be more
 accurate. Furthermore, forward search may find a sparser model with

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -146,9 +146,10 @@ K-fold CV, and for drawing new group-level effects when predicting from a
 multilevel submodel (however, not yet in case of a GAMM).}
 
 \item{search_terms}{Only relevant for forward search. A custom character
-vector of terms to consider for the search. The intercept (\code{"1"}) needs to
-be included explicitly. The default considers all the terms in the
-reference model's formula.}
+vector of terms to consider for the search. The intercept (\code{"1"}) is always
+included internally via \code{union()}, so there's no difference between
+including it explicitly or omitting it. The default \code{search_terms}
+considers all the terms in the reference model's formula.}
 }
 \value{
 An object of class \code{vsel}. The elements of this object are not meant

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -145,9 +145,10 @@ is smaller than the number of observations), for sampling the folds in
 K-fold CV, and for drawing new group-level effects when predicting from a
 multilevel submodel (however, not yet in case of a GAMM).}
 
-\item{search_terms}{A custom character vector of terms to consider for the
-search. The intercept (\code{"1"}) needs to be included explicitly. The default
-considers all the terms in the reference model's formula.}
+\item{search_terms}{Only relevant for forward search. A custom character
+vector of terms to consider for the search. The intercept (\code{"1"}) needs to
+be included explicitly. The default considers all the terms in the
+reference model's formula.}
 }
 \value{
 An object of class \code{vsel}. The elements of this object are not meant

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -146,10 +146,12 @@ K-fold CV, and for drawing new group-level effects when predicting from a
 multilevel submodel (however, not yet in case of a GAMM).}
 
 \item{search_terms}{Only relevant for forward search. A custom character
-vector of terms to consider for the search. The intercept (\code{"1"}) is always
-included internally via \code{union()}, so there's no difference between
-including it explicitly or omitting it. The default \code{search_terms}
-considers all the terms in the reference model's formula.}
+vector of predictor term blocks to consider for the search. Section
+"Details" below describes more precisely what "predictor term block" means.
+The intercept (\code{"1"}) is always included internally via \code{union()}, so
+there's no difference between including it explicitly or omitting it. The
+default \code{search_terms} considers all the terms in the reference model's
+formula.}
 }
 \value{
 An object of class \code{vsel}. The elements of this object are not meant
@@ -190,6 +192,29 @@ overfitting when more predictors are added.
 An L1 search may select interaction terms before the corresponding main
 terms are selected. If this is undesired, choose the forward search
 instead.
+
+The elements of the \code{search_terms} character vector don't need to be
+individual predictor terms. Instead, they can be building blocks consisting
+of several predictor terms connected by the \code{+} symbol. To understand how
+these building blocks works, it is important to know how \pkg{projpred}'s
+forward search works: It starts with an empty vector \code{chosen} which will
+later contain already selected predictor terms. Then, the search iterates
+over model sizes \eqn{j \in \{1, ..., J\}}{j = 1, ..., J}. The candidate
+models at model size \eqn{j} are constructed from those elements from
+\code{search_terms} which yield model size \eqn{j} when combined with the
+\code{chosen} predictor terms. Note that sometimes, there may be no candidate
+models for model size \eqn{j}. Also note that internally, \code{search_terms} is
+expanded to include the intercept (\code{"1"}), so the first step of the search
+(model size 1) always consists of the intercept-only model as the only
+candidate.
+
+As a \code{search_terms} example, consider a reference model with formula \code{y ~ x1 + x2 + x3}. Then, to ensure that \code{x1} is always included in the
+candidate models, specify \code{search_terms = c("x1", "x1 + x2", "x1 + x3", "x1 + x2 + x3")}. This search would start with \code{y ~ 1} as the only
+candidate at model size 1. At model size 2, \code{y ~ x1} would be the only
+candidate. At model size 3, \code{y ~ x1 + x2} and \code{y ~ x1 + x3} would be the
+two candidates. At the last model size of 4, \code{y ~ x1 + x2 + x3} would be
+the only candidate. As another example, to exclude \code{x1} from the search,
+specify \code{search_terms = c("x2", "x3", "x2 + x3")}.
 }
 \note{
 The case \code{cv_method == "LOO" && !validate_search} constitutes an

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -110,10 +110,12 @@ those predictors have no cost and will therefore be selected first, whereas
 used for each predictor.}
 
 \item{search_terms}{Only relevant for forward search. A custom character
-vector of terms to consider for the search. The intercept (\code{"1"}) is always
-included internally via \code{union()}, so there's no difference between
-including it explicitly or omitting it. The default \code{search_terms}
-considers all the terms in the reference model's formula.}
+vector of predictor term blocks to consider for the search. Section
+"Details" below describes more precisely what "predictor term block" means.
+The intercept (\code{"1"}) is always included internally via \code{union()}, so
+there's no difference between including it explicitly or omitting it. The
+default \code{search_terms} considers all the terms in the reference model's
+formula.}
 
 \item{seed}{Pseudorandom number generation (PRNG) seed by which the same
 results can be obtained again if needed. If \code{NULL}, no seed is set and
@@ -158,6 +160,29 @@ overfitting when more predictors are added.
 An L1 search may select interaction terms before the corresponding main
 terms are selected. If this is undesired, choose the forward search
 instead.
+
+The elements of the \code{search_terms} character vector don't need to be
+individual predictor terms. Instead, they can be building blocks consisting
+of several predictor terms connected by the \code{+} symbol. To understand how
+these building blocks works, it is important to know how \pkg{projpred}'s
+forward search works: It starts with an empty vector \code{chosen} which will
+later contain already selected predictor terms. Then, the search iterates
+over model sizes \eqn{j \in \{1, ..., J\}}{j = 1, ..., J}. The candidate
+models at model size \eqn{j} are constructed from those elements from
+\code{search_terms} which yield model size \eqn{j} when combined with the
+\code{chosen} predictor terms. Note that sometimes, there may be no candidate
+models for model size \eqn{j}. Also note that internally, \code{search_terms} is
+expanded to include the intercept (\code{"1"}), so the first step of the search
+(model size 1) always consists of the intercept-only model as the only
+candidate.
+
+As a \code{search_terms} example, consider a reference model with formula \code{y ~ x1 + x2 + x3}. Then, to ensure that \code{x1} is always included in the
+candidate models, specify \code{search_terms = c("x1", "x1 + x2", "x1 + x3", "x1 + x2 + x3")}. This search would start with \code{y ~ 1} as the only
+candidate at model size 1. At model size 2, \code{y ~ x1} would be the only
+candidate. At model size 3, \code{y ~ x1 + x2} and \code{y ~ x1 + x3} would be the
+two candidates. At the last model size of 4, \code{y ~ x1 + x2 + x3} would be
+the only candidate. As another example, to exclude \code{x1} from the search,
+specify \code{search_terms = c("x2", "x3", "x2 + x3")}.
 }
 \examples{
 if (requireNamespace("rstanarm", quietly = TRUE)) {

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -110,9 +110,10 @@ those predictors have no cost and will therefore be selected first, whereas
 used for each predictor.}
 
 \item{search_terms}{Only relevant for forward search. A custom character
-vector of terms to consider for the search. The intercept (\code{"1"}) needs to
-be included explicitly. The default considers all the terms in the
-reference model's formula.}
+vector of terms to consider for the search. The intercept (\code{"1"}) is always
+included internally via \code{union()}, so there's no difference between
+including it explicitly or omitting it. The default \code{search_terms}
+considers all the terms in the reference model's formula.}
 
 \item{seed}{Pseudorandom number generation (PRNG) seed by which the same
 results can be obtained again if needed. If \code{NULL}, no seed is set and

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -45,9 +45,9 @@ test set which is used for evaluating the predictive performance of the
 reference model. If not provided, the training set is used.}
 
 \item{method}{The method for the search part. Possible options are \code{"L1"} for
-L1 search and \code{"forward"} for forward search. If \code{NULL}, then \code{"forward"}
-is used if the reference model has multilevel or additive terms and \code{"L1"}
-otherwise. See also section "Details" below.}
+L1 search and \code{"forward"} for forward search. If \code{NULL}, then internally,
+\code{"L1"} is used, except if the reference model has multilevel or additive
+terms or if \code{!is.null(search_terms)}. See also section "Details" below.}
 
 \item{ndraws}{Number of posterior draws used in the search part. Ignored if
 \code{nclusters} is not \code{NULL} or in case of L1 search (because L1 search always
@@ -146,7 +146,8 @@ linearly.
 
 For argument \code{method}, there are some restrictions: For a reference model
 with multilevel or additive formula terms, only the forward search is
-available.
+available. Furthermore, argument \code{search_terms} requires a forward search
+to take effect.
 
 L1 search is faster than forward search, but forward search may be more
 accurate. Furthermore, forward search may find a sparser model with

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -109,9 +109,10 @@ those predictors have no cost and will therefore be selected first, whereas
 \code{Inf} means those predictors will never be selected. If \code{NULL}, then \code{1} is
 used for each predictor.}
 
-\item{search_terms}{A custom character vector of terms to consider for the
-search. The intercept (\code{"1"}) needs to be included explicitly. The default
-considers all the terms in the reference model's formula.}
+\item{search_terms}{Only relevant for forward search. A custom character
+vector of terms to consider for the search. The intercept (\code{"1"}) needs to
+be included explicitly. The default considers all the terms in the
+reference model's formula.}
 
 \item{seed}{Pseudorandom number generation (PRNG) seed by which the same
 results can be obtained again if needed. If \code{NULL}, no seed is set and

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -833,9 +833,9 @@ projection_tester <- function(p,
   y_nms <- paste0(".", y_nm)
   # A preliminary check for `nprjdraws_expected` (doesn't work for "datafit"s
   # and, because of issue #131, for submodels which are GAMMs):
-  sub_formul_crr_rhs <- as.formula(paste(
+  sub_formul_crr_rhs <- flatten_formula(as.formula(paste(
     "~", paste(sub_trms_crr, collapse = " + ")
-  ))
+  )))
   if (!inherits(p$refmodel, "datafit") &&
       !(formula_contains_additive_terms(sub_formul_crr_rhs) &&
         formula_contains_group_terms(sub_formul_crr_rhs))) {
@@ -849,9 +849,9 @@ projection_tester <- function(p,
     y_nms <- paste0(y_nms, ".", seq_len(nprjdraws_expected))
   }
   sub_formul_crr <- lapply(y_nms, function(y_nm_i) {
-    as.formula(paste(
+    flatten_formula(as.formula(paste(
       y_nm_i, "~", paste(sub_trms_crr, collapse = " + ")
-    ))
+    )))
   })
   sub_data_crr <- p$refmodel$fetch_data()
   if (p_type_expected) {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -310,6 +310,11 @@ nterms_avail <- c(nterms_avail, list(
   full = 0:nterms_max_tst
 ))
 
+nterms_max_smmry <- list(
+  default_nterms_max_smmry = NULL,
+  halfway = nterms_max_tst %/% 2L
+)
+
 ## Modified datasets ------------------------------------------------------
 
 dat_wobs_ones <- within(dat, {
@@ -1093,17 +1098,18 @@ cre_args_smmry_vsel <- function(args_obj) {
     lapply(stats_tst, function(stats_crr) {
       if (!run_more) {
         if (!is.null(args_obj[[tstsetup_vsel]]$search_terms)) {
-          nterms_tst <- nterms_avail["default_nterms"]
+          nterms_tst <- nterms_max_smmry["default_nterms_max_smmry"]
         } else {
-          nterms_tst <- nterms_avail["single"]
+          nterms_tst <- nterms_max_smmry["halfway"]
         }
       } else {
         if (mod_crr == "glm" && fam_crr == "gauss" &&
             is.null(args_obj[[tstsetup_vsel]]$search_terms) &&
             length(stats_crr) == 0) {
-          nterms_tst <- nterms_avail[c("default_nterms", "single")]
+          nterms_tst <- nterms_max_smmry[c("default_nterms_max_smmry",
+                                           "halfway")]
         } else {
-          nterms_tst <- nterms_avail["default_nterms"]
+          nterms_tst <- nterms_max_smmry["default_nterms_max_smmry"]
         }
       }
       lapply(nterms_tst, function(nterms_crr) {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -306,12 +306,9 @@ if (!run_more) {
 nterms_avail <- c(nterms_avail, list(
   empty = 0L,
   single = nterms_max_tst %/% 2L,
-  subvec = as.integer(round(seq(0, nterms_max_tst, length.out = 3))),
+  subvec = as.integer(round(seq(0, nterms_max_tst, length.out = 2))),
   full = 0:nterms_max_tst
 ))
-if (identical(nterms_avail$subvec, nterms_avail$full)) {
-  nterms_avail <- nterms_avail[setdiff(names(nterms_avail), "full")]
-}
 
 ## Modified datasets ------------------------------------------------------
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -309,6 +309,9 @@ nterms_avail <- c(nterms_avail, list(
   subvec = as.integer(round(seq(0, nterms_max_tst, length.out = 3))),
   full = 0:nterms_max_tst
 ))
+if (identical(nterms_avail$subvec, nterms_avail$full)) {
+  nterms_avail <- nterms_avail[setdiff(names(nterms_avail), "full")]
+}
 
 ## Modified datasets ------------------------------------------------------
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -644,6 +644,7 @@ meth_tst <- list(
 
 search_trms_tst <- list(
   default_search_trms = list(),
+  alltrms = list(search_terms = setdiff(trms_common, "offset(offs_col)")),
   fixed = list(search_terms = c("xco.1", "xco.1 + xco.2", "xco.1 + xco.3",
                                 "xco.1 + xco.2 + xco.3")),
   excluded = list(search_terms = c("xco.2", "xco.3", "xco.2 + xco.3")),
@@ -713,14 +714,15 @@ if (run_vs) {
       if (mod_crr == "glm" && fam_crr == "gauss" &&
           grepl("\\.stdformul\\.", tstsetup_ref) &&
           identical(meth_i$method, "forward")) {
-        # Here, we test non-NULL `search_terms`:
-        search_trms <- search_trms_tst[setdiff(names(search_trms_tst),
-                                               "default_search_trms")]
+        # Here, we also test non-NULL `search_terms`:
+        search_trms <- search_trms_tst
       } else {
         search_trms <- search_trms_tst["default_search_trms"]
       }
       lapply(search_trms, function(search_trms_i) {
-        if (length(search_trms_i)) {
+        if (length(search_trms_i) &&
+            !identical(search_trms_i$search_terms,
+                       search_trms_tst$alltrms$search_terms)) {
           nterms_max_tst <- count_terms_chosen(search_trms_i$search_terms) - 1L
         }
         return(c(

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -933,6 +933,7 @@ cre_args_prj_vsel <- function(tstsetups_prj_vsel) {
       list(nclusters = nclusters_pred_tst, seed = seed_tst)
     )
     if (args_obj[[tstsetup_vsel]]$mod_nm != "glm" ||
+        !is.null(args_obj[[tstsetup_vsel]]$search_terms) ||
         grepl("\\.spclformul", tstsetup_vsel)) {
       nterms_avail <- nterms_avail["subvec"]
     }
@@ -965,6 +966,10 @@ if (run_vs) {
     }
     return(tstsetups_out)
   }))
+  tstsetups_prj_vs <- union(
+    tstsetups_prj_vs,
+    grep("\\.default_search_trms", names(vss), value = TRUE, invert = TRUE)
+  )
   tstsetups_prj_vs <- setNames(nm = tstsetups_prj_vs)
   stopifnot(length(tstsetups_prj_vs) > 0)
   args_prj_vs <- cre_args_prj_vsel(tstsetups_prj_vs)
@@ -999,6 +1004,10 @@ if (run_cvvs) {
     }
     return(tstsetups_out)
   }))
+  tstsetups_prj_cvvs <- union(
+    tstsetups_prj_cvvs,
+    grep("\\.default_search_trms", names(cvvss), value = TRUE, invert = TRUE)
+  )
   tstsetups_prj_cvvs <- setNames(nm = tstsetups_prj_cvvs)
   stopifnot(length(tstsetups_prj_cvvs) > 0)
   args_prj_cvvs <- cre_args_prj_vsel(tstsetups_prj_cvvs)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -797,14 +797,17 @@ if (run_cvvs) {
           # `validate_search = FALSE`:
           meth_i <- c(meth_i, list(validate_search = FALSE))
         }
-        return(c(
-          nlist(tstsetup_ref), only_nonargs(args_ref[[tstsetup_ref]]),
-          list(
-            nclusters = nclusters_tst, nclusters_pred = nclusters_pred_tst,
-            nterms_max = nterms_max_tst, verbose = FALSE, seed = seed_tst
-          ),
-          meth_i, cvmeth_i
-        ))
+        search_trms <- search_trms_tst["default_search_trms"]
+        lapply(search_trms, function(search_trms_i) {
+          return(c(
+            nlist(tstsetup_ref), only_nonargs(args_ref[[tstsetup_ref]]),
+            list(
+              nclusters = nclusters_tst, nclusters_pred = nclusters_pred_tst,
+              nterms_max = nterms_max_tst, verbose = FALSE, seed = seed_tst
+            ),
+            meth_i, cvmeth_i, search_trms_i
+          ))
+        })
       })
     })
   })

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1086,10 +1086,17 @@ cre_args_smmry_vsel <- function(args_obj) {
                                        "binom" = "binom_stats",
                                        "common_stats"),
                         character())
+    if (!run_more && !is.null(args_obj[[tstsetup_vsel]]$search_terms)) {
+      add_stats <- character()
+    }
     stats_tst <- stats_tst[c("default_stats", add_stats)]
     lapply(stats_tst, function(stats_crr) {
       if (!run_more) {
-        nterms_tst <- nterms_avail["single"]
+        if (!is.null(args_obj[[tstsetup_vsel]]$search_terms)) {
+          nterms_tst <- nterms_avail["default_nterms"]
+        } else {
+          nterms_tst <- nterms_avail["single"]
+        }
       } else {
         if (mod_crr == "glm" && fam_crr == "gauss" &&
             is.null(args_obj[[tstsetup_vsel]]$search_terms) &&

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -948,25 +948,24 @@ cre_args_prj_vsel <- function(tstsetups_prj_vsel) {
 #### varsel() -------------------------------------------------------------
 
 if (run_vs) {
-  tstsetups_prj_vs <- setNames(
-    nm = unlist(lapply(mod_nms, function(mod_nm) {
-      if (any(grepl(paste0("\\.", mod_nm, "\\.gauss\\."), names(vss)))) {
-        tstsetups_out <- grep(
-          paste0("\\.", mod_nm, "\\.gauss\\..*\\.default_meth"), names(vss),
-          value = TRUE
-        )
-      } else {
-        tstsetups_out <- grep(
-          paste0("\\.", mod_nm, "\\..*\\.default_meth"), names(vss),
-          value = TRUE
-        )
-      }
-      if (!run_more) {
-        tstsetups_out <- head(tstsetups_out, 1)
-      }
-      return(tstsetups_out)
-    }))
-  )
+  tstsetups_prj_vs <- unlist(lapply(mod_nms, function(mod_nm) {
+    if (any(grepl(paste0("\\.", mod_nm, "\\.gauss\\."), names(vss)))) {
+      tstsetups_out <- grep(
+        paste0("\\.", mod_nm, "\\.gauss\\..*\\.default_meth"), names(vss),
+        value = TRUE
+      )
+    } else {
+      tstsetups_out <- grep(
+        paste0("\\.", mod_nm, "\\..*\\.default_meth"), names(vss),
+        value = TRUE
+      )
+    }
+    if (!run_more) {
+      tstsetups_out <- head(tstsetups_out, 1)
+    }
+    return(tstsetups_out)
+  }))
+  tstsetups_prj_vs <- setNames(nm = tstsetups_prj_vs)
   stopifnot(length(tstsetups_prj_vs) > 0)
   args_prj_vs <- cre_args_prj_vsel(tstsetups_prj_vs)
   args_prj_vs <- unlist_cust(args_prj_vs)
@@ -982,26 +981,25 @@ if (run_vs) {
 #### cv_varsel() ----------------------------------------------------------
 
 if (run_cvvs) {
-  tstsetups_prj_cvvs <- setNames(
-    nm = unlist(lapply(mod_nms, function(mod_nm) {
-      if (any(grepl(paste0("\\.", mod_nm, "\\.gauss\\."), names(cvvss)))) {
-        tstsetups_out <- grep(
-          paste0("\\.", mod_nm,
-                 "\\.gauss\\..*\\.default_meth\\.default_cvmeth"),
-          names(cvvss), value = TRUE
-        )
-      } else {
-        tstsetups_out <- grep(
-          paste0("\\.", mod_nm, "\\..*\\.default_meth\\.default_cvmeth"),
-          names(cvvss), value = TRUE
-        )
-      }
-      if (!run_more) {
-        tstsetups_out <- head(tstsetups_out, 1)
-      }
-      return(tstsetups_out)
-    }))
-  )
+  tstsetups_prj_cvvs <- unlist(lapply(mod_nms, function(mod_nm) {
+    if (any(grepl(paste0("\\.", mod_nm, "\\.gauss\\."), names(cvvss)))) {
+      tstsetups_out <- grep(
+        paste0("\\.", mod_nm,
+               "\\.gauss\\..*\\.default_meth\\.default_cvmeth"),
+        names(cvvss), value = TRUE
+      )
+    } else {
+      tstsetups_out <- grep(
+        paste0("\\.", mod_nm, "\\..*\\.default_meth\\.default_cvmeth"),
+        names(cvvss), value = TRUE
+      )
+    }
+    if (!run_more) {
+      tstsetups_out <- head(tstsetups_out, 1)
+    }
+    return(tstsetups_out)
+  }))
+  tstsetups_prj_cvvs <- setNames(nm = tstsetups_prj_cvvs)
   stopifnot(length(tstsetups_prj_cvvs) > 0)
   args_prj_cvvs <- cre_args_prj_vsel(tstsetups_prj_cvvs)
   args_prj_cvvs <- unlist_cust(args_prj_cvvs)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1076,7 +1076,10 @@ cre_args_smmry_vsel <- function(args_obj) {
   tstsetups_smmry_vsel <- union(
     tstsetups_smmry_vsel,
     unlist(lapply(mods_fams_missing, function(mod_fam) {
-      head(grep(paste0("\\.", mod_fam, "\\."), tstsetups, value = TRUE), 1)
+      head(
+        grep(paste0(".", mod_fam, "."), tstsetups, value = TRUE, fixed = TRUE),
+        1
+      )
     }))
   )
 

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -260,6 +260,9 @@ test_that(paste(
       method_expected = meth_exp_crr,
       nprjdraws_search_expected = 1L,
       nprjdraws_eval_expected = 1L,
+      search_trms_empty_size =
+        length(args_vs_datafit[[tstsetup]]$search_terms) &&
+        all(grepl("\\+", args_vs_datafit[[tstsetup]]$search_terms)),
       extra_tol = 1.2,
       info_str = tstsetup
     )
@@ -527,6 +530,9 @@ test_that(paste(
     smmry_tester(
       smmry,
       vsel_expected = vss_datafit[[tstsetup]],
+      search_trms_empty_size =
+        length(args_vs_datafit[[tstsetup]]$search_terms) &&
+        all(grepl("\\+", args_vs_datafit[[tstsetup]]$search_terms)),
       info_str = tstsetup,
       stats_expected = stats_common,
       type_expected = type_tst,

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -292,6 +292,9 @@ test_that(paste(
       valsearch_expected = args_cvvs_datafit[[tstsetup]]$validate_search,
       nprjdraws_search_expected = 1L,
       nprjdraws_eval_expected = 1L,
+      search_trms_empty_size =
+        length(args_cvvs_datafit[[tstsetup]]$search_terms) &&
+        all(grepl("\\+", args_cvvs_datafit[[tstsetup]]$search_terms)),
       extra_tol = 1.2,
       info_str = tstsetup
     )
@@ -570,6 +573,9 @@ test_that(paste(
     smmry_tester(
       smmry,
       vsel_expected = cvvss_datafit[[tstsetup]],
+      search_trms_empty_size =
+        length(args_cvvs_datafit[[tstsetup]]$search_terms) &&
+        all(grepl("\\+", args_cvvs_datafit[[tstsetup]]$search_terms)),
       info_str = tstsetup,
       stats_expected = stats_common,
       type_expected = type_tst,

--- a/tests/testthat/test_formula.R
+++ b/tests/testthat/test_formula.R
@@ -246,12 +246,64 @@ test_that("check redundant models", {
   expect_false(is_next_submodel_redundant(current, "z"))
 })
 
-test_that("check reduce models", {
-  chosen <- c("x + (x | g)", "x", "(1 | g)", "(x | g)")
-  r <- reduce_models(chosen)
-  expect_equal(r, chosen[1])
+test_that("select_possible_terms_size() avoids redundant models", {
+  chosen <- "x1 * x2"
+  size_chosen <- count_terms_chosen(chosen)
+  expect_equal(size_chosen, 4)
+  allterms <- c("x1 * x2", "x1", "x2")
+  expect_null(
+    select_possible_terms_size(chosen, allterms, size = size_chosen + 1)
+  )
 
-  chosen <- c("x", "(1 | g)", "(x | g)")
-  r <- reduce_models(chosen)
-  expect_equal(r, chosen)
+  chosen <- "x + (x | g)"
+  size_chosen <- count_terms_chosen(chosen)
+  expect_equal(size_chosen, 4)
+  allterms <- c("x + (x | g)", "x", "(1 | g)", "(x | g)")
+  expect_null(
+    select_possible_terms_size(chosen, allterms, size = size_chosen + 1)
+  )
+
+  chosen <- "s(x1)"
+  size_chosen <- count_terms_chosen(chosen)
+  expect_equal(size_chosen, 2)
+  allterms <- c("s(x1)", "x1")
+  expect_null(
+    select_possible_terms_size(chosen, allterms, size = size_chosen + 1)
+  )
+})
+
+test_that("select_possible_terms_size() works for non-redundant models", {
+  chosen <- "x1"
+  size_chosen <- count_terms_chosen(chosen)
+  expect_equal(size_chosen, 2)
+  allterms <- c("x1 * x2", "x1", "x2")
+  expect_identical(
+    select_possible_terms_size(chosen, allterms, size = size_chosen + 1),
+    "x2"
+  )
+  chosen <- c(chosen, "x2")
+  size_chosen <- count_terms_chosen(chosen)
+  expect_equal(size_chosen, 3)
+  expect_identical(
+    select_possible_terms_size(chosen, allterms, size = size_chosen + 1),
+    "x1:x2"
+  )
+
+  chosen <- "x"
+  size_chosen <- count_terms_chosen(chosen)
+  expect_equal(size_chosen, 2)
+  allterms <- c("x", "(1 | g)", "(x | g)")
+  expect_identical(
+    select_possible_terms_size(chosen, allterms, size = size_chosen + 1),
+    "(1 | g)"
+  )
+
+  chosen <- "x1"
+  size_chosen <- count_terms_chosen(chosen)
+  expect_equal(size_chosen, 2)
+  allterms <- c("s(x1)", "x1")
+  expect_identical(
+    select_possible_terms_size(chosen, allterms, size = size_chosen + 1),
+    "s(x1)"
+  )
 })

--- a/tests/testthat/test_methods_vsel.R
+++ b/tests/testthat/test_methods_vsel.R
@@ -74,6 +74,9 @@ test_that(paste(
     smmry_tester(
       smmrys_vs[[tstsetup]],
       vsel_expected = vss[[tstsetup_vs]],
+      search_trms_empty_size =
+        length(args_vs[[tstsetup_vs]]$search_terms) &&
+        all(grepl("\\+", args_vs[[tstsetup_vs]]$search_terms)),
       info_str = tstsetup,
       stats_expected = args_smmry_vs[[tstsetup]]$stats,
       type_expected = args_smmry_vs[[tstsetup]]$type,

--- a/tests/testthat/test_methods_vsel.R
+++ b/tests/testthat/test_methods_vsel.R
@@ -96,6 +96,9 @@ test_that(paste(
     smmry_tester(
       smmrys_cvvs[[tstsetup]],
       vsel_expected = cvvss[[tstsetup_cvvs]],
+      search_trms_empty_size =
+        length(args_cvvs[[tstsetup_cvvs]]$search_terms) &&
+        all(grepl("\\+", args_cvvs[[tstsetup_cvvs]]$search_terms)),
       info_str = tstsetup,
       stats_expected = args_smmry_cvvs[[tstsetup]]$stats,
       type_expected = args_smmry_cvvs[[tstsetup]]$type,

--- a/tests/testthat/test_proj_pred.R
+++ b/tests/testthat/test_proj_pred.R
@@ -151,7 +151,7 @@ test_that(paste(
 ), {
   skip_if_not(run_cvvs)
   tstsetups <- head(
-    grep("\\.glm\\.gauss.*\\.default_meth\\.default_cvmeth\\.subvec",
+    grep("\\.glm\\.gauss.*\\.default_meth\\.default_cvmeth\\..*\\.subvec",
          names(prjs_cvvs), value = TRUE),
     1
   )
@@ -770,7 +770,7 @@ test_that(paste(
 ), {
   skip_if_not(run_cvvs)
   tstsetups <- head(
-    grep("\\.glm\\.gauss.*\\.default_meth\\.default_cvmeth\\.subvec",
+    grep("\\.glm\\.gauss.*\\.default_meth\\.default_cvmeth\\..*\\.subvec",
          names(prjs_cvvs), value = TRUE),
     1
   )

--- a/tests/testthat/test_proj_pred.R
+++ b/tests/testthat/test_proj_pred.R
@@ -131,7 +131,7 @@ test_that(paste(
   "to project() works"
 ), {
   skip_if_not(run_vs)
-  tstsetups <- head(grep("\\.glm\\.gauss.*\\.default_meth\\.subvec",
+  tstsetups <- head(grep("\\.glm\\.gauss.*\\.default_meth\\..*\\.subvec",
                          names(prjs_vs), value = TRUE),
                     1)
   for (tstsetup in tstsetups) {
@@ -510,8 +510,8 @@ test_that(paste(
   "`filter_nterms` works (for an `object` of (informal) class \"proj_list\")"
 ), {
   skip_if_not(run_vs)
-  tstsetups <- grep("\\.glm\\.gauss.*\\.default_meth\\.full$", names(prjs_vs),
-                    value = TRUE)
+  tstsetups <- grep("\\.glm\\.gauss.*\\.default_meth\\..*\\.full$",
+                    names(prjs_vs), value = TRUE)
   for (tstsetup in tstsetups) {
     # Unavailable number(s) of terms:
     for (filter_nterms_crr in nterms_unavail) {
@@ -749,7 +749,7 @@ test_that(paste(
   "to project() works"
 ), {
   skip_if_not(run_vs)
-  tstsetups <- head(grep("\\.glm\\.gauss.*\\.default_meth\\.subvec",
+  tstsetups <- head(grep("\\.glm\\.gauss.*\\.default_meth\\..*\\.subvec",
                          names(prjs_vs), value = TRUE),
                     1)
   for (tstsetup in tstsetups) {
@@ -1063,8 +1063,8 @@ test_that(paste(
   "`filter_nterms` works (for an `object` of (informal) class \"proj_list\")"
 ), {
   skip_if_not(run_vs)
-  tstsetups <- grep("\\.glm\\.gauss.*\\.default_meth\\.full$", names(prjs_vs),
-                    value = TRUE)
+  tstsetups <- grep("\\.glm\\.gauss.*\\.default_meth\\..*\\.full$",
+                    names(prjs_vs), value = TRUE)
   for (tstsetup in tstsetups) {
     # Unavailable number(s) of terms:
     for (filter_nterms_crr in nterms_unavail) {

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -492,6 +492,9 @@ test_that(paste(
       valsearch_expected = args_cvvs[[tstsetup]]$validate_search,
       nprjdraws_search_expected = args_cvvs[[tstsetup]]$nclusters,
       nprjdraws_eval_expected = args_cvvs[[tstsetup]]$nclusters_pred,
+      search_trms_empty_size =
+        length(args_cvvs[[tstsetup]]$search_terms) &&
+        all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
       info_str = tstsetup
     )
   }
@@ -618,6 +621,9 @@ test_that("setting `nloo` smaller than the number of observations works", {
       nprjdraws_search_expected = args_cvvs_i$nclusters,
       nprjdraws_eval_expected = args_cvvs_i$nclusters_pred,
       nloo_expected = nloo_tst,
+      search_trms_empty_size =
+        length(args_cvvs_i$search_terms) &&
+        all(grepl("\\+", args_cvvs_i$search_terms)),
       info_str = tstsetup
     )
     # Expected equality for most components with a few exceptions:
@@ -670,6 +676,9 @@ test_that("`validate_search` works", {
       valsearch_expected = FALSE,
       nprjdraws_search_expected = args_cvvs_i$nclusters,
       nprjdraws_eval_expected = args_cvvs_i$nclusters_pred,
+      search_trms_empty_size =
+        length(args_cvvs_i$search_terms) &&
+        all(grepl("\\+", args_cvvs_i$search_terms)),
       info_str = tstsetup
     )
     # Expected equality for most components with a few exceptions:
@@ -819,6 +828,9 @@ test_that(paste(
       valsearch_expected = args_cvvs_i$validate_search,
       nprjdraws_search_expected = args_cvvs_i$nclusters,
       nprjdraws_eval_expected = args_cvvs_i$nclusters_pred,
+      search_trms_empty_size =
+        length(args_cvvs_i$search_terms) &&
+        all(grepl("\\+", args_cvvs_i$search_terms)),
       info_str = tstsetup
     )
     # Expected equality for some components:
@@ -921,6 +933,9 @@ test_that(paste(
       valsearch_expected = args_cvvs_i$validate_search,
       nprjdraws_search_expected = args_cvvs_i$nclusters,
       nprjdraws_eval_expected = args_cvvs_i$nclusters_pred,
+      search_trms_empty_size =
+        length(args_cvvs_i$search_terms) &&
+        all(grepl("\\+", args_cvvs_i$search_terms)),
       info_str = tstsetup
     )
     # Expected equality for some components:

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -418,6 +418,54 @@ test_that("for L1 search, `penalty` has an expected effect", {
   }
 })
 
+# search_terms ------------------------------------------------------------
+
+test_that(paste(
+  "including all terms in `search_terms` gives the same results as the default",
+  "`search_terms`"
+), {
+  tstsetups <- grep("\\.alltrms", names(vss), value = TRUE)
+  for (tstsetup in tstsetups) {
+    tstsetup_default <- sub("\\.alltrms", "\\.default_search_trms", tstsetup)
+    if (!tstsetup_default %in% names(vss)) next
+    expect_identical(vss[[tstsetup]], vss[[tstsetup_default]], info = tstsetup)
+  }
+})
+
+test_that(paste(
+  "forcing the inclusion of a term in the candidate models via `search_terms`",
+  "works as expected"
+), {
+  tstsetups <- grep("\\.fixed", names(vss), value = TRUE)
+  for (tstsetup in tstsetups) {
+    # In principle, `search_trms_tst$fixed$search_terms[1]` could be used
+    # instead of `"xco.1"`, but that would seem like the forced term always has
+    # to come first in `search_terms` (which is not the case):
+    expect_identical(solution_terms(vss[[tstsetup]])[1], "xco.1",
+                     info = tstsetup)
+  }
+})
+
+test_that(paste(
+  "forcing the exclusion of a term in the candidate models via `search_terms`",
+  "works as expected"
+), {
+  tstsetups <- grep("\\.excluded", names(vss), value = TRUE)
+  for (tstsetup in tstsetups) {
+    expect_false("xco.1" %in% solution_terms(vss[[tstsetup]]), info = tstsetup)
+  }
+})
+
+test_that(paste(
+  "forcing the skipping of a model size via `search_terms` works as expected"
+), {
+  tstsetups <- grep("\\.empty_size", names(vss), value = TRUE)
+  for (tstsetup in tstsetups) {
+    expect_true(all(grepl("\\+", solution_terms(vss[[tstsetup]]))),
+                info = tstsetup)
+  }
+})
+
 # cv_varsel() -------------------------------------------------------------
 
 context("cv_varsel()")

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -22,6 +22,9 @@ test_that(paste(
       method_expected = meth_exp_crr,
       nprjdraws_search_expected = args_vs[[tstsetup]]$nclusters,
       nprjdraws_eval_expected = args_vs[[tstsetup]]$nclusters_pred,
+      search_trms_empty_size =
+        length(args_vs[[tstsetup]]$search_terms) &&
+        all(grepl("\\+", args_vs[[tstsetup]]$search_terms)),
       info_str = tstsetup
     )
   }
@@ -107,6 +110,9 @@ test_that("`d_test` works", {
       method_expected = meth_exp_crr,
       nprjdraws_search_expected = args_vs_i$nclusters,
       nprjdraws_eval_expected = args_vs_i$nclusters_pred,
+      search_trms_empty_size =
+        length(args_vs_i$search_terms) &&
+        all(grepl("\\+", args_vs_i$search_terms)),
       info_str = tstsetup
     )
     expect_identical(vs_repr$d_test, d_test_crr, info = tstsetup)
@@ -214,6 +220,10 @@ test_that(paste(
   for (tstsetup in tstsetups) {
     args_vs_i <- args_vs[[tstsetup]]
     m_max <- args_vs_i$nterms_max + 1L
+    if (length(args_vs_i$search_terms) &&
+        all(grepl("\\+", args_vs_i$search_terms))) {
+      m_max <- m_max - 1L
+    }
     ncl_crr <- args_vs_i$nclusters
     ssq_regul_sel_alpha <- array(dim = c(length(regul_tst), m_max, ncl_crr))
     ssq_regul_sel_beta <- array(dim = c(length(regul_tst), m_max, ncl_crr))
@@ -234,6 +244,9 @@ test_that(paste(
           method_expected = "forward",
           nprjdraws_search_expected = args_vs_i$nclusters,
           nprjdraws_eval_expected = args_vs_i$nclusters_pred,
+          search_trms_empty_size =
+            length(args_vs_i$search_terms) &&
+            all(grepl("\\+", args_vs_i$search_terms)),
           info_str = tstsetup
         )
       }


### PR DESCRIPTION
This fixes #155 (a collection of user-reported issues concerning the `search_terms` argument) by improving the documentation and by handling argument `method` more appropriately. A bug related to the `search_terms` argument is also fixed. See the new `NEWS.md` entries for details concerning the user-visible changes. Some refactoring with regard to the `search_terms` argument is also performed.