### PR TITLE
PSIS weights from reference model, not submodel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 ## Bug fixes
 
 * Fix GitHub issue #324 (large `search_terms` caused the R session to crash).
+* Fix GitHub issue #204. (GitHub: #325)
+* In the `validate_search = FALSE` case of `cv_varsel()` (with `cv_method = "LOO"`), the PSIS weights are now calculated based on the reference model (they used to be calculated based on the submodels which is incorrect). (GitHub: #325)
 
 # projpred 2.1.2
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -397,6 +397,10 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     }
 
     ## compute approximate LOO with PSIS weights
+    log_lik_ref <- t(refmodel$family$ll_fun(
+      p_pred$mu[inds, , drop = FALSE], p_pred$dis, refmodel$y[inds],
+      refmodel$wobs[inds]
+    ))
     for (k in seq_along(submodels)) {
       mu_k <- refmodel$family$mu_fun(submodels[[k]]$submodl,
                                      obs = inds,
@@ -405,9 +409,9 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
         mu_k, submodels[[k]]$dis, refmodel$y[inds], refmodel$wobs[inds]
       ))
       sub_psisloo <- suppressWarnings(
-        loo::psis(-log_lik_sub,
+        loo::psis(-log_lik_ref,
                   cores = 1,
-                  r_eff = rep(1, ncol(log_lik_sub)))
+                  r_eff = rep(1, ncol(log_lik_ref)))
       )
       lw_sub <- suppressWarnings(weights(sub_psisloo))
       # Take into account that clustered draws usually have different weights:

--- a/R/misc.R
+++ b/R/misc.R
@@ -193,7 +193,7 @@ bootstrap <- function(x, fun = mean, B = 2000,
 #   that do not have a dispersion parameter).
 #   * `dis`: A vector of length \eqn{S_{\mbox{prj}}}{S_prj} containing the
 #   reference model's dispersion parameter value for each draw/cluster (NA for
-#   those families that do not have a dispersion parameter). See issue #204.
+#   those families that do not have a dispersion parameter).
 #   * `weights`: A vector of length \eqn{S_{\mbox{prj}}}{S_prj} containing the
 #   weights for the draws/clusters.
 #   * `cl`: Cluster assignment for each posterior draw, that is, a vector that

--- a/R/misc.R
+++ b/R/misc.R
@@ -287,7 +287,7 @@ bootstrap <- function(x, fun = mean, B = 2000,
     # Unnormalized weight for the j-th cluster:
     wcluster[j] <- sum(wsample[ind])
     # Aggregated dispersion parameter for the j-th cluster:
-    dis_agg[j] <- dis[ind] %*% ws
+    dis_agg[j] <- crossprod(dis[ind], ws)
   }
   wcluster <- wcluster / sum(wcluster)
 

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -1204,16 +1204,9 @@ vsel_tester <- function(
     )
   }
   expect_type(vs$search_path$p_sel, "list")
-  if (from_datafit) {
-    # Due to issue #204:
-    expect_named(vs$search_path$p_sel,
-                 c("mu", "var", "dis", "weights", "cl", "clust_used"),
-                 info = info_str)
-  } else {
-    expect_named(vs$search_path$p_sel,
-                 c("mu", "var", "weights", "cl", "clust_used"),
-                 info = info_str)
-  }
+  expect_named(vs$search_path$p_sel,
+               c("mu", "var", "dis", "weights", "cl", "clust_used"),
+               info = info_str)
   expect_true(is.matrix(vs$search_path$p_sel$mu), info = info_str)
   expect_true(is.numeric(vs$search_path$p_sel$mu), info = info_str)
   expect_equal(dim(vs$search_path$p_sel$mu),
@@ -1228,12 +1221,10 @@ vsel_tester <- function(
   expect_equal(dim(vs$search_path$p_sel$var),
                c(nobsv, nprjdraws_search_expected),
                info = info_str)
-  if ("dis" %in% names(vs$search_path$p_sel)) {
-    expect_true(is.vector(vs$search_path$p_sel$dis) &&
-                  is.atomic(vs$search_path$p_sel$dis),
-                info = info_str)
-    expect_length(vs$search_path$p_sel$dis, nprjdraws_search_expected)
-  }
+  expect_true(is.vector(vs$search_path$p_sel$dis) &&
+                is.atomic(vs$search_path$p_sel$dis),
+              info = info_str)
+  expect_length(vs$search_path$p_sel$dis, nprjdraws_search_expected)
   expect_type(vs$search_path$p_sel$weights, "double")
   expect_length(vs$search_path$p_sel$weights, nprjdraws_search_expected)
   expect_true(is.numeric(vs$search_path$p_sel$cl), info = info_str)


### PR DESCRIPTION
As discussed with @avehtari, the `validate_search = FALSE` case of `cv_varsel(<...>, cv_method = "LOO")` needs to take the PSIS weights from the reference model, not from the submodel. This is accomplished by this PR, which also required fixing #204.