### PR TITLE
Set `r_eff` to `NA`

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -52,6 +52,12 @@
 #'   exception where the search part is not cross-validated. In that case, the
 #'   evaluation part is based on a PSIS-LOO CV.
 #'
+#'   For all PSIS-LOO CVs, \pkg{projpred} calls [loo::psis()] with `r_eff = NA`.
+#'   This is only a problem if there was extreme autocorrelation between the
+#'   MCMC iterations when the reference model was built. In those cases however,
+#'   the reference model should not have been used anyway, so we don't expect
+#'   \pkg{projpred}'s `r_eff = NA` to be a problem.
+#'
 #' @references
 #'
 #' Magnusson, M., Andersen, M., Jonasson, J., and Vehtari, A. (2019). Bayesian
@@ -330,8 +336,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     loglik <- refmodel$loglik
   }
   n <- ncol(loglik)
-  ## TODO: should take r_eff:s into account
-  psisloo <- loo::psis(-loglik, cores = 1, r_eff = rep(1, n))
+  psisloo <- loo::psis(-loglik, cores = 1, r_eff = NA)
   lw <- weights(psisloo)
   # pareto_k <- loo::pareto_k_values(psisloo)
   ## by default use all observations
@@ -409,9 +414,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
         mu_k, submodels[[k]]$dis, refmodel$y[inds], refmodel$wobs[inds]
       ))
       sub_psisloo <- suppressWarnings(
-        loo::psis(-log_lik_ref,
-                  cores = 1,
-                  r_eff = rep(1, ncol(log_lik_ref)))
+        loo::psis(-log_lik_ref, cores = 1, r_eff = NA)
       )
       lw_sub <- suppressWarnings(weights(sub_psisloo))
       # Take into account that clustered draws usually have different weights:

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -220,6 +220,12 @@ specify \code{search_terms = c("x2", "x3", "x2 + x3")}.
 The case \code{cv_method == "LOO" && !validate_search} constitutes an
 exception where the search part is not cross-validated. In that case, the
 evaluation part is based on a PSIS-LOO CV.
+
+For all PSIS-LOO CVs, \pkg{projpred} calls \code{\link[loo:psis]{loo::psis()}} with \code{r_eff = NA}.
+This is only a problem if there was extreme autocorrelation between the
+MCMC iterations when the reference model was built. In those cases however,
+the reference model should not have been used anyway, so we don't expect
+\pkg{projpred}'s \code{r_eff = NA} to be a problem.
 }
 \examples{
 \dontshow{if (identical(Sys.getenv("RUN_EX"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}


### PR DESCRIPTION
For all PSIS-LOO CVs performed in projpred, this PR sets `r_eff` to `NA` as discussed with @avehtari. The reasoning is
that in order to calculate the relative efficiencies (using `loo::relative_eff()`), we would have to define an argument such as `chain_id` in `init_refmodel()`, requiring even more input from users in case of a custom reference model. For the PSIS based on the clustered draws (the `validate_search = FALSE` case), calculating the relative efficiencies is probably even less straightforward. The documentation for argument `r_eff` of `loo::psis()` says:

> If r_eff is not provided then the reported PSIS effective sample sizes and Monte Carlo error estimates will be over-optimistic.

so we see that these relative efficiencies are irrelevant for projpred (because projpred does not report PSIS effective sample sizes and neither Monte Carlo error estimates). As @avehtari pointed out, only extreme autocorrelation in the MCMC chains might be a problem, as documented now at `?cv_varsel`.