### PR TITLE
New argument `transform` for `<...>$family$mu_fun()`

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -205,17 +205,13 @@ proj_linpred <- function(object, newdata = NULL,
 }
 
 ## function applied to each projected submodel in case of proj_linpred()
-proj_linpred_aux <- function(proj, weights, transform = FALSE,
+proj_linpred_aux <- function(proj, weights, offset, newdata, transform = FALSE,
                              integrated = FALSE, extract_y_ind = TRUE, ...) {
-  dot_args <- list(...)
-  stopifnot(!is.null(dot_args$newdata))
-  stopifnot(!is.null(dot_args$offset))
-  mu <- proj$refmodel$family$mu_fun(proj$submodl,
-                                    newdata = dot_args$newdata,
-                                    offset = dot_args$offset)
+  mu <- proj$refmodel$family$mu_fun(proj$submodl, newdata = newdata,
+                                    offset = offset)
   w_o <- proj$refmodel$extract_model_data(
-    proj$refmodel$fit, newdata = dot_args$newdata, wrhs = weights,
-    orhs = dot_args$offset, extract_y = extract_y_ind
+    proj$refmodel$fit, newdata = newdata, wrhs = weights,
+    orhs = offset, extract_y = extract_y_ind
   )
   ynew <- w_o$y
   lpd_out <- compute_lpd(
@@ -271,13 +267,11 @@ proj_predict <- function(object, newdata = NULL,
 }
 
 ## function applied to each projected submodel in case of proj_predict()
-proj_predict_aux <- function(proj, weights, nresample_clusters = 1000, ...) {
-  dot_args <- list(...)
-  stopifnot(!is.null(dot_args$newdata))
-  stopifnot(!is.null(dot_args$offset))
+proj_predict_aux <- function(proj, weights, offset, newdata,
+                             nresample_clusters = 1000, ...) {
   mu <- proj$refmodel$family$mu_fun(proj$submodl,
-                                    newdata = dot_args$newdata,
-                                    offset = dot_args$offset)
+                                    newdata = newdata,
+                                    offset = offset)
   if (proj$p_type) {
     # In this case, the posterior draws have been clustered.
     draw_inds <- sample(x = seq_along(proj$weights), size = nresample_clusters,

--- a/R/methods.R
+++ b/R/methods.R
@@ -174,8 +174,8 @@ proj_helper <- function(object, newdata,
     if (length(offsetnew) == 0) {
       offsetnew <- rep(0, NROW(newdata))
     }
-    onesub_fun(proj, weights = weightsnew, offset = offsetnew,
-               newdata = newdata, extract_y_ind = extract_y_ind, ...)
+    onesub_fun(proj, newdata = newdata, offset = offsetnew,
+               weights = weightsnew, extract_y_ind = extract_y_ind, ...)
   })
 
   return(.unlist_proj(preds))
@@ -205,7 +205,7 @@ proj_linpred <- function(object, newdata = NULL,
 }
 
 ## function applied to each projected submodel in case of proj_linpred()
-proj_linpred_aux <- function(proj, weights, offset, newdata, transform = FALSE,
+proj_linpred_aux <- function(proj, newdata, offset, weights, transform = FALSE,
                              integrated = FALSE, extract_y_ind = TRUE, ...) {
   mu <- proj$refmodel$family$mu_fun(proj$submodl, newdata = newdata,
                                     offset = offset)
@@ -267,7 +267,7 @@ proj_predict <- function(object, newdata = NULL,
 }
 
 ## function applied to each projected submodel in case of proj_predict()
-proj_predict_aux <- function(proj, weights, offset, newdata,
+proj_predict_aux <- function(proj, newdata, offset, weights,
                              nresample_clusters = 1000, ...) {
   mu <- proj$refmodel$family$mu_fun(proj$submodl,
                                     newdata = newdata,

--- a/R/methods.R
+++ b/R/methods.R
@@ -204,7 +204,7 @@ proj_linpred <- function(object, newdata = NULL, offsetnew = NULL,
 ## function applied to each projected submodel in case of proj_linpred()
 proj_linpred_aux <- function(proj, newdata, offset, weights, transform = FALSE,
                              integrated = FALSE, extract_y_ind = TRUE, ...) {
-  pred_out <- proj$refmodel$family$mu_fun(proj$submodl, newdata = newdata,
+  pred_sub <- proj$refmodel$family$mu_fun(proj$submodl, newdata = newdata,
                                           offset = offset,
                                           transform = transform)
   w_o <- proj$refmodel$extract_model_data(
@@ -212,18 +212,18 @@ proj_linpred_aux <- function(proj, newdata, offset, weights, transform = FALSE,
     orhs = offset, extract_y = extract_y_ind
   )
   ynew <- w_o$y
-  lpd_out <- compute_lpd(ynew = ynew, pred_sub = pred_out, proj = proj,
+  lpd_out <- compute_lpd(ynew = ynew, pred_sub = pred_sub, proj = proj,
                          weights = weights, transformed = transform)
   if (integrated) {
     ## average over the posterior draws
-    pred_out <- pred_out %*% proj$weights
+    pred_sub <- pred_sub %*% proj$weights
     if (!is.null(lpd_out)) {
       lpd_out <- as.matrix(
         apply(lpd_out, 1, log_weighted_mean_exp, proj$weights)
       )
     }
   }
-  return(nlist(pred = t(pred_out),
+  return(nlist(pred = t(pred_sub),
                lpd = if (is.null(lpd_out)) lpd_out else t(lpd_out)))
 }
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -206,17 +206,16 @@ proj_linpred <- function(object, newdata = NULL,
 
 ## function applied to each projected submodel in case of proj_linpred()
 proj_linpred_aux <- function(proj, weights, transform = FALSE,
-                             integrated = FALSE, ...) {
+                             integrated = FALSE, extract_y_ind = TRUE, ...) {
   dot_args <- list(...)
   stopifnot(!is.null(dot_args$newdata))
   stopifnot(!is.null(dot_args$offset))
-  stopifnot(!is.null(dot_args$extract_y_ind))
   mu <- proj$refmodel$family$mu_fun(proj$submodl,
                                     newdata = dot_args$newdata,
                                     offset = dot_args$offset)
   w_o <- proj$refmodel$extract_model_data(
     proj$refmodel$fit, newdata = dot_args$newdata, wrhs = weights,
-    orhs = dot_args$offset, extract_y = dot_args$extract_y_ind
+    orhs = dot_args$offset, extract_y = extract_y_ind
   )
   ynew <- w_o$y
   lpd_out <- compute_lpd(

--- a/R/methods.R
+++ b/R/methods.R
@@ -92,10 +92,8 @@ NULL
 ## projections. For each projection, it evaluates the fun-function, which
 ## calculates the linear predictor if called from proj_linpred and samples from
 ## the predictive distribution if called from proj_predict.
-proj_helper <- function(object, newdata,
-                        offsetnew, weightsnew,
-                        onesub_fun, filter_nterms = NULL,
-                        ...) {
+proj_helper <- function(object, newdata, offsetnew, weightsnew, onesub_fun,
+                        filter_nterms = NULL, ...) {
   if (inherits(object, "projection") || .is_proj_list(object)) {
     if (!is.null(filter_nterms)) {
       if (!.is_proj_list(object)) {
@@ -183,9 +181,8 @@ proj_helper <- function(object, newdata,
 
 #' @rdname pred-projection
 #' @export
-proj_linpred <- function(object, newdata = NULL,
-                         offsetnew = NULL, weightsnew = NULL,
-                         filter_nterms = NULL,
+proj_linpred <- function(object, newdata = NULL, offsetnew = NULL,
+                         weightsnew = NULL, filter_nterms = NULL,
                          transform = FALSE, integrated = FALSE,
                          .seed = sample.int(.Machine$integer.max, 1), ...) {
   # Set seed, but ensure the old RNG state is restored on exit:
@@ -214,9 +211,7 @@ proj_linpred_aux <- function(proj, newdata, offset, weights, transform = FALSE,
     orhs = offset, extract_y = extract_y_ind
   )
   ynew <- w_o$y
-  lpd_out <- compute_lpd(
-    ynew = ynew, mu = mu, proj = proj, weights = weights
-  )
+  lpd_out <- compute_lpd(ynew = ynew, mu = mu, proj = proj, weights = weights)
   pred_out <- if (!transform) proj$refmodel$family$linkfun(mu) else mu
   if (integrated) {
     ## average over the posterior draws
@@ -245,9 +240,8 @@ compute_lpd <- function(ynew, mu, proj, weights) {
 
 #' @rdname pred-projection
 #' @export
-proj_predict <- function(object, newdata = NULL,
-                         offsetnew = NULL, weightsnew = NULL,
-                         filter_nterms = NULL,
+proj_predict <- function(object, newdata = NULL, offsetnew = NULL,
+                         weightsnew = NULL, filter_nterms = NULL,
                          nresample_clusters = 1000,
                          .seed = sample.int(.Machine$integer.max, 1), ...) {
   # Set seed, but ensure the old RNG state is restored on exit:
@@ -279,7 +273,6 @@ proj_predict_aux <- function(proj, newdata, offset, weights,
   } else {
     draw_inds <- seq_along(proj$weights)
   }
-
   return(do.call(rbind, lapply(draw_inds, function(i) {
     proj$refmodel$family$ppd(mu[, i], proj$dis[i], weights)
   })))

--- a/R/methods.R
+++ b/R/methods.R
@@ -175,9 +175,8 @@ proj_helper <- function(object, newdata,
     if (length(offsetnew) == 0) {
       offsetnew <- rep(0, NROW(newdata))
     }
-    onesub_fun(proj, weightsnew,
-               offset = offsetnew, newdata = newdata,
-               extract_y_ind = extract_y_ind,
+    onesub_fun(proj, weights = weightsnew, offset = offsetnew,
+               newdata = newdata, extract_y_ind = extract_y_ind,
                transform = transform, integrated = integrated,
                nresample_clusters = nresample_clusters)
   })

--- a/R/methods.R
+++ b/R/methods.R
@@ -175,9 +175,7 @@ proj_helper <- function(object, newdata,
     if (length(offsetnew) == 0) {
       offsetnew <- rep(0, NROW(newdata))
     }
-    mu <- proj$refmodel$family$mu_fun(proj$submodl,
-                                      newdata = newdata, offset = offsetnew)
-    onesub_fun(proj, mu, weightsnew,
+    onesub_fun(proj, weightsnew,
                offset = offsetnew, newdata = newdata,
                extract_y_ind = extract_y_ind,
                transform = transform, integrated = integrated,
@@ -211,13 +209,16 @@ proj_linpred <- function(object, newdata = NULL,
 }
 
 ## function applied to each projected submodel in case of proj_linpred()
-proj_linpred_aux <- function(proj, mu, weights, ...) {
+proj_linpred_aux <- function(proj, weights, ...) {
   dot_args <- list(...)
   stopifnot(!is.null(dot_args$transform))
   stopifnot(!is.null(dot_args$integrated))
   stopifnot(!is.null(dot_args$newdata))
   stopifnot(!is.null(dot_args$offset))
   stopifnot(!is.null(dot_args$extract_y_ind))
+  mu <- proj$refmodel$family$mu_fun(proj$submodl,
+                                    newdata = dot_args$newdata,
+                                    offset = dot_args$offset)
   w_o <- proj$refmodel$extract_model_data(
     proj$refmodel$fit, newdata = dot_args$newdata, wrhs = weights,
     orhs = dot_args$offset, extract_y = dot_args$extract_y_ind
@@ -276,8 +277,13 @@ proj_predict <- function(object, newdata = NULL,
 }
 
 ## function applied to each projected submodel in case of proj_predict()
-proj_predict_aux <- function(proj, mu, weights, ...) {
+proj_predict_aux <- function(proj, weights, ...) {
   dot_args <- list(...)
+  stopifnot(!is.null(dot_args$newdata))
+  stopifnot(!is.null(dot_args$offset))
+  mu <- proj$refmodel$family$mu_fun(proj$submodl,
+                                    newdata = dot_args$newdata,
+                                    offset = dot_args$offset)
   if (proj$p_type) {
     # In this case, the posterior draws have been clustered.
     stopifnot(!is.null(dot_args$nresample_clusters))

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -591,14 +591,19 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     family <- extend_family(family)
   }
 
-  family$mu_fun <- function(fits, obs = NULL, newdata = NULL, offset = NULL) {
+  family$mu_fun <- function(fits, obs = NULL, newdata = NULL, offset = NULL,
+                            transform = TRUE) {
     newdata <- fetch_data(data, obs = obs, newdata = newdata)
     if (is.null(offset)) {
       offset <- rep(0, nrow(newdata))
     } else {
       stopifnot(length(offset) %in% c(1L, nrow(newdata)))
     }
-    family$linkinv(proj_predfun(fits, newdata = newdata) + offset)
+    pred_sub <- proj_predfun(fits, newdata = newdata) + offset
+    if (transform) {
+      pred_sub <- family$linkinv(pred_sub)
+    }
+    return(pred_sub)
   }
 
   # Special case: `datafit` -------------------------------------------------


### PR DESCRIPTION
The main purpose of this PR is to add a new argument `transform` to `<refmodel_object>$family$mu_fun()`. The purpose of this (and so is done now by this PR) is to apply the transformation of the submodel's predictions from the latent space (`eta`) to the response space (`mu`) in `proj_linpred()` only conditionally on argument `transform` (which avoids unnecessary back-and-forth transformations between latent space and response space and therefore comes with a slightly improved computational efficiency and also with a numerical improvement for the binomial family—possibly also for the Poisson family and any other families with non-identity link functions—where numerical inaccuracies can cause `link(linkinv(eta))` to be different from `eta`).

Furthermore, some refactoring in `proj_helper()` and downstream functions is performed (to simplify the code, but also to improve safety).