### PR TITLE
Create `README.md` from `README.Rmd`

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,74 @@
+---
+output: github_document
+---
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/README-",
+  out.width = "100%"
+)
+```
+
+<!-- badges: start -->
+<!-- [![codecov](https://codecov.io/gh/stan-dev/projpred/branch/master/graph/badge.svg)](https://app.codecov.io/gh/stan-dev/projpred) -->
+[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/projpred?color=blue)](https://CRAN.R-project.org/package=projpred)
+<!-- badges: end -->
+
+# projpred [<img src="man/figures/logo.svg" align="right" height="139" alt="Stan Logo"/>](https://mc-stan.org)
+
+The R package **projpred** performs the projection predictive variable selection
+for various regression models. Usually, the reference model will be an
+[**rstanarm**](https://mc-stan.org/rstanarm/) or
+[**brms**](https://paul-buerkner.github.io/brms/) fit, but custom reference
+models can also be used. Details on supported model types are given in section
+["Supported types of
+models"](https://mc-stan.org/projpred/articles/projpred.html#modtypes) of the
+main vignette^[The main vignette can be accessed offline by typing
+`vignette(topic = "projpred", package = "projpred")` or---more
+conveniently---`browseVignettes("projpred")` within R.].
+
+For details on how to cite **projpred**, see the [projpred citation
+info](https://CRAN.R-project.org/package=projpred/citation.html) on CRAN^[The
+citation information can be accessed offline by typing
+`print(citation("projpred"), bibtex = TRUE)` within R.]. Further references
+(including earlier work that **projpred** is based on) are given in section
+["Introduction"](https://mc-stan.org/projpred/articles/projpred.html#introduction)
+of the main vignette.
+
+The [vignettes](https://mc-stan.org/projpred/articles/)^[The overview of all
+vignettes can be accessed offline by typing `browseVignettes("projpred")` within
+R.] (currently, the main vignette is the only one) illustrate how to use the
+**projpred** functions in conjunction. Details on the **projpred** functions as
+well as some shorter examples may be found in the
+[documentation](https://mc-stan.org/projpred/reference/index.html)^[The
+documentation can be accessed offline using `?` or `help()` within R.].
+
+## Installation
+
+There are two ways for installing **projpred**: from
+[CRAN](https://CRAN.R-project.org/package=projpred) or from
+[GitHub](https://github.com/stan-dev/projpred). The GitHub version might be more
+recent than the CRAN version, but the CRAN version might be more stable.
+
+### From CRAN
+
+```r
+install.packages("projpred")
+```
+
+### From GitHub
+
+This requires the [**devtools**](https://devtools.r-lib.org/) package, so if
+necessary, the following code will also install **devtools** (from
+[CRAN](https://CRAN.R-project.org/package=devtools)):
+```r
+if (!requireNamespace("devtools", quietly = TRUE)) {
+  install.packages("devtools")
+}
+devtools::install_github("stan-dev/projpred", build_vignettes = TRUE)
+```
+To save time, you may omit `build_vignettes = TRUE`.

--- a/README.md
+++ b/README.md
@@ -1,59 +1,73 @@
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
 <!-- badges: start -->
 <!-- [![codecov](https://codecov.io/gh/stan-dev/projpred/branch/master/graph/badge.svg)](https://app.codecov.io/gh/stan-dev/projpred) -->
+
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/projpred?color=blue)](https://CRAN.R-project.org/package=projpred)
 <!-- badges: end -->
 
 # projpred [<img src="man/figures/logo.svg" align="right" height="139" alt="Stan Logo"/>](https://mc-stan.org)
 
-The R package **projpred** performs the projection predictive variable selection
-for various regression models. Usually, the reference model will be an
-[**rstanarm**](https://mc-stan.org/rstanarm/) or
-[**brms**](https://paul-buerkner.github.io/brms/) fit, but custom reference
-models can also be used. Details on supported model types are given in section
-["Supported types of
-models"](https://mc-stan.org/projpred/articles/projpred.html#modtypes) of the
-main vignette^[The main vignette can be accessed offline by typing
-`vignette(topic = "projpred", package = "projpred")` or---more
-conveniently---`browseVignettes("projpred")` within R.].
+The R package **projpred** performs the projection predictive variable
+selection for various regression models. Usually, the reference model
+will be an [**rstanarm**](https://mc-stan.org/rstanarm/) or
+[**brms**](https://paul-buerkner.github.io/brms/) fit, but custom
+reference models can also be used. Details on supported model types are
+given in section [“Supported types of
+models”](https://mc-stan.org/projpred/articles/projpred.html#modtypes)
+of the main vignette[^1].
 
 For details on how to cite **projpred**, see the [projpred citation
-info](https://CRAN.R-project.org/package=projpred/citation.html) on CRAN^[The
-citation information can be accessed offline by typing
-`print(citation("projpred"), bibtex = TRUE)` within R.]. Further references
-(including earlier work that **projpred** is based on) are given in section
-["Introduction"](https://mc-stan.org/projpred/articles/projpred.html#introduction)
+info](https://CRAN.R-project.org/package=projpred/citation.html) on
+CRAN[^2]. Further references (including earlier work that **projpred**
+is based on) are given in section
+[“Introduction”](https://mc-stan.org/projpred/articles/projpred.html#introduction)
 of the main vignette.
 
-The [vignettes](https://mc-stan.org/projpred/articles/)^[The overview of all
-vignettes can be accessed offline by typing `browseVignettes("projpred")` within
-R.] (currently, the main vignette is the only one) illustrate how to use the
-**projpred** functions in conjunction. Details on the **projpred** functions as
-well as some shorter examples may be found in the
-[documentation](https://mc-stan.org/projpred/reference/index.html)^[The
-documentation can be accessed offline using `?` or `help()` within R.].
+The [vignettes](https://mc-stan.org/projpred/articles/)[^3] (currently,
+the main vignette is the only one) illustrate how to use the
+**projpred** functions in conjunction. Details on the **projpred**
+functions as well as some shorter examples may be found in the
+[documentation](https://mc-stan.org/projpred/reference/index.html)[^4].
 
 ## Installation
 
 There are two ways for installing **projpred**: from
 [CRAN](https://CRAN.R-project.org/package=projpred) or from
-[GitHub](https://github.com/stan-dev/projpred). The GitHub version might be more
-recent than the CRAN version, but the CRAN version might be more stable.
+[GitHub](https://github.com/stan-dev/projpred). The GitHub version might
+be more recent than the CRAN version, but the CRAN version might be more
+stable.
 
 ### From CRAN
 
-```r
+``` r
 install.packages("projpred")
 ```
 
 ### From GitHub
 
-This requires the [**devtools**](https://devtools.r-lib.org/) package, so if
-necessary, the following code will also install **devtools** (from
+This requires the [**devtools**](https://devtools.r-lib.org/) package,
+so if necessary, the following code will also install **devtools** (from
 [CRAN](https://CRAN.R-project.org/package=devtools)):
-```r
+
+``` r
 if (!requireNamespace("devtools", quietly = TRUE)) {
   install.packages("devtools")
 }
 devtools::install_github("stan-dev/projpred", build_vignettes = TRUE)
 ```
+
 To save time, you may omit `build_vignettes = TRUE`.
+
+[^1]: The main vignette can be accessed offline by typing
+    `vignette(topic = "projpred", package = "projpred")` or—more
+    conveniently—`browseVignettes("projpred")` within R.
+
+[^2]: The citation information can be accessed offline by typing
+    `print(citation("projpred"), bibtex = TRUE)` within R.
+
+[^3]: The overview of all vignettes can be accessed offline by typing
+    `browseVignettes("projpred")` within R.
+
+[^4]: The documentation can be accessed offline using `?` or `help()`
+    within R.


### PR DESCRIPTION
By this PR, the `README.md` file is created from a `README.Rmd` file. The reason for this is that currently, the footnotes are not shown correctly in the GitHub preview of `README.md` (at the bottom of the main GitHub page <https://github.com/stan-dev/projpred/>). On the pkgdown website (<https://mc-stan.org/projpred/>) and on CRAN (<https://cran.r-project.org/web/packages/projpred/readme/README.html>), they are shown correctly, so this seems to be related to differences in the interpretation of Markdown syntax between CRAN/pkgdown/knitr and GitHub.

For initializing this, `usethis::use_readme_rmd()` was run once. This also added a Git hook to prevent the `.Rmd` being ahead of the `.md`. However, since that Git hook is a *local* file (`.git/hooks/pre-commit`), contributors are advised to add that Git hook as well (at least if they want to modify the `README`). This can be done by running
```r
usethis::use_git_hook(hook = "pre-commit", script = usethis:::render_template("readme-rmd-pre-commit.sh"))
```
Alternatively, to avoid the internal **usethis** function `usethis:::render_template()`, this can be done by
1. Ensuring that `README.Rmd` has no unstaged changes (for extra safety, I would recommend creating a backup copy of `README.Rmd`),
2. Running `usethis::use_readme_rmd()`, thereby overwriting `README.Rmd`,
3. Reverting `README.Rmd` to the state from enumeration point 1.
