### PR TITLE
Fix `run_more = TRUE` tests

### DIFF
--- a/R/project.R
+++ b/R/project.R
@@ -194,12 +194,12 @@ project <- function(object, nterms = NULL, solution_terms = NULL,
         ## by default, project onto the suggested model size
         nterms <- min(object$suggested_size, length(solution_terms))
       } else {
-        stop("No suggested model size found, please specify nterms or solution",
-             "terms")
+        stop("No suggested model size found, please specify `nterms` or ",
+             "`solution_terms`.")
       }
     } else {
       if (!is.numeric(nterms) || any(nterms < 0)) {
-        stop("nterms must contain non-negative values.")
+        stop("Argument `nterms` must contain non-negative values.")
       }
       if (max(nterms) > length(solution_terms)) {
         stop(paste(

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -1117,6 +1117,8 @@ vsel_tester <- function(
     nprjdraws_search_expected <- 1
   }
   if (search_trms_empty_size) {
+    # This is the "empty_size" setting, so we have to subtract the skipped model
+    # size (see issue #307):
     solterms_len_expected <- solterms_len_expected - 1L
   }
 
@@ -1470,6 +1472,8 @@ smmry_tester <- function(smmry, vsel_expected, nterms_max_expected = NULL,
     nterms_ch <- nterms_max_expected
   }
   if (search_trms_empty_size) {
+    # This is the "empty_size" setting, so we have to subtract the skipped model
+    # size (see issue #307):
     nterms_ch <- nterms_ch - 1
   }
   expect_identical(smmry$nterms, nterms_ch,

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -833,9 +833,13 @@ projection_tester <- function(p,
   y_nms <- paste0(".", y_nm)
   # A preliminary check for `nprjdraws_expected` (doesn't work for "datafit"s
   # and, because of issue #131, for submodels which are GAMMs):
-  sub_formul_crr_rhs <- flatten_formula(as.formula(paste(
+  sub_formul_crr_rhs <- as.formula(paste(
     "~", paste(sub_trms_crr, collapse = " + ")
-  )))
+  ))
+  if (all(grepl("\\+", sub_trms_crr))) {
+    # Avoid duplicated terms in the "empty_size" `search_terms` setting:
+    sub_formul_crr_rhs <- update(sub_formul_crr_rhs, . ~ .)
+  }
   if (!inherits(p$refmodel, "datafit") &&
       !(formula_contains_additive_terms(sub_formul_crr_rhs) &&
         formula_contains_group_terms(sub_formul_crr_rhs))) {
@@ -849,9 +853,14 @@ projection_tester <- function(p,
     y_nms <- paste0(y_nms, ".", seq_len(nprjdraws_expected))
   }
   sub_formul_crr <- lapply(y_nms, function(y_nm_i) {
-    flatten_formula(as.formula(paste(
+    fml_tmp <- as.formula(paste(
       y_nm_i, "~", paste(sub_trms_crr, collapse = " + ")
-    )))
+    ))
+    if (all(grepl("\\+", sub_trms_crr))) {
+      # Avoid duplicated terms in the "empty_size" `search_terms` setting:
+      fml_tmp <- update(fml_tmp, . ~ .)
+    }
+    return(fml_tmp)
   })
   sub_data_crr <- p$refmodel$fetch_data()
   if (p_type_expected) {
@@ -1174,9 +1183,14 @@ vsel_tester <- function(
       sub_trms_crr <- setdiff(sub_trms_crr, "1")
     }
     sub_formul_crr <- lapply(y_nms, function(y_nm_i) {
-      flatten_formula(as.formula(paste(
+      fml_tmp <- as.formula(paste(
         y_nm_i, "~", paste(sub_trms_crr, collapse = " + ")
-      )))
+      ))
+      if (all(grepl("\\+", sub_trms_crr))) {
+        # Avoid duplicated terms in the "empty_size" `search_terms` setting:
+        fml_tmp <- update(fml_tmp, . ~ .)
+      }
+      return(fml_tmp)
     })
     submodl_tester(
       vs$search_path$submodls[[i]],

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -804,6 +804,12 @@ if (run_cvvs) {
         }
         search_trms <- search_trms_tst["default_search_trms"]
         lapply(search_trms, function(search_trms_i) {
+          if (length(search_trms_i) &&
+              !identical(search_trms_i$search_terms,
+                         search_trms_tst$alltrms$search_terms)) {
+            nterms_max_tst <- count_terms_chosen(search_trms_i$search_terms) -
+              1L
+          }
           return(c(
             nlist(tstsetup_ref), only_nonargs(args_ref[[tstsetup_ref]]),
             list(

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -284,37 +284,6 @@ if (ncol(s_mat) == 1) {
   names(dat)[names(dat) == "s"] <- "s.1"
 }
 
-## nterms -----------------------------------------------------------------
-
-ntermss <- sapply(mod_nms, function(mod_nm) {
-  get(paste("nterms", mod_nm, sep = "_"))
-})
-nterms_max_tst <- min(ntermss)
-if (!run_more) {
-  nterms_max_tst <- min(nterms_max_tst, 2L)
-}
-
-nterms_unavail <- list(
-  single = nterms_max_tst + 130L,
-  vec = c(nterms_max_tst + 130L, nterms_max_tst + 290L)
-)
-if (!run_more) {
-  nterms_avail <- list()
-} else {
-  nterms_avail <- list(default_nterms = NULL)
-}
-nterms_avail <- c(nterms_avail, list(
-  empty = 0L,
-  single = nterms_max_tst %/% 2L,
-  subvec = as.integer(round(seq(0, nterms_max_tst, length.out = 2))),
-  full = 0:nterms_max_tst
-))
-
-nterms_max_smmry <- list(
-  default_nterms_max_smmry = NULL,
-  halfway = nterms_max_tst %/% 2L
-)
-
 ## Modified datasets ------------------------------------------------------
 
 dat_wobs_ones <- within(dat, {
@@ -623,6 +592,10 @@ fits <- suppressWarnings(lapply(args_fit, function(args_fit_i) {
 
 ## Setup ------------------------------------------------------------------
 
+seed_tst <- 74341
+seed2_tst <- 866028
+seed3_tst <- 1208499
+
 nclusters_tst <- 2L
 nclusters_pred_tst <- 3L
 if (!run_more) {
@@ -673,9 +646,36 @@ stats_tst <- list(
 )
 type_tst <- c("mean", "lower", "upper", "se")
 
-seed_tst <- 74341
-seed2_tst <- 866028
-seed3_tst <- 1208499
+### nterms ----------------------------------------------------------------
+
+ntermss <- sapply(mod_nms, function(mod_nm) {
+  get(paste("nterms", mod_nm, sep = "_"))
+})
+nterms_max_tst <- min(ntermss)
+if (!run_more) {
+  nterms_max_tst <- min(nterms_max_tst, 2L)
+}
+
+nterms_unavail <- list(
+  single = nterms_max_tst + 130L,
+  vec = c(nterms_max_tst + 130L, nterms_max_tst + 290L)
+)
+if (!run_more) {
+  nterms_avail <- list()
+} else {
+  nterms_avail <- list(default_nterms = NULL)
+}
+nterms_avail <- c(nterms_avail, list(
+  empty = 0L,
+  single = nterms_max_tst %/% 2L,
+  subvec = as.integer(round(seq(0, nterms_max_tst, length.out = 2))),
+  full = 0:nterms_max_tst
+))
+
+nterms_max_smmry <- list(
+  default_nterms_max_smmry = NULL,
+  halfway = nterms_max_tst %/% 2L
+)
 
 ## Reference model --------------------------------------------------------
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -651,6 +651,8 @@ type_tst <- c("mean", "lower", "upper", "se")
 ntermss <- sapply(mod_nms, function(mod_nm) {
   get(paste("nterms", mod_nm, sep = "_"))
 })
+# The `nterms_max` setting which will be used throughout the tests, except for
+# the special `search_terms` tests:
 nterms_max_tst <- min(ntermss)
 if (!run_more) {
   nterms_max_tst <- min(nterms_max_tst, 2L)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -998,6 +998,9 @@ if (run_vs) {
   args_prj_vs <- unlist_cust(args_prj_vs)
 
   prjs_vs <- lapply(args_prj_vs, function(args_prj_vs_i) {
+    if (is.na(vss[[args_prj_vs_i$tstsetup_vsel]]$suggested_size)) {
+      args_prj_vs_i$nterms <- nterms_avail$single
+    }
     do.call(project, c(
       list(object = vss[[args_prj_vs_i$tstsetup_vsel]]),
       excl_nonargs(args_prj_vs_i)
@@ -1039,6 +1042,9 @@ if (run_cvvs) {
   prjs_cvvs <- suppressWarnings(lapply(
     args_prj_cvvs,
     function(args_prj_cvvs_i) {
+      if (is.na(cvvss[[args_prj_cvvs_i$tstsetup_vsel]]$suggested_size)) {
+        args_prj_cvvs_i$nterms <- nterms_avail$single
+      }
       do.call(project, c(
         list(object = cvvss[[args_prj_cvvs_i$tstsetup_vsel]]),
         excl_nonargs(args_prj_cvvs_i)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -948,6 +948,17 @@ cre_args_prj_vsel <- function(tstsetups_prj_vsel) {
         grepl("\\.spclformul", tstsetup_vsel)) {
       nterms_avail <- nterms_avail["subvec"]
     }
+    if (!is.null(args_obj[[tstsetup_vsel]]$search_terms)) {
+      nterms_max_cut <- args_obj[[tstsetup_vsel]]$nterms_max
+      if (all(grepl("\\+", args_obj[[tstsetup_vsel]]$search_terms))) {
+        # This is the "empty_size" setting, so we have to subtract the skipped
+        # model size (see issue #307):
+        nterms_max_cut <- nterms_max_cut - 1L
+      }
+      nterms_avail <- lapply(nterms_avail, function(nterms_avail_i) {
+        pmin(nterms_avail_i, nterms_max_cut)
+      })
+    }
     lapply(nterms_avail, function(nterms_crr) {
       if (!is.null(nterms_crr)) {
         args_out <- c(args_out, list(nterms = nterms_crr))

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -222,6 +222,8 @@ test_that(paste(
     m_max <- args_vs_i$nterms_max + 1L
     if (length(args_vs_i$search_terms) &&
         all(grepl("\\+", args_vs_i$search_terms))) {
+      # This is the "empty_size" setting, so we have to subtract the skipped
+      # model size (see issue #307):
       m_max <- m_max - 1L
     }
     ncl_crr <- args_vs_i$nclusters


### PR DESCRIPTION
This fixes the unit tests when run with `run_more = TRUE`. These fixes are necessary because of the changes in PR #308. Two error messages in `project()` are also slightly improved.