### PR TITLE
Fixes and other improvements for argument `d_test` of `varsel()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * At multiple places throughout the package: Improvement of the numerical stability for some link functions, achieved by avoiding unnecessary back-and-forth transformations between latent space and response space. (GitHub: #337, #338)
 * All arguments `seed` and `.seed` are now allowed to be `NA` for not calling `set.seed()` internally at all.
 * Argument `d_test` of `varsel()` is not considered as an internal feature anymore. This was possible after fixing a bug for `d_test` (see below).
+* The order of the observations in the subelements of `<vsel_object>$summaries` and `<vsel_object>$d_test` now corresponds to the order of the observations in the original dataset if `<vsel_object>` was created by a call to `cv_varsel([...], cv_method = "kfold")` (formerly, in that case, the observations in those subelements were ordered by fold). Thereby, the order of the observations in those subelements now always corresponds to the order of the observations in the original dataset, except if `<vsel_object>` was created by a call to `varsel([...], d_test = <non-NULL_d_test_object>)`, in which case the order of the observations in those subelements corresponds to the order of the observations in `<non-NULL_d_test_object>`.
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Several improvements in the documentation (especially in the explanation of the `suggest_size()` heuristic).
 * At multiple places throughout the package: Improvement of the numerical stability for some link functions, achieved by avoiding unnecessary back-and-forth transformations between latent space and response space. (GitHub: #337, #338)
 * All arguments `seed` and `.seed` are now allowed to be `NA` for not calling `set.seed()` internally at all.
+* Argument `d_test` of `varsel()` is not considered as an internal feature anymore. This was possible after fixing a bug for `d_test` (see below).
 
 ## Bug fixes
 
@@ -16,6 +17,7 @@
 * Fix GitHub issue #331.
 * `plot.vsel()` now draws the dashed red horizontal line for the reference model (and---if present---the dotted black horizontal line for the baseline model) first (i.e., before the submodel-specific graphical elements), to avoid overplotting.
 * Fix GitHub issue #339. (GitHub: #340)
+* Fix argument `d_test` of `varsel()`: Not only the predictive performance of the *reference model* needs to be evaluated on the test data, but also the predictive performance of the *submodels*.
 
 # projpred 2.1.2
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -516,12 +516,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   summ_ref <- list(lppd = loo_ref, mu = mu_ref)
   summaries <- list(sub = summ_sub, ref = summ_ref)
 
-  d_test <- list(
-    y = refmodel$y, type = "LOO",
-    test_points = seq_along(refmodel$y),
-    weights = refmodel$wobs,
-    data = NULL, offset = refmodel$offset
-  )
+  d_test <- list(y = refmodel$y, type = "LOO", weights = refmodel$wobs,
+                 data = NULL, offset = refmodel$offset)
 
   out_list <- nlist(solution_terms_cv = solution_terms_mat, summaries, d_test)
   if (!validate_search) {
@@ -643,7 +639,6 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
   d_cv <- rbind2list(lapply(list_cv, function(fold) {
     list(y = fold$d_test$y,
          weights = fold$d_test$weights,
-         test_points = fold$d_test$omitted,
          offset = fold$d_test$offset)
   }))
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -516,8 +516,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   summ_ref <- list(lppd = loo_ref, mu = mu_ref)
   summaries <- list(sub = summ_sub, ref = summ_ref)
 
-  d_test <- list(y = refmodel$y, type = "LOO", weights = refmodel$wobs,
-                 data = NULL, offset = refmodel$offset)
+  d_test <- list(type = "LOO", data = NULL, offset = refmodel$offset,
+                 weights = refmodel$wobs, y = refmodel$y)
 
   out_list <- nlist(solution_terms_cv = solution_terms_mat, summaries, d_test)
   if (!validate_search) {
@@ -636,14 +636,14 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
   # Combine the K separate test "datasets" (rather "information objects") into a
   # single list:
   d_cv <- rbind2list(lapply(list_cv, function(fold) {
-    list(y = fold$d_test$y,
+    list(offset = fold$d_test$offset,
          weights = fold$d_test$weights,
-         offset = fold$d_test$offset)
+         y = fold$d_test$y)
   }))
 
   return(nlist(solution_terms_cv,
                summaries = nlist(sub, ref),
-               d_test = c(d_cv, type = "kfold")))
+               d_test = c(list(type = "kfold", data = NULL), d_cv)))
 }
 
 # Re-fit the reference model K times (once for each fold; `cvfun` case) or fetch

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -481,9 +481,9 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
         p_ref = p_pred, refmodel = refmodel, regul = opt$regul,
         refit_prj = refit_prj, ...
       )
-      summaries_sub <- .get_sub_summaries(
-        submodels = submodels, test_points = c(i), refmodel = refmodel
-      )
+      summaries_sub <- .get_sub_summaries(submodels = submodels,
+                                          refmodel = refmodel,
+                                          test_points = i)
       for (k in seq_along(summaries_sub)) {
         loo_sub[[k]][i] <- summaries_sub[[k]]$lppd
         mu_sub[[k]][i] <- summaries_sub[[k]]$mu
@@ -602,10 +602,9 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
   # Perform the evaluation of the submodels for each fold (and make sure to
   # combine the results from the K folds into a single results list):
   get_summaries_submodel_cv <- function(submodels, fold) {
-    .get_sub_summaries(
-      submodels = submodels, test_points = fold$d_test$omitted,
-      refmodel = refmodel
-    )
+    .get_sub_summaries(submodels = submodels,
+                       refmodel = refmodel,
+                       test_points = fold$d_test$omitted)
   }
   sub_cv_summaries <- mapply(get_summaries_submodel_cv, submodels_cv, list_cv)
   if (is.null(dim(sub_cv_summaries))) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -4,6 +4,10 @@
   packageStartupMessage(msg)
 }
 
+nms_d_test <- function() {
+  c("type", "data", "offset", "weights", "y")
+}
+
 weighted.sd <- function(x, w, na.rm = FALSE) {
   if (na.rm) {
     ind <- !is.na(w) & !is.na(x)

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -1,13 +1,15 @@
-.get_sub_summaries <- function(submodels, test_points, refmodel) {
+.get_sub_summaries <- function(submodels, test_points, refmodel,
+                               y = refmodel$y[test_points],
+                               wobs = refmodel$wobs[test_points],
+                               newdata = NULL,
+                               offset = refmodel$offset[test_points]) {
   lapply(submodels, function(model) {
     .weighted_summary_means(
-      y_test = list(y = refmodel$y[test_points],
-                    weights = refmodel$wobs[test_points]),
+      y_test = list(y = y, weights = wobs),
       family = refmodel$family,
       wsample = model$weights,
-      mu = refmodel$family$mu_fun(model$submodl,
-                                  obs = test_points,
-                                  offset = refmodel$offset[test_points]),
+      mu = refmodel$family$mu_fun(model$submodl, obs = test_points,
+                                  newdata = newdata, offset = offset),
       dis = model$dis
     )
   })

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -1,8 +1,7 @@
-.get_sub_summaries <- function(submodels, test_points, refmodel,
-                               y = refmodel$y[test_points],
+.get_sub_summaries <- function(submodels, refmodel, test_points, newdata = NULL,
+                               offset = refmodel$offset[test_points],
                                wobs = refmodel$wobs[test_points],
-                               newdata = NULL,
-                               offset = refmodel$offset[test_points]) {
+                               y = refmodel$y[test_points]) {
   lapply(submodels, function(model) {
     .weighted_summary_means(
       y_test = list(y = y, weights = wobs),

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -227,7 +227,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
   )
   sub <- .get_sub_summaries(submodels = submodels,
                             refmodel = refmodel,
-                            test_points = seq_along(d_test$y),
+                            test_points = NULL,
                             newdata = d_test$data,
                             offset = d_test$offset,
                             wobs = d_test$weights,

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -202,10 +202,8 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
   search_terms <- args$search_terms
 
   if (is.null(d_test)) {
-    d_test <- list(
-      y = refmodel$y, test_points = seq_len(NROW(refmodel$y)), data = NULL,
-      weights = refmodel$wobs, type = "train", offset = refmodel$offset
-    )
+    d_test <- list(y = refmodel$y, data = NULL, weights = refmodel$wobs,
+                   type = "train", offset = refmodel$offset)
   }
 
   ## reference distributions for selection and prediction after selection
@@ -228,7 +226,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
     ...
   )
   sub <- .get_sub_summaries(
-    submodels = submodels, test_points = d_test$test_points,
+    submodels = submodels, test_points = seq_along(d_test$y),
     refmodel = refmodel, y = d_test$y, wobs = d_test$weights,
     newdata = d_test$data, offset = d_test$offset
   )

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -202,10 +202,9 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
 
   if (is.null(d_test)) {
     d_type <- "train"
-    test_points <- seq_len(NROW(refmodel$y))
-    d_test <- nlist(
-      y = refmodel$y, test_points, data = NULL, weights = refmodel$wobs,
-      type = d_type, offset = refmodel$offset
+    d_test <- list(
+      y = refmodel$y, test_points = seq_len(NROW(refmodel$y)), data = NULL,
+      weights = refmodel$wobs, type = d_type, offset = refmodel$offset
     )
   } else {
     d_type <- d_test$type

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -201,13 +201,10 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
   search_terms <- args$search_terms
 
   if (is.null(d_test)) {
-    d_type <- "train"
     d_test <- list(
       y = refmodel$y, test_points = seq_len(NROW(refmodel$y)), data = NULL,
-      weights = refmodel$wobs, type = d_type, offset = refmodel$offset
+      weights = refmodel$wobs, type = "train", offset = refmodel$offset
     )
-  } else {
-    d_type <- d_test$type
   }
 
   ## reference distributions for selection and prediction after selection
@@ -243,7 +240,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
     ntest <- NROW(refmodel$y)
     ref <- list(mu = rep(NA, ntest), lppd = rep(NA, ntest))
   } else {
-    if (d_type == "train") {
+    if (d_test$type == "train") {
       mu_test <- refmodel$mu
       if (!all(refmodel$offset == 0)) {
         mu_test <- refmodel$family$linkinv(

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -10,10 +10,10 @@
 #' @param object An object of class `refmodel` (returned by [get_refmodel()] or
 #'   [init_refmodel()]) or an object that can be passed to argument `object` of
 #'   [get_refmodel()].
-#' @param d_test For internal use only. A `list` providing information about the
-#'   test set which is used for evaluating the predictive performance of the
-#'   submodels as well as of the reference model. If `NULL`, the training set is
-#'   used.
+#' @param d_test A `list` of the structure outlined in section "Argument
+#'   `d_test`" below, providing test data for evaluating the predictive
+#'   performance of the submodels as well as of the reference model. If `NULL`,
+#'   the training data is used.
 #' @param method The method for the search part. Possible options are `"L1"` for
 #'   L1 search and `"forward"` for forward search. If `NULL`, then internally,
 #'   `"L1"` is used, except if the reference model has multilevel or additive
@@ -82,6 +82,19 @@
 #' @param ... Arguments passed to [get_refmodel()] as well as to the divergence
 #'   minimizer (during a forward search and also during the evaluation part, but
 #'   the latter only if `refit_prj` is `TRUE`).
+#'
+#' @details
+#'
+#' # Argument `d_test`
+#'
+#' If not `NULL`, then `d_test` needs to be a `list` with the following
+#' elements:
+#' * `data`: a `data.frame` containing the predictor variables for the test set.
+#' * `offset`: a numeric vector containing the offset values for the test set
+#' (if there is no offset, use a vector of zeros).
+#' * `weights`: a numeric vector containing the observation weights for the test
+#' set (if there are no observation weights, use a vector of ones).
+#' * `y`: a numeric vector containing the response values for the test set.
 #'
 #' @details Arguments `ndraws`, `nclusters`, `nclusters_pred`, and `ndraws_pred`
 #'   are automatically truncated at the number of posterior draws in the

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -12,7 +12,8 @@
 #'   [get_refmodel()].
 #' @param d_test For internal use only. A `list` providing information about the
 #'   test set which is used for evaluating the predictive performance of the
-#'   reference model. If not provided, the training set is used.
+#'   submodels as well as of the reference model. If `NULL`, the training set is
+#'   used.
 #' @param method The method for the search part. Possible options are `"L1"` for
 #'   L1 search and `"forward"` for forward search. If `NULL`, then internally,
 #'   `"L1"` is used, except if the reference model has multilevel or additive
@@ -227,8 +228,9 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
     ...
   )
   sub <- .get_sub_summaries(
-    submodels = submodels, test_points = seq_along(refmodel$y),
-    refmodel = refmodel
+    submodels = submodels, test_points = d_test$test_points,
+    refmodel = refmodel, y = d_test$y, wobs = d_test$weights,
+    newdata = d_test$data, offset = d_test$offset
   )
 
   ## predictive statistics of the reference model on test data. if no test data

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -202,8 +202,8 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
   search_terms <- args$search_terms
 
   if (is.null(d_test)) {
-    d_test <- list(y = refmodel$y, data = NULL, weights = refmodel$wobs,
-                   type = "train", offset = refmodel$offset)
+    d_test <- list(type = "train", data = NULL, offset = refmodel$offset,
+                   weights = refmodel$wobs, y = refmodel$y)
   }
 
   ## reference distributions for selection and prediction after selection
@@ -225,11 +225,13 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
     p_ref = p_pred, refmodel = refmodel, regul = regul, refit_prj = refit_prj,
     ...
   )
-  sub <- .get_sub_summaries(
-    submodels = submodels, test_points = seq_along(d_test$y),
-    refmodel = refmodel, y = d_test$y, wobs = d_test$weights,
-    newdata = d_test$data, offset = d_test$offset
-  )
+  sub <- .get_sub_summaries(submodels = submodels,
+                            refmodel = refmodel,
+                            test_points = seq_along(d_test$y),
+                            newdata = d_test$data,
+                            offset = d_test$offset,
+                            wobs = d_test$weights,
+                            y = d_test$y)
 
   ## predictive statistics of the reference model on test data. if no test data
   ## are provided,

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -204,6 +204,9 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
   if (is.null(d_test)) {
     d_test <- list(type = "train", data = NULL, offset = refmodel$offset,
                    weights = refmodel$wobs, y = refmodel$y)
+  } else {
+    d_test$type <- "test"
+    d_test <- d_test[nms_d_test()]
   }
 
   ## reference distributions for selection and prediction after selection

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -42,7 +42,8 @@ the latter only if \code{refit_prj} is \code{TRUE}).}
 
 \item{d_test}{For internal use only. A \code{list} providing information about the
 test set which is used for evaluating the predictive performance of the
-reference model. If not provided, the training set is used.}
+submodels as well as of the reference model. If \code{NULL}, the training set is
+used.}
 
 \item{method}{The method for the search part. Possible options are \code{"L1"} for
 L1 search and \code{"forward"} for forward search. If \code{NULL}, then internally,

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -40,10 +40,10 @@ varsel(object, ...)
 minimizer (during a forward search and also during the evaluation part, but
 the latter only if \code{refit_prj} is \code{TRUE}).}
 
-\item{d_test}{For internal use only. A \code{list} providing information about the
-test set which is used for evaluating the predictive performance of the
-submodels as well as of the reference model. If \code{NULL}, the training set is
-used.}
+\item{d_test}{A \code{list} of the structure outlined in section "Argument
+\code{d_test}" below, providing test data for evaluating the predictive
+performance of the submodels as well as of the reference model. If \code{NULL},
+the training data is used.}
 
 \item{method}{The method for the search part. Possible options are \code{"L1"} for
 L1 search and \code{"forward"} for forward search. If \code{NULL}, then internally,
@@ -184,6 +184,19 @@ two candidates. At the last model size of 4, \code{y ~ x1 + x2 + x3} would be
 the only candidate. As another example, to exclude \code{x1} from the search,
 specify \code{search_terms = c("x2", "x3", "x2 + x3")}.
 }
+\section{Argument \code{d_test}}{
+If not \code{NULL}, then \code{d_test} needs to be a \code{list} with the following
+elements:
+\itemize{
+\item \code{data}: a \code{data.frame} containing the predictor variables for the test set.
+\item \code{offset}: a numeric vector containing the offset values for the test set
+(if there is no offset, use a vector of zeros).
+\item \code{weights}: a numeric vector containing the observation weights for the test
+set (if there are no observation weights, use a vector of ones).
+\item \code{y}: a numeric vector containing the response values for the test set.
+}
+}
+
 \examples{
 if (requireNamespace("rstanarm", quietly = TRUE)) {
   # Data:

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -1281,10 +1281,14 @@ vsel_tester <- function(
       nloo_expected <- nobsv
     }
   }
+  nobsv_summ <- nobsv
+  if (!is.null(dtest_expected)) {
+    nobsv_summ <- nrow(dtest_expected$data)
+  }
   for (j in seq_along(vs$summaries$sub)) {
     expect_named(vs$summaries$sub[[!!j]], vsel_smmrs_sub_nms, info = info_str)
     expect_type(vs$summaries$sub[[!!j]]$mu, "double")
-    expect_length(vs$summaries$sub[[!!j]]$mu, nobsv)
+    expect_length(vs$summaries$sub[[!!j]]$mu, nobsv_summ)
     if (with_cv) {
       expect_identical(sum(!is.na(vs$summaries$sub[[!!j]]$mu)),
                        nloo_expected, info = info_str)
@@ -1292,7 +1296,7 @@ vsel_tester <- function(
       expect_true(all(!is.na(vs$summaries$sub[[!!j]]$mu)), info = info_str)
     }
     expect_type(vs$summaries$sub[[!!j]]$lppd, "double")
-    expect_length(vs$summaries$sub[[!!j]]$lppd, nobsv)
+    expect_length(vs$summaries$sub[[!!j]]$lppd, nobsv_summ)
     if (with_cv) {
       expect_identical(sum(!is.na(vs$summaries$sub[[!!j]]$lppd)),
                        nloo_expected, info = info_str)
@@ -1314,13 +1318,13 @@ vsel_tester <- function(
   }
   expect_type(vs$summaries$ref, "list")
   expect_named(vs$summaries$ref, vsel_smmrs_ref_nms, info = info_str)
-  expect_length(vs$summaries$ref$mu, nobsv)
+  expect_length(vs$summaries$ref$mu, nobsv_summ)
   if (!from_datafit) {
     expect_true(all(!is.na(vs$summaries$ref$mu)), info = info_str)
   } else {
     expect_true(all(is.na(vs$summaries$ref$mu)), info = info_str)
   }
-  expect_length(vs$summaries$ref$lppd, nobsv)
+  expect_length(vs$summaries$ref$lppd, nobsv_summ)
   if (!from_datafit) {
     expect_true(all(!is.na(vs$summaries$ref$lppd)), info = info_str)
   } else {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -305,6 +305,49 @@ dat_offs_new <- within(dat, {
   offs_col_new <- seq(-2, 2, length.out = nobsv)
 })
 
+nobsv_indep <- tail(nobsv_tst, 1)
+dis_indep <- runif(1L, 1, 2)
+offs_indep <- rnorm(nobsv_indep)
+wobs_indep <- sample(1:4, nobsv_indep, replace = TRUE)
+idxs_indep <- sample.int(nobsv, size = nobsv_indep, replace = TRUE)
+dat_indep <- lapply(mod_nms, function(mod_nm) {
+  lapply(fam_nms, function(fam_nm) {
+    pred_link <- get(paste0("eta_", mod_nm))
+    pred_link <- pred_link[idxs_indep, , drop = FALSE]
+    if (fam_nm != "brnll" && !mod_nm %in% c("gam", "gamm")) {
+      # For the "brnll" `fam_nm`, offsets are simply not added to have some
+      # scenarios without offsets.
+      # For GAMs, offsets are not added because of rstanarm issue #546 (see
+      # also further below).
+      # For GAMMs, offsets are not added because of rstanarm issue #253 (see
+      # also further below).
+      pred_link <- pred_link + offs_indep
+    }
+    pred_resp <- get(paste0("f_", fam_nm))$linkinv(pred_link)
+    if (fam_nm == "gauss") {
+      return(rnorm(nobsv_indep, mean = pred_resp, sd = dis_indep))
+    } else if (fam_nm == "brnll") {
+      return(rbinom(nobsv_indep, 1, pred_resp))
+    } else if (fam_nm == "binom") {
+      return(rbinom(nobsv_indep, wobs_indep, pred_resp))
+    } else if (fam_nm == "poiss") {
+      return(rpois(nobsv_indep, pred_resp))
+    } else {
+      stop("Unknown `fam_nm`.")
+    }
+  })
+})
+dat_indep <- unlist(dat_indep, recursive = FALSE)
+names(dat_indep) <- paste("y", gsub("\\.", "_", names(dat_indep)), sep = "_")
+dat_indep <- cbind(
+  as.data.frame(dat_indep),
+  dat[idxs_indep,
+      grep("^y_", names(dat), value = TRUE, invert = TRUE),
+      drop = FALSE]
+)
+dat_indep$wobs_col <- wobs_indep
+dat_indep$offs_col <- offs_indep
+
 # Fits --------------------------------------------------------------------
 
 ## Setup ------------------------------------------------------------------

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1227,8 +1227,6 @@ vsel_nms_cv <- c(
 vsel_nms_pred <- c("summaries", "solution_terms", "kl", "suggested_size",
                    "summary")
 vsel_nms_pred_opt <- c("solution_terms", "suggested_size")
-# Related to `d_test`:
-vsel_nms_dtest <- c("d_test", setdiff(vsel_nms_pred, c("solution_terms", "kl")))
 # Related to `nloo`:
 vsel_nms_cv_nloo <- c("summaries", "pct_solution_terms_cv", "suggested_size",
                       "summary")
@@ -1239,8 +1237,8 @@ vsel_nms_cv_valsearch <- c("validate_search", "summaries",
                            "summary")
 vsel_nms_cv_valsearch_opt <- c("suggested_size")
 # Related to `cvfits`:
-vsel_nms_cv_cvfits <- c("refmodel", "d_test", "summaries",
-                        "pct_solution_terms_cv", "summary", "suggested_size")
+vsel_nms_cv_cvfits <- c("refmodel", "summaries", "pct_solution_terms_cv",
+                        "summary", "suggested_size")
 vsel_nms_cv_cvfits_opt <- c("pct_solution_terms_cv", "suggested_size")
 vsel_smmrs_sub_nms <- vsel_smmrs_ref_nms <- c("mu", "lppd")
 

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -89,15 +89,33 @@ test_that(paste(
     pkg_crr <- args_vs_i$pkg_nm
     mod_crr <- args_vs_i$mod_nm
     fam_crr <- args_vs_i$fam_nm
-    refmod_crr <- refmods[[tstsetup_ref]]
+    if (!all(refmods[[tstsetup_ref]]$offset == 0)) {
+      offs_crr <- offs_tst
+    } else {
+      offs_crr <- rep(0, nobsv)
+    }
+    if (!all(refmods[[tstsetup_ref]]$wobs == 1)) {
+      wobs_crr <- wobs_tst
+    } else {
+      wobs_crr <- rep(1, nobsv)
+    }
+    formul_fit_crr <- args_fit[[args_vs_i$tstsetup_fit]]$formula
+    dat_crr <- get_dat_formul(formul_crr = formul_fit_crr,
+                              needs_adj = grepl("\\.spclformul", tstsetup))
     d_test_crr <- list(
       data = dat,
-      offset = refmod_crr$offset,
-      weights = refmod_crr$wobs,
-      y = refmod_crr$y
+      offset = offs_crr,
+      weights = wobs_crr,
+      y = dat_crr[[gsub(
+        "\\(|\\)",
+        "",
+        as.character(
+          rm_addresp(rm_cbind(formul_fit_crr))
+        )[2]
+      )]]
     )
     vs_repr <- do.call(varsel, c(
-      list(object = refmod_crr, d_test = d_test_crr),
+      list(object = refmods[[tstsetup_ref]], d_test = d_test_crr),
       excl_nonargs(args_vs_i)
     ))
     meth_exp_crr <- args_vs_i$method
@@ -106,7 +124,7 @@ test_that(paste(
     }
     vsel_tester(
       vs_repr,
-      refmod_expected = refmod_crr,
+      refmod_expected = refmods[[tstsetup_ref]],
       dtest_expected = c(list(type = "test"), d_test_crr),
       solterms_len_expected = args_vs_i$nterms_max,
       method_expected = meth_exp_crr,

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -80,9 +80,6 @@ test_that(paste(
 ), {
   skip_if_not(run_vs)
   tstsetups <- names(vss)
-  ### Alternative with less test setups:
-  # tstsetups <- grep("\\.glm\\.", names(vss), value = TRUE)
-  ###
   for (tstsetup in tstsetups) {
     args_vs_i <- args_vs[[tstsetup]]
     tstsetup_ref <- args_vs_i$tstsetup_ref
@@ -144,6 +141,149 @@ test_that(paste(
                                                 c("type", "data"))],
                  info = tstsetup)
   }
+})
+
+test_that(paste(
+  "`d_test` set to actual test data gives `<vsel_object>summaries$sub` results",
+  "that can be reproduced by proj_linpred() and `<vsel_object>summaries$ref`",
+  "results that can be reproduced by posterior_epred() and log_lik()"
+), {
+  skip_if_not(run_vs)
+  if (exists(".Random.seed", envir = .GlobalEnv)) {
+    rng_old <- get(".Random.seed", envir = .GlobalEnv)
+  }
+  tstsetups <- names(vss)
+  ### TODO (GAMMs): Currently, the following test setup leads to the error
+  ### ```
+  ### Error in t(as.matrix(b$reTrms$Zt[ii, ])) %*%
+  ### as.matrix(c(as.matrix(ranef[[i]]))) :
+  ###   non-conformable arguments
+  ### ```
+  ### thrown by predict.gamm4(). This needs to be fixed. For now, exclude this
+  ### test setup:
+  tstsetups <- grep("brms\\.gamm\\.binom", tstsetups, value = TRUE,
+                    invert = TRUE)
+  ###
+  for (tstsetup in tstsetups) {
+    args_vs_i <- args_vs[[tstsetup]]
+    tstsetup_ref <- args_vs_i$tstsetup_ref
+    pkg_crr <- args_vs_i$pkg_nm
+    mod_crr <- args_vs_i$mod_nm
+    fam_crr <- args_vs_i$fam_nm
+    if (!all(refmods[[tstsetup_ref]]$offset == 0)) {
+      offs_crr <- offs_indep
+    } else {
+      offs_crr <- rep(0, nobsv_indep)
+    }
+    if (!all(refmods[[tstsetup_ref]]$wobs == 1)) {
+      wobs_crr <- wobs_indep
+    } else {
+      wobs_crr <- rep(1, nobsv_indep)
+    }
+    formul_fit_crr <- args_fit[[args_vs_i$tstsetup_fit]]$formula
+    dat_indep_crr <- get_dat_formul(
+      formul_crr = formul_fit_crr,
+      needs_adj = grepl("\\.spclformul", tstsetup),
+      dat_crr = dat_indep
+    )
+    d_test_crr <- list(
+      data = dat_indep,
+      offset = offs_crr,
+      weights = wobs_crr,
+      y = dat_indep_crr[[gsub(
+        "\\(|\\)",
+        "",
+        as.character(
+          rm_addresp(rm_cbind(formul_fit_crr))
+        )[2]
+      )]]
+    )
+    vs_indep <- do.call(varsel, c(
+      list(object = refmods[[tstsetup_ref]], d_test = d_test_crr),
+      excl_nonargs(args_vs_i)
+    ))
+    meth_exp_crr <- args_vs_i$method
+    if (is.null(meth_exp_crr)) {
+      meth_exp_crr <- ifelse(mod_crr == "glm", "L1", "forward")
+    }
+    vsel_tester(
+      vs_indep,
+      refmod_expected = refmods[[tstsetup_ref]],
+      dtest_expected = c(list(type = "test"), d_test_crr),
+      solterms_len_expected = args_vs_i$nterms_max,
+      method_expected = meth_exp_crr,
+      nprjdraws_search_expected = args_vs_i$nclusters,
+      nprjdraws_eval_expected = args_vs_i$nclusters_pred,
+      search_trms_empty_size =
+        length(args_vs_i$search_terms) &&
+        all(grepl("\\+", args_vs_i$search_terms)),
+      info_str = tstsetup
+    )
+
+    ### Summaries for the submodels -------------------------------------------
+
+    # For getting the correct seed in proj_linpred():
+    set.seed(args_vs_i$seed)
+    p_sel_dummy <- .get_refdist(refmods[[tstsetup_ref]],
+                                nclusters = vs_indep$nprjdraws_search)
+    # As soon as GitHub issues #168 and #211 are fixed, we can use `refit_prj =
+    # FALSE` here:
+    pl_indep <- proj_linpred(vs_indep,
+                             newdata = dat_indep_crr,
+                             offsetnew = d_test_crr$offset,
+                             weightsnew = d_test_crr$weights,
+                             transform = TRUE,
+                             integrated = TRUE,
+                             .seed = NA,
+                             nterms = c(0L, seq_along(vs_indep$solution_terms)),
+                             nclusters = args_vs_i$nclusters_pred,
+                             seed = NA)
+    summ_sub_ch <- lapply(pl_indep, function(pl_indep_k) {
+      names(pl_indep_k)[names(pl_indep_k) == "pred"] <- "mu"
+      names(pl_indep_k)[names(pl_indep_k) == "lpd"] <- "lppd"
+      pl_indep_k$mu <- unname(drop(pl_indep_k$mu))
+      pl_indep_k$lppd <- drop(pl_indep_k$lppd)
+      return(pl_indep_k)
+    })
+    names(summ_sub_ch) <- NULL
+    expect_equal(vs_indep$summaries$sub, summ_sub_ch,
+                 tolerance = .Machine$double.eps, info = tstsetup)
+
+    ### Summaries for the reference model -------------------------------------
+
+    if (pkg_crr == "rstanarm") {
+      mu_new <- rstantools::posterior_epred(refmods[[tstsetup_ref]]$fit,
+                                            newdata = dat_indep,
+                                            offset = d_test_crr$offset)
+      if (grepl("\\.without_wobs", tstsetup)) {
+        lppd_new <- rstantools::log_lik(refmods[[tstsetup_ref]]$fit,
+                                        newdata = dat_indep,
+                                        offset = d_test_crr$offset)
+      } else {
+        ### Currently, rstanarm issue #567 causes an error to be thrown when
+        ### calling log_lik(). Therefore, use the following dummy which
+        ### guarantees test success:
+        lppd_new <- matrix(vs_indep$summaries$ref$lppd,
+                           nrow = nrefdraws, ncol = nobsv_indep, byrow = TRUE)
+        ###
+      }
+    } else if (pkg_crr == "brms") {
+      mu_new <- rstantools::posterior_epred(refmods[[tstsetup_ref]]$fit,
+                                            newdata = dat_indep)
+      lppd_new <- rstantools::log_lik(refmods[[tstsetup_ref]]$fit,
+                                      newdata = dat_indep)
+    }
+    summ_ref_ch <- list(
+      mu = unname(colMeans(mu_new)),
+      lppd = unname(apply(lppd_new, 2, log_sum_exp) - log(nrefdraws))
+    )
+    expect_equal(vs_indep$summaries$ref, summ_ref_ch,
+                 tolerance = 1e2 * .Machine$double.eps, info = tstsetup)
+    lppd_ref_ch2 <- unname(loo::elpd(lppd_new)$pointwise[, "elpd"])
+    expect_equal(vs_indep$summaries$ref$lppd, lppd_ref_ch2,
+                 tolerance = 1e2 * .Machine$double.eps, info = tstsetup)
+  }
+  if (exists("rng_old")) assign(".Random.seed", rng_old, envir = .GlobalEnv)
 })
 
 ## Regularization ---------------------------------------------------------

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -87,12 +87,10 @@ test_that("`d_test` works", {
     fam_crr <- args_vs_i$fam_nm
     refmod_crr <- refmods[[tstsetup_ref]]
     d_test_crr <- list(
-      y = refmod_crr$y,
-      test_points = seq_along(refmod_crr$y),
       data = dat,
+      offset = refmod_crr$offset,
       weights = refmod_crr$wobs,
-      type = "test",
-      offset = refmod_crr$offset
+      y = refmod_crr$y
     )
     vs_repr <- do.call(varsel, c(
       list(object = refmod_crr, d_test = d_test_crr),
@@ -105,7 +103,7 @@ test_that("`d_test` works", {
     vsel_tester(
       vs_repr,
       refmod_expected = refmod_crr,
-      dtest_expected = d_test_crr,
+      dtest_expected = c(list(type = "test"), d_test_crr),
       solterms_len_expected = args_vs_i$nterms_max,
       method_expected = meth_exp_crr,
       nprjdraws_search_expected = args_vs_i$nclusters,
@@ -115,10 +113,13 @@ test_that("`d_test` works", {
         all(grepl("\\+", args_vs_i$search_terms)),
       info_str = tstsetup
     )
-    expect_identical(vs_repr$d_test, d_test_crr, info = tstsetup)
-    expect_equal(vs_repr[setdiff(names(vs_repr), vsel_nms_dtest)],
-                 vss[[tstsetup]][setdiff(names(vss[[tstsetup]]),
-                                         vsel_nms_dtest)],
+    expect_equal(vs_repr[setdiff(names(vs_repr), "d_test")],
+                 vss[[tstsetup]][setdiff(names(vss[[tstsetup]]), "d_test")],
+                 info = tstsetup)
+    expect_equal(vs_repr$d_test[setdiff(names(vs_repr$d_test),
+                                        c("type", "data"))],
+                 vss[[tstsetup]]$d_test[setdiff(names(vss[[tstsetup]]$d_test),
+                                                c("type", "data"))],
                  info = tstsetup)
   }
 })

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -103,13 +103,7 @@ test_that(paste(
       data = dat,
       offset = offs_crr,
       weights = wobs_crr,
-      y = dat_crr[[gsub(
-        "\\(|\\)",
-        "",
-        as.character(
-          rm_addresp(rm_cbind(formul_fit_crr))
-        )[2]
-      )]]
+      y = dat_crr[[stdize_lhs(formul_fit_crr)$y_nm]]
     )
     vs_repr <- do.call(varsel, c(
       list(object = refmods[[tstsetup_ref]], d_test = d_test_crr),
@@ -190,13 +184,7 @@ test_that(paste(
       data = dat_indep,
       offset = offs_crr,
       weights = wobs_crr,
-      y = dat_indep_crr[[gsub(
-        "\\(|\\)",
-        "",
-        as.character(
-          rm_addresp(rm_cbind(formul_fit_crr))
-        )[2]
-      )]]
+      y = dat_indep_crr[[stdize_lhs(formul_fit_crr)$y_nm]]
     )
     vs_indep <- do.call(varsel, c(
       list(object = refmods[[tstsetup_ref]], d_test = d_test_crr),

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -73,7 +73,11 @@ test_that("`seed` works (and restores the RNG state afterwards)", {
   }
 })
 
-test_that("`d_test` works", {
+## d_test -----------------------------------------------------------------
+
+test_that(paste(
+  "`d_test` set to the training data gives the same results as its default"
+), {
   skip_if_not(run_vs)
   tstsetups <- names(vss)
   ### Alternative with less test setups:
@@ -421,7 +425,7 @@ test_that("for L1 search, `penalty` has an expected effect", {
   }
 })
 
-# search_terms ------------------------------------------------------------
+## search_terms -----------------------------------------------------------
 
 test_that(paste(
   "including all terms in `search_terms` gives the same results as the default",
@@ -564,6 +568,8 @@ test_that("`seed` works (and restores the RNG state afterwards)", {
   }
 })
 
+## nloo -------------------------------------------------------------------
+
 test_that("invalid `nloo` fails", {
   for (tstsetup in names(refmods)) {
     # Use suppressWarnings() because of occasional warnings concerning Pareto k
@@ -646,6 +652,8 @@ test_that("setting `nloo` smaller than the number of observations works", {
     }
   }
 })
+
+## validate_search --------------------------------------------------------
 
 test_that("`validate_search` works", {
   skip_if_not(run_cvvs)
@@ -741,6 +749,8 @@ test_that("`validate_search` works", {
   sum_as_unexpected <- 2L
   expect_true(sum(!suggsize_cond, na.rm = TRUE) <= sum_as_unexpected)
 })
+
+## Arguments specific to K-fold CV ----------------------------------------
 
 test_that("invalid `K` fails", {
   expect_error(cv_varsel(refmods[[1]], cv_method = "kfold", K = 1),


### PR DESCRIPTION
As stated in the new `NEWS.md` entries, this PR:
* Fixes argument `d_test` of `varsel()`: Not only the predictive performance of the *reference model* needs to be evaluated on the test data, but also the predictive performance of the *submodels*.
* Does not consider argument `d_test` of `varsel()` as an internal feature anymore. This was possible after fixing the bug for `d_test` mentioned above.
* Ensures that the order of the observations in the subelements of `<vsel_object>$summaries` and `<vsel_object>$d_test` now always corresponds to the order of the observations in the original dataset (except if `<vsel_object>` was created by a call to `varsel([...], d_test = <non-NULL_d_test_object>)`, in which case the order of the observations in those subelements corresponds to the order of the observations in `<non-NULL_d_test_object>`). The only case not following this rule up to now was K-fold CV.

Apart from that, the existing `d_test` tests is enhanced and a new test is added which tests that when `d_test` is set to actual test data, the `<vsel_object>summaries$sub` results can be reproduced by `proj_linpred()` and the `<vsel_object>summaries$ref` results can be reproduced by `posterior_epred()` and `log_lik()`.

Some refactoring of `d_test`-related code is also performed, to enhance readability and consistency.