### PR TITLE
Avoid more transformations between latent space and response space

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -309,6 +309,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   ##
 
   mu <- refmodel$mu
+  eta <- refmodel$eta
   dis <- refmodel$dis
   ## the clustering/subsampling used for selection
   p_sel <- .get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)
@@ -457,12 +458,12 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
 
       ## reweight the clusters/samples according to the psis-loo weights
       p_sel <- .get_p_clust(
-        family = refmodel$family, mu = mu, dis = dis, wsample = exp(lw[, i]),
-        cl = cl_sel
+        family = refmodel$family, mu = mu, eta = eta, dis = dis,
+        wsample = exp(lw[, i]), cl = cl_sel
       )
       p_pred <- .get_p_clust(
-        family = refmodel$family, mu = mu, dis = dis, wsample = exp(lw[, i]),
-        cl = cl_pred
+        family = refmodel$family, mu = mu, eta = eta, dis = dis,
+        wsample = exp(lw[, i]), cl = cl_pred
       )
 
       ## perform selection with the reweighted clusters/samples

--- a/R/misc.R
+++ b/R/misc.R
@@ -239,12 +239,13 @@ bootstrap <- function(x, fun = mean, B = 2000,
     } else if (nclusters == 1) {
       # special case, only one cluster
       cl <- rep(1, S)
-      p_ref <- .get_p_clust(refmodel$family, refmodel$mu, refmodel$dis,
-                            wobs = refmodel$wobs, cl = cl)
+      p_ref <- .get_p_clust(family = refmodel$family, mu = refmodel$mu,
+                            dis = refmodel$dis, wobs = refmodel$wobs, cl = cl)
     } else {
       # several clusters
-      p_ref <- .get_p_clust(refmodel$family, refmodel$mu, refmodel$dis,
-                            wobs = refmodel$wobs, nclusters = nclusters)
+      p_ref <- .get_p_clust(family = refmodel$family, mu = refmodel$mu,
+                            dis = refmodel$dis, wobs = refmodel$wobs,
+                            nclusters = nclusters)
     }
   } else {
     ndraws <- min(S, ndraws)

--- a/R/misc.R
+++ b/R/misc.R
@@ -240,12 +240,13 @@ bootstrap <- function(x, fun = mean, B = 2000,
       # special case, only one cluster
       cl <- rep(1, S)
       p_ref <- .get_p_clust(family = refmodel$family, mu = refmodel$mu,
-                            dis = refmodel$dis, wobs = refmodel$wobs, cl = cl)
+                            eta = refmodel$eta, dis = refmodel$dis,
+                            wobs = refmodel$wobs, cl = cl)
     } else {
       # several clusters
       p_ref <- .get_p_clust(family = refmodel$family, mu = refmodel$mu,
-                            dis = refmodel$dis, wobs = refmodel$wobs,
-                            nclusters = nclusters)
+                            eta = refmodel$eta, dis = refmodel$dis,
+                            wobs = refmodel$wobs, nclusters = nclusters)
     }
   } else {
     ndraws <- min(S, ndraws)
@@ -274,7 +275,7 @@ bootstrap <- function(x, fun = mean, B = 2000,
 }
 
 # Function for clustering the parameter draws:
-.get_p_clust <- function(family, mu, dis, nclusters = 10,
+.get_p_clust <- function(family, mu, eta, dis, nclusters = 10,
                          wobs = rep(1, dim(mu)[1]),
                          wsample = rep(1, dim(mu)[2]), cl = NULL) {
   # cluster the samples in the latent space if no clustering provided
@@ -282,8 +283,7 @@ bootstrap <- function(x, fun = mean, B = 2000,
     # Note: A seed is not set here because this function is not exported and has
     # a calling stack at the beginning of which a seed is set.
 
-    f <- family$linkfun(mu)
-    out <- kmeans(t(f), nclusters, iter.max = 50)
+    out <- kmeans(t(eta), nclusters, iter.max = 50)
     cl <- out$cluster # cluster indices for each sample
   } else if (typeof(cl) == "list") {
     # old clustering solution provided, so fetch the cluster indices

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -88,9 +88,12 @@ project_submodel <- function(solution_terms, p_ref, refmodel, regul = 1e-4,
 
 .init_submodel <- function(submodl, p_ref, refmodel, solution_terms, wobs,
                            wsample) {
-  p_ref$mu <- refmodel$family$linkinv(
-    refmodel$family$linkfun(p_ref$mu) + refmodel$offset
-  )
+  # Take offsets into account (the `if ()` condition is added for efficiency):
+  if (!all(refmodel$offset == 0)) {
+    p_ref$mu <- refmodel$family$linkinv(
+      refmodel$family$linkfun(p_ref$mu) + refmodel$offset
+    )
+  }
   if (!(all(is.na(p_ref$var)) ||
         refmodel$family$family %in% c("gaussian", "Student_t"))) {
     stop("For family `", refmodel$family$family, "()`, .init_submodel() might ",
@@ -110,9 +113,11 @@ project_submodel <- function(solution_terms, p_ref, refmodel, regul = 1e-4,
     # ### TODO: Add `dis` and perhaps other elements here?:
     # p_ref <- list(mu = pobs$z, var = p_ref$var)
     # ###
-    # p_ref$mu <- refmodel$family$linkinv(
-    #   refmodel$family$linkfun(p_ref$mu) + refmodel$offset
-    # )
+    # if (!all(refmodel$offset == 0)) {
+    #   p_ref$mu <- refmodel$family$linkinv(
+    #     refmodel$family$linkfun(p_ref$mu) + refmodel$offset
+    #   )
+    # }
     # wobs <- pobs$wobs
     ###
   }

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -767,6 +767,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
       mu <- y / weights
     }
     mu <- matrix(mu)
+    eta <- family$linkfun(mu)
   }
 
   # Miscellaneous -----------------------------------------------------------
@@ -805,9 +806,10 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   # Output ------------------------------------------------------------------
 
   refmodel <- nlist(
-    fit = object, formula, div_minimizer, family, mu, dis, y, loglik, intercept,
-    proj_predfun, fetch_data = fetch_data_wrapper, wobs = weights, wsample,
-    offset, cvfun, cvfits, extract_model_data, ref_predfun, cvrefbuilder
+    fit = object, formula, div_minimizer, family, mu, eta, dis, y, loglik,
+    intercept, proj_predfun, fetch_data = fetch_data_wrapper, wobs = weights,
+    wsample, offset, cvfun, cvfits, extract_model_data, ref_predfun,
+    cvrefbuilder
   )
   if (proper_model) {
     class(refmodel) <- "refmodel"

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -246,9 +246,12 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
     ref <- list(mu = rep(NA, ntest), lppd = rep(NA, ntest))
   } else {
     if (d_type == "train") {
-      mu_test <- refmodel$family$linkinv(
-        refmodel$family$linkfun(refmodel$mu) + refmodel$offset
-      )
+      mu_test <- refmodel$mu
+      if (!all(refmodel$offset == 0)) {
+        mu_test <- refmodel$family$linkinv(
+          refmodel$family$linkfun(mu_test) + refmodel$offset
+        )
+      }
     } else {
       mu_test <- refmodel$family$linkinv(
         refmodel$ref_predfun(refmodel$fit, newdata = d_test$data) +

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -166,9 +166,10 @@ refmodel_tester <- function(
 
   # Test the general structure of the object:
   refmod_nms <- c(
-    "fit", "formula", "div_minimizer", "family", "mu", "dis", "y", "loglik",
-    "intercept", "proj_predfun", "fetch_data", "wobs", "wsample", "offset",
-    "cvfun", "cvfits", "extract_model_data", "ref_predfun", "cvrefbuilder"
+    "fit", "formula", "div_minimizer", "family", "mu", "eta", "dis", "y",
+    "loglik", "intercept", "proj_predfun", "fetch_data", "wobs", "wsample",
+    "offset", "cvfun", "cvfits", "extract_model_data", "ref_predfun",
+    "cvrefbuilder"
   )
   refmod_class_expected <- "refmodel"
   if (is_datafit) {
@@ -284,6 +285,20 @@ refmodel_tester <- function(
                        info = info_str)
     }
   }
+
+  # eta
+  eta_cut <- refmod$eta
+  mu_cut <- refmod$mu
+  if (refmod$family$family %in% c("binomial")) {
+    # To avoid failing tests due to numerical inaccuracies for extreme
+    # values:
+    tol_ex <- 1e-12
+    eta_cut[eta_cut < f_binom$linkfun(tol_ex)] <- f_binom$linkfun(tol_ex)
+    eta_cut[eta_cut > f_binom$linkfun(1 - tol_ex)] <- f_binom$linkfun(1 - tol_ex)
+    mu_cut[mu_cut < tol_ex] <- tol_ex
+    mu_cut[mu_cut > 1 - tol_ex] <- 1 - tol_ex
+  }
+  expect_equal(eta_cut, refmod$family$linkfun(mu_cut), info = info_str)
 
   # dis
   if (refmod$family$family == "gaussian") {


### PR DESCRIPTION
Following upon #337, this PR avoids even more unnecessary back-and-forth transformations between latent space and response space. Originally, the commits from this PR were performed on branch `fweber144:augdat` (see PR #322), but they turned out to be useful for non-identity link functions in the traditional projection, too (see #337 and the commit messages here for some more details).