### PR TITLE
Fix nontrivial offsets for `d_test`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Fix GitHub issue #329.
 * Fix GitHub issue #331.
 * `plot.vsel()` now draws the dashed red horizontal line for the reference model (and---if present---the dotted black horizontal line for the baseline model) first (i.e., before the submodel-specific graphical elements), to avoid overplotting.
+* Fix GitHub issue #339.
 
 # projpred 2.1.2
 

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -294,7 +294,7 @@ predict.refmodel <- function(object, newdata = NULL, ynew = NULL,
   if (length(offsetnew) == 0) {
     offsetnew <- rep(0, length(w_o$y))
   }
-  if (inherits(object$fit, "stanreg") && length(object$offset) > 0) {
+  if (inherits(object$fit, "stanreg") && length(object$fit$offset) > 0) {
     if ("projpred_internal_offs_stanreg" %in% names(newdata)) {
       stop("Need to write to column `projpred_internal_offs_stanreg` of ",
            "`newdata`, but that column already exists. Please rename this ",

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -253,8 +253,18 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
         )
       }
     } else {
+      newdata_for_ref <- d_test$data
+      if (inherits(refmodel$fit, "stanreg") &&
+          length(refmodel$fit$offset) > 0) {
+        if ("projpred_internal_offs_stanreg" %in% names(newdata_for_ref)) {
+          stop("Need to write to column `projpred_internal_offs_stanreg` of ",
+               "`d_test$data`, but that column already exists. Please rename ",
+               "this column in `d_test$data` and try again.")
+        }
+        newdata_for_ref$projpred_internal_offs_stanreg <- d_test$offset
+      }
       mu_test <- refmodel$family$linkinv(
-        refmodel$ref_predfun(refmodel$fit, newdata = d_test$data) +
+        refmodel$ref_predfun(refmodel$fit, newdata = newdata_for_ref) +
           d_test$offset
       )
     }


### PR DESCRIPTION
This fixes #339. Thereby, all calls to `<refmodel_object>$ref_predfun()` where actual new data can occur should be handled appropriately with regard to nontrivial offsets in `stanreg` fits. Furthermore, commit 9fe3f375570b4f72ee042f814363517d510f6d3d comes with a minor enhancement (see the commit message for details).