### PR TITLE
Handle error `PIRLS loop resulted in NaN value`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Improve the documentation for argument `search_terms` of `varsel()` and `cv_varsel()`. (GitHub: #155, #308)
 * In case of user-specified (non-`NULL`) `search_terms`, `method = NULL` is internally changed to `method = "forward"` and `method = "L1"` throws a warning. This is done because `search_terms` only takes effect in case of a forward search. (GitHub: #155, #308)
 * Internally, the intercept is now always included in `search_terms`. This is necessary to prevent a bug described below. (GitHub: #308)
+* When fitting multilevel submodels via **lme4**, **projpred** now tries to handle `PIRLS loop resulted in NaN value` errors automatically.
 
 ## Bug fixes
 

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -283,16 +283,15 @@ fit_glmer_callback <- function(formula, family,
                                    optCtrl = list(method = "nlminb")),
         ...
       ))
-    } else if (grepl("PIRLS step-halvings", as.character(e))) {
+    } else if (grepl("PIRLS", as.character(e))) {
       if (length(dot_args$nAGQ) > 0) {
         nAGQ_new <- dot_args$nAGQ + 1L
       } else {
         nAGQ_new <- 20L
       }
       if (nAGQ_new > 30L) {
-        stop("Encountering the `PIRLS step-halvings` error while running the ",
-             "lme4 fitting procedure, but cannot fix this automatically ",
-             "anymore.")
+        stop("Encountering a PIRLS error while running the lme4 fitting ",
+             "procedure, but cannot fix this automatically anymore.")
       }
       return(fit_glmer_callback(
         formula = formula,

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -202,7 +202,8 @@ fit_gamm_callback <- function(formula, projpred_formula_no_random,
           control$optCtrl$method == "nlminb") {
         stop("Encountering the `not positive definite` error while running ",
              "the lme4 fitting procedure, but cannot fix this automatically ",
-             "anymore.")
+             "anymore. You will probably have to tweak gamm4 tuning ",
+             "parameters manually (via `...`).")
       }
       return(fit_gamm_callback(
         formula = formula,
@@ -273,7 +274,8 @@ fit_glmer_callback <- function(formula, family,
           control$optCtrl$method == "nlminb") {
         stop("Encountering the `not positive definite` error while running ",
              "the lme4 fitting procedure, but cannot fix this automatically ",
-             "anymore.")
+             "anymore. You will probably have to tweak lme4 tuning parameters ",
+             "manually (via `...`).")
       }
       return(fit_glmer_callback(
         formula = formula,
@@ -291,7 +293,9 @@ fit_glmer_callback <- function(formula, family,
       }
       if (nAGQ_new > 30L) {
         stop("Encountering a PIRLS error while running the lme4 fitting ",
-             "procedure, but cannot fix this automatically anymore.")
+             "procedure, but cannot fix this automatically anymore. You will ",
+             "probably have to tweak lme4 tuning parameters manually (via ",
+             "`...`).")
       }
       return(fit_glmer_callback(
         formula = formula,
@@ -317,7 +321,8 @@ fit_glmer_callback <- function(formula, family,
         stop("Encountering the ",
              "`pwrssUpdate did not converge in (maxit) iterations` error ",
              "while running the lme4 fitting procedure, but cannot fix this ",
-             "automatically anymore.")
+             "automatically anymore. You will probably have to tweak lme4 ",
+             "tuning parameters manually (via `...`).")
       }
       return(fit_glmer_callback(
         formula = formula,


### PR DESCRIPTION
This tries to handle the error `PIRLS loop resulted in NaN value` by increasing `nAGQ`. Some related error messages are improved, too.