### PR TITLE
Disallow offsets for `datafit`s

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 * Several improvements in the documentation.
 * For the RMSE as well as the AUC (see argument `stats` of `summary.vsel()`), the bootstrapping results are now also used for inferring the lower and upper confidence interval bounds. (GitHub: #318, #347; thanks to users @awd97 and @VisionResearchBlog)
+* For `datafit`s, offsets are not supported anymore. (GitHub: #186 (partly), #351)
 
 ## Bug fixes
 

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -663,6 +663,13 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     offset <- rep(0, NROW(y))
   }
 
+  if (!proper_model && !all(offset == 0)) {
+    # Disallow offsets for `datafit`s because the submodel fitting does not take
+    # offsets into account (but `<refmodel>$mu` contains the observed response
+    # values which inevitably "include" the offsets):
+    stop("For a `datafit`, offsets are not allowed.")
+  }
+
   # For avoiding the warning "contrasts dropped from factor <factor_name>" when
   # predicting for each projected draw, e.g., for submodels fit with lm()/glm():
   has_contr <- sapply(data, function(data_col) {

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -732,10 +732,13 @@ test_that(paste(
         abs(t(betas[[i + 1]]) - lasso$beta[ind[1:i], lambdainds[i + 1]])
       })
       expect_true(median(unlist(delta)) < 6e-2)
-      expect_true(median(abs(sapply(head(vs$search_path$submodls,
-                                         length(lambdainds)), function(x) {
-        x[[1]]$alpha
-      }) - lasso$a0[lambdainds])) < 1.5e-1)
+      expect_true(median(abs(
+        sapply(head(vs$search_path$submodls, length(lambdainds)),
+               function(x) {
+                 x[[1]]$alpha
+               }) -
+          lasso$a0[lambdainds])
+      ) < 1.5e-1)
     } else {
       expect_true(sum(ind == solution_terms_lasso[[i]]) >= nterms / 2)
     }

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -2,6 +2,12 @@ context("datafit")
 
 # Setup -------------------------------------------------------------------
 
+# Note: Since PR #351, offsets are not supported anymore for `datafit`s. Here,
+# we use the data as generated in `setup.R`, i.e., sometimes with offsets. So
+# far, this doesn't seem to cause problems in the submodel fitting routines, but
+# it might do in the future. Then, either the scenarios including offsets have
+# to be excluded or new data has to be generated without offsets.
+
 .extrmoddat_datafit <- function(object, newdata = NULL, wrhs = NULL,
                                 orhs = NULL, resp_form = NULL) {
   if (is.null(newdata)) {

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -603,7 +603,6 @@ test_that(paste(
   b <- seq(0, 1, length.out = nterms)
   dis <- runif(1, 0.3, 0.5)
   weights <- sample(1:4, n, replace = TRUE)
-  offset <- rep(0, n)
 
   fams <- list(gaussian(), binomial(), poisson())
   x_list <- lapply(fams, function(fam) x)
@@ -660,9 +659,6 @@ test_that(paste(
       if ("weights" %in% colnames(newdata)) {
         wrhs <- ~ weights
       }
-      if ("offset" %in% colnames(newdata)) {
-        orhs <- ~ offset
-      }
       if ("y" %in% colnames(newdata)) {
         resp_form <- ~ y
       }
@@ -699,10 +695,8 @@ test_that(paste(
     ))
     expect_warning(
       pred1 <- proj_linpred(vs,
-                            newdata = data.frame(x = x, offset = offset,
-                                                 weights = weights),
+                            newdata = data.frame(x = x, weights = weights),
                             nterms = 0:nterms, transform = FALSE,
-                            offsetnew = ~offset,
                             refit_prj = FALSE),
       paste("^Currently, `refit_prj = FALSE` requires some caution, see GitHub",
             "issues #168 and #211\\.$"),
@@ -712,7 +706,6 @@ test_that(paste(
     # compute the results for the Lasso
     lasso <- glmnet::glmnet(x, y_glmnet,
                             family = fam$family, weights = weights,
-                            offset = offset,
                             lambda.min.ratio = lambda_min_ratio,
                             nlambda = nlambda, thresh = 1e-12)
     solution_terms <- predict(lasso, type = "nonzero", s = lasso$lambda)
@@ -722,8 +715,7 @@ test_that(paste(
     })
     ## lambdaval <- lasso$lambda[lambdainds]
     ## pred2 <- predict(lasso,
-    ##   newx = x, type = "link", s = lambdaval,
-    ##   newoffset = offset
+    ##   newx = x, type = "link", s = lambdaval
     ## )
 
     # check that the predictions agree (up to nterms-2 only, because glmnet


### PR DESCRIPTION
Following https://github.com/stan-dev/projpred/issues/186#issuecomment-1245771190, this PR disallows offsets for `datafit`s because the submodel fitting does not take offsets into account (but `<refmodel>$mu` contains the observed response values which inevitably "include" the offsets, i.e., we cannot get (hypothetical) observed response values excluding offsets if offsets are actually present).