### PR TITLE
Tests: cmdstanr backend

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,6 +50,7 @@ Suggests:
     knitr,
     rmarkdown,
     glmnet,
+    cmdstanr,
     bayesplot (>= 1.5.0),
     optimx,
     posterior,
@@ -61,6 +62,8 @@ Suggests:
     future.callr,
     doFuture
 LinkingTo: Rcpp, RcppArmadillo
+Additional_repositories:
+    https://mc-stan.org/r-packages/
 LazyData: TRUE
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.0

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -532,8 +532,10 @@ args_fit <- lapply(pkg_nms, function(pkg_nm) {
             } else if (pkg_nm == "brms") {
               pkg_args <- list(file = file_pth,
                                file_refit = "on_change",
-                               silent = 2,
-                               diagnostics = NULL)
+                               silent = 2)
+              if (identical(getOption("brms.backend", "rstan"), "cmdstanr")) {
+                pkg_args <- c(pkg_args, list(diagnostics = NULL))
+              }
             }
 
             return(c(

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -328,8 +328,8 @@ if (run_brms) {
   if (requireNamespace("cmdstanr", quietly = TRUE) &&
       !is.null(cmdstanr::cmdstan_version(error_on_NA = FALSE))) {
     options(brms.backend = "cmdstanr")
-    # Relative file paths currently don't work for option
-    # `cmdstanr_write_stan_file_dir`, so use the full path:
+    # Relative file paths currently (UPDATE: fixed by cmdstanr PR #665) don't
+    # work for option `cmdstanr_write_stan_file_dir`, so use the full path:
     options(cmdstanr_write_stan_file_dir = file.path(getwd(), file_pth))
   }
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -328,6 +328,9 @@ if (run_brms) {
   if (requireNamespace("cmdstanr", quietly = TRUE) &&
       !is.null(cmdstanr::cmdstan_version(error_on_NA = FALSE))) {
     options(brms.backend = "cmdstanr")
+    # Relative file paths currently don't work for option
+    # `cmdstanr_write_stan_file_dir`, so use the full path:
+    options(cmdstanr_write_stan_file_dir = file.path(getwd(), file_pth))
   }
 }
 pkg_nms <- setNames(nm = pkg_nms)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -325,7 +325,8 @@ if (run_brms) {
   file_pth <- testthat::test_path("bfits")
   if (!dir.exists(file_pth)) dir.create(file_pth)
   # Backend:
-  if (requireNamespace("cmdstanr", quietly = TRUE) &&
+  if (identical(Sys.getenv("TESTS_BRMS_BACKEND"), "cmdstanr") &&
+      requireNamespace("cmdstanr", quietly = TRUE) &&
       !is.null(cmdstanr::cmdstan_version(error_on_NA = FALSE))) {
     options(brms.backend = "cmdstanr")
     # Relative file paths currently (UPDATE: fixed by cmdstanr PR #665) don't

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -324,6 +324,10 @@ if (run_brms) {
   # For storing "brmsfit"s locally:
   file_pth <- testthat::test_path("bfits")
   if (!dir.exists(file_pth)) dir.create(file_pth)
+  # Backend:
+  if (requireNamespace("cmdstanr", quietly = TRUE)) {
+    options(brms.backend = "cmdstanr")
+  }
 }
 pkg_nms <- setNames(nm = pkg_nms)
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -325,7 +325,8 @@ if (run_brms) {
   file_pth <- testthat::test_path("bfits")
   if (!dir.exists(file_pth)) dir.create(file_pth)
   # Backend:
-  if (requireNamespace("cmdstanr", quietly = TRUE)) {
+  if (requireNamespace("cmdstanr", quietly = TRUE) &&
+      !is.null(cmdstanr::cmdstan_version(error_on_NA = FALSE))) {
     options(brms.backend = "cmdstanr")
   }
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -530,7 +530,9 @@ args_fit <- lapply(pkg_nms, function(pkg_nm) {
                             random_arg)
             } else if (pkg_nm == "brms") {
               pkg_args <- list(file = file_pth,
-                               file_refit = "on_change") # , silent = 2
+                               file_refit = "on_change",
+                               silent = 2,
+                               diagnostics = NULL)
             }
 
             return(c(


### PR DESCRIPTION
This PR allows to use the cmdstanr backend for the brms fits in the unit tests by setting environment variable `TESTS_BRMS_BACKEND` to `"cmdstanr"`.