### PR TITLE
Fix #330

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # projpred 2.1.2.9000
 
+## Major changes
+
+* Some severe bugs (GitHub issues #329, #330, and #342) have been fixed, concerning the performance evaluation of models with nontrivial observation weights (i.e., models where at least one observation had a weight differing from 1). Concerned performance statistics were `"mse"`, `"rmse"`, `"acc"` (= `"pctcorr"`), and `"auc"` (i.e., all performance statistics except for `"elpd"` and `"mlpd"`).
+
 ## Minor changes
 
 * Several improvements in the documentation (especially in the explanation of the `suggest_size()` heuristic).
@@ -20,7 +24,7 @@
 * Fix GitHub issue #339. (GitHub: #340)
 * Fix argument `d_test` of `varsel()`: Not only the predictive performance of the *reference model* needs to be evaluated on the test data, but also the predictive performance of the *submodels*. (GitHub: #341)
 * Fix GitHub issue #342.
-* Fix GitHub issue #330, at least partly.
+* Fix GitHub issue #330. (GitHub: #344, commit 23e7101)
 
 # projpred 2.1.2
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -628,7 +628,8 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
     summ$mu <- summ$mu[order(idxs_sorted_by_fold)]
     summ$lppd <- summ$lppd[order(idxs_sorted_by_fold)]
 
-    # Add weights (see GitHub issue #330 for why this needs to be clarified):
+    # Add fold-specific weights (see the discussion at GitHub issue #94 for why
+    # this might have to be changed):
     summ$w <- rep(1, length(summ$mu))
     summ$w <- summ$w / sum(summ$w)
     return(summ)

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -519,7 +519,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
 
   ## put all the results together in the form required by cv_varsel
   summ_sub <- lapply(seq_len(nterms_max), function(k) {
-    list(lppd = loo_sub[[k]], mu = mu_sub[[k]], w = validset$w)
+    list(lppd = loo_sub[[k]], mu = mu_sub[[k]], wcv = validset$wcv)
   })
   summ_ref <- list(lppd = loo_ref, mu = mu_ref)
   summaries <- list(sub = summ_sub, ref = summ_ref)
@@ -630,8 +630,8 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
 
     # Add fold-specific weights (see the discussion at GitHub issue #94 for why
     # this might have to be changed):
-    summ$w <- rep(1, length(summ$mu))
-    summ$w <- summ$w / sum(summ$w)
+    summ$wcv <- rep(1, length(summ$mu))
+    summ$wcv <- summ$wcv / sum(summ$wcv)
     return(summ)
   })
 
@@ -744,20 +744,20 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
 #
 #     ## assign the weights corresponding to this stratification (for example, the
 #     ## 'bad' values are likely to be overpresented in the sample)
-#     w <- rep(0, n)
-#     w[inds[inds %in% bad]] <- length(bad) / sum(inds %in% bad)
-#     w[inds[inds %in% ok]] <- length(ok) / sum(inds %in% ok)
-#     w[inds[inds %in% good]] <- length(good) / sum(inds %in% good)
+#     wcv <- rep(0, n)
+#     wcv[inds[inds %in% bad]] <- length(bad) / sum(inds %in% bad)
+#     wcv[inds[inds %in% ok]] <- length(ok) / sum(inds %in% ok)
+#     wcv[inds[inds %in% good]] <- length(good) / sum(inds %in% good)
 #   } else {
 #     ## all points used
 #     inds <- seq_len(n)
-#     w <- rep(1, n)
+#     wcv <- rep(1, n)
 #   }
 #
 #   ## ensure weights are normalized
-#   w <- w / sum(w)
+#   wcv <- wcv / sum(wcv)
 #
-#   return(nlist(inds, w))
+#   return(nlist(inds, wcv))
 # }
 
 ## decide which points to go through in the validation based on
@@ -773,12 +773,12 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
     stop("Argument `nloo` must not be larger than the number of observations.")
   } else if (nloo == length(lppd)) {
     inds <- seq_len(nloo)
-    w <- rep(1, nloo)
+    wcv <- rep(1, nloo)
   } else if (nloo < length(lppd)) {
-    w <- exp(lppd - max(lppd))
-    inds <- sample(seq_along(lppd), size = nloo, prob = w)
+    wcv <- exp(lppd - max(lppd))
+    inds <- sample(seq_along(lppd), size = nloo, prob = wcv)
   }
-  w <- w / sum(w)
+  wcv <- wcv / sum(wcv)
 
-  return(nlist(inds, w))
+  return(nlist(inds, wcv))
 }

--- a/R/methods.R
+++ b/R/methods.R
@@ -447,11 +447,7 @@ plot.vsel <- function(
 #'   * `"acc"` (or its alias, `"pctcorr"`): classification accuracy
 #'   ([binomial()] family only).
 #'   * `"auc"`: area under the ROC curve ([binomial()] family only). For the
-#'   corresponding standard error, bootstrapping is used. In the "aggregated"
-#'   binomial case (i.e., if there is more than one Bernoulli trial for at least
-#'   one observation), \pkg{projpred} calculates the AUC by deaggregating the
-#'   observations internally to a long dataset with only zeros and ones as
-#'   response values.
+#'   corresponding standard error, bootstrapping is used.
 #' @param type One or more items from `"mean"`, `"se"`, `"lower"`, `"upper"`,
 #'   `"diff"`, and `"diff.se"` indicating which of these to compute for each
 #'   item from `stats` (mean, standard error, lower and upper confidence

--- a/R/misc.R
+++ b/R/misc.R
@@ -33,37 +33,8 @@ log_sum_exp <- function(x) {
 auc <- function(x) {
   resp <- x[, 1]
   pred <- x[, 2]
-  weights <- x[, 3]
-  wcv <- x[, 4]
+  wcv <- x[, 3]
   n <- nrow(x)
-  if (!all(weights == 1)) { # TODO: Move this out of auc() to get_stat() and then simplify get_stat() as far as possible (e.g., `weights` shouldn't be needed anymore).
-    # Several checks which should in fact not be necessary because auc() is only
-    # used in case of the binomial family:
-    if (!all(.is.wholenumber(weights))) {
-      stop("Currently, projpred:::auc() does not support non-integer ",
-           "observation weights.")
-    }
-    if (!all(.is.wholenumber(resp))) {
-      stop("Currently, projpred:::auc() does not support non-integer response ",
-           "values in case of nontrivial observation weights.")
-    }
-    if (!all(0 <= resp & resp <= weights)) {
-      stop("Currently, projpred:::auc() does not support response values ",
-           "smaller than zero or larger than the observation weights.")
-    }
-    x <- do.call(rbind, lapply(seq_len(n), function(i_short) {
-      cbind(c(rep(0L, weights[i_short] - resp[i_short]),
-              rep(1L, resp[i_short])),
-            pred[i_short],
-            1,
-            wcv[i_short])
-    }))
-    resp <- x[, 1]
-    pred <- x[, 2]
-    weights <- x[, 3]
-    wcv <- x[, 4]
-    n <- nrow(x)
-  }
   ord <- order(pred, decreasing = TRUE)
   resp <- resp[ord]
   pred <- pred[ord]

--- a/R/misc.R
+++ b/R/misc.R
@@ -34,8 +34,9 @@ auc <- function(x) {
   resp <- x[, 1]
   pred <- x[, 2]
   weights <- x[, 3]
+  wcv <- x[, 4]
   n <- nrow(x)
-  if (!all(weights == 1)) {
+  if (!all(weights == 1)) { # TODO: Move this out of auc() to get_stat() and then simplify get_stat() as far as possible (e.g., `weights` shouldn't be needed anymore).
     # Several checks which should in fact not be necessary because auc() is only
     # used in case of the binomial family:
     if (!all(.is.wholenumber(weights))) {
@@ -54,17 +55,20 @@ auc <- function(x) {
       cbind(c(rep(0L, weights[i_short] - resp[i_short]),
               rep(1L, resp[i_short])),
             pred[i_short],
-            1)
+            1,
+            wcv[i_short])
     }))
     resp <- x[, 1]
     pred <- x[, 2]
     weights <- x[, 3]
+    wcv <- x[, 4]
     n <- nrow(x)
   }
   ord <- order(pred, decreasing = TRUE)
   resp <- resp[ord]
   pred <- pred[ord]
-  w0 <- w1 <- rep(1, n)
+  wcv <- wcv[ord]
+  w0 <- w1 <- wcv
   stopifnot(all(resp %in% c(0, 1)))
   w0[resp == 1] <- 0 # for calculating the false positive rate (fpr)
   w1[resp == 0] <- 0 # for calculating the true positive rate (tpr)

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -164,27 +164,19 @@ get_stat <- function(mu, lppd, d_test, stat, mu.bs = NULL, lppd.bs = NULL,
   ## ensure the weights sum to n_notna
   weights <- n_notna * weights / sum(weights)
 
-  # TODO: Simplify by taking code parts that are common to multiple `stat`s out
-  # of the following `if ()` parts and moving them up here.
-  if (stat == "mlpd") {
-    if (!is.null(lppd.bs)) {
-      value <- mean((lppd - lppd.bs) * weights, na.rm = TRUE)
-      value.se <- weighted.sd(lppd - lppd.bs, weights, na.rm = TRUE) /
-        sqrt(n_notna)
-    } else {
-      value <- mean(lppd * weights, na.rm = TRUE)
-      value.se <- weighted.sd(lppd, weights, na.rm = TRUE) /
-        sqrt(n_notna)
-    }
-  } else if (stat == "elpd") {
+  if (stat %in% c("mlpd", "elpd")) {
     if (!is.null(lppd.bs)) {
       value <- sum((lppd - lppd.bs) * weights, na.rm = TRUE)
-      value.se <- weighted.sd(lppd - lppd.bs, weights, na.rm = TRUE) /
-        sqrt(n_notna) * n_notna
+      value.se <- weighted.sd(lppd - lppd.bs, weights, na.rm = TRUE) *
+        sqrt(n_notna)
     } else {
       value <- sum(lppd * weights, na.rm = TRUE)
-      value.se <- weighted.sd(lppd, weights, na.rm = TRUE) /
-        sqrt(n_notna) * n_notna
+      value.se <- weighted.sd(lppd, weights, na.rm = TRUE) *
+        sqrt(n_notna)
+    }
+    if (stat == "mlpd") {
+      value <- value / n_notna
+      value.se <- value.se / n_notna
     }
   } else if (stat == "mse") {
     if (is.null(d_test$y_prop)) {

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -132,24 +132,22 @@
   return(stat_tab)
 }
 
+## Calculates given statistic stat with standard error and confidence bounds.
+## mu.bs and lppd.bs are the pointwise mu and lppd for another model that is
+## used as a baseline for computing the difference in the given statistic,
+## for example the relative elpd. If these arguments are not given (NULL) then
+## the actual (non-relative) value is computed.
+## NOTE: Element `wcv[i]` (with i = 1, ..., N and N denoting the number of
+## observations) contains the weight of the CV fold that observation i is in.
+## In case of varsel() output, this is `NULL`. Currently, these `wcv` are
+## nonconstant (and not `NULL`) only in case of subsampled LOO CV. The actual
+## observation weights (specified by the user) are contained in
+## `d_test$weights`. These are already taken into account by
+## `<refmodel_object>$family$ll_fun()` and are thus already taken into account
+## in `lppd`. However, `mu` does not take them into account, so some further
+## adjustments are necessary below.
 get_stat <- function(mu, lppd, d_test, stat, mu.bs = NULL, lppd.bs = NULL,
                      wcv = NULL, alpha = 0.1, ...) {
-  ##
-  ## Calculates given statistic stat with standard error and confidence bounds.
-  ## mu.bs and lppd.bs are the pointwise mu and lppd for another model that is
-  ## used as a baseline for computing the difference in the given statistic,
-  ## for example the relative elpd. If these arguments are not given (NULL) then
-  ## the actual (non-relative) value is computed.
-  ## NOTE: Element `wcv[i]` (with i = 1, ..., N and N denoting the number of
-  ## observations) contains the weight of the CV fold that observation i is in.
-  ## In case of varsel() output, this is `NULL`. Currently, these `wcv` are
-  ## nonconstant (and not `NULL`) only in case of subsampled LOO CV. The actual
-  ## observation weights (specified by the user) are contained in
-  ## `d_test$weights`. These are already taken into account by
-  ## `<refmodel_object>$family$ll_fun()` and are thus already taken into account
-  ## in `lppd`. However, `mu` does not take them into account, so some further
-  ## adjustments are necessary below.
-
   n <- length(mu)
   if (stat %in% c("mlpd", "elpd")) {
     n_notna <- sum(!is.na(lppd))
@@ -273,7 +271,7 @@ get_stat <- function(mu, lppd, d_test, stat, mu.bs = NULL, lppd.bs = NULL,
     } else if (stat == "auc") {
       auc.data <- cbind(y, mu, wcv)
       if (!is.null(mu.bs)) {
-        mu.bs[is.na(mu)] <- NA # compute the relative auc using only those points
+        mu.bs[is.na(mu)] <- NA # compute the AUCs using only those points
         mu[is.na(mu.bs)] <- NA # for which both mu and mu.bs are non-NA
         auc.data.bs <- cbind(y, mu.bs, wcv)
         value <- auc(auc.data) - auc(auc.data.bs)

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -150,7 +150,7 @@ get_stat <- function(mu, lppd, d_test, stat, mu.bs = NULL, lppd.bs = NULL,
 
   if (is.null(weights)) {
     ## set default weights if not given
-    weights <- rep(1 / n_notna, n)
+    weights <- rep(1, n)
   }
   ## ensure the weights sum to n_notna
   weights <- n_notna * weights / sum(weights)

--- a/man/plot.vsel.Rd
+++ b/man/plot.vsel.Rd
@@ -35,11 +35,7 @@ bootstrapping is used.
 \item \code{"acc"} (or its alias, \code{"pctcorr"}): classification accuracy
 (\code{\link[=binomial]{binomial()}} family only).
 \item \code{"auc"}: area under the ROC curve (\code{\link[=binomial]{binomial()}} family only). For the
-corresponding standard error, bootstrapping is used. In the "aggregated"
-binomial case (i.e., if there is more than one Bernoulli trial for at least
-one observation), \pkg{projpred} calculates the AUC by deaggregating the
-observations internally to a long dataset with only zeros and ones as
-response values.
+corresponding standard error, bootstrapping is used.
 }}
 
 \item{deltas}{If \code{TRUE}, the submodel statistics are estimated as differences

--- a/man/summary.vsel.Rd
+++ b/man/summary.vsel.Rd
@@ -37,11 +37,7 @@ bootstrapping is used.
 \item \code{"acc"} (or its alias, \code{"pctcorr"}): classification accuracy
 (\code{\link[=binomial]{binomial()}} family only).
 \item \code{"auc"}: area under the ROC curve (\code{\link[=binomial]{binomial()}} family only). For the
-corresponding standard error, bootstrapping is used. In the "aggregated"
-binomial case (i.e., if there is more than one Bernoulli trial for at least
-one observation), \pkg{projpred} calculates the AUC by deaggregating the
-observations internally to a long dataset with only zeros and ones as
-response values.
+corresponding standard error, bootstrapping is used.
 }}
 
 \item{type}{One or more items from \code{"mean"}, \code{"se"}, \code{"lower"}, \code{"upper"},

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -1126,7 +1126,7 @@ vsel_tester <- function(
   # Preparations:
   if (with_cv) {
     vsel_nms <- vsel_nms_cv
-    vsel_smmrs_sub_nms <- c(vsel_smmrs_sub_nms, "w")
+    vsel_smmrs_sub_nms <- c(vsel_smmrs_sub_nms, "wcv")
 
     if (is.null(cv_method_expected)) {
       cv_method_expected <- "LOO"


### PR DESCRIPTION
This fixes issue #330 completely (commit 23e7101 already fixed it partly, i.e., as far as possible at that time).

Note that in contrast to what I assumed in the `TODO` comment added by 23e7101, the `auc()` function actually seems to have expected the CV fold weights in the third column of its input matrix. The user-supplied observation weights were simply ignored for the `"auc"` statistic before 23e7101.