### PR TITLE
Catch `d_test$y` consisting of only `NA`s

### DIFF
--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -163,7 +163,7 @@ get_stat <- function(mu, lppd, d_test, stat, mu.bs = NULL, lppd.bs = NULL,
       n_notna.bs <- sum(!is.na(lppd.bs))
     }
   } else {
-    n_notna <- sum(!is.na(mu))
+    n_notna <- sum(!is.na(mu) & !is.na(d_test$y_prop %||% d_test$y))
     if (!is.null(mu.bs)) {
       n_notna.bs <- sum(!is.na(mu.bs))
     }


### PR DESCRIPTION
This catches the case where `d_test$y` (in `get_stat()`) consists of only `NA`s. On `master`, such a case should only be a rare and unintended exception (namely, if argument `d_test` of `varsel()` is specified so that element `y` contains only `NA`s), but this will become more important later for the latent projection.