### PR TITLE
Avoid `preprocess_data()` in `fit_gamm_callback()` and break infinite loop

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 
 * Throw a more informative error message in case of special group-level terms which are currently not supported (in particular, nested ones).
 * Previously, using a `search_terms` vector which excluded the intercept in conjunction with `refit_prj = FALSE` (the latter in `project()`, `varsel()`, or `cv_varsel()`) led to incorrect submodels being fetched from the search or to an error while doing so. This has been fixed now by internally forcing the inclusion of the intercept in `search_terms`. (GitHub: #308)
+* Fix GitHub issues #147 and #202. (GitHub: #312)
 
 # projpred 2.1.1
 


### PR DESCRIPTION
This fixes #147 and #202. Note that #147 is not really "fixed" in the sense that `cv_varsel()` runs without throwing an error. Instead, the error message is just more informative now. For making `cv_varsel()` run without error, it might be worth a try to modify the **gamm4** package so that argument `nAGQ` may also be used there (this helped in getting rid of a different error for GLMMs).