### PR TITLE
Fix offset bug when aggregating within a cluster

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 ## Bug fixes
 
-* Fix a bug for offsets in cases where `family` (see `init_refmodel()`) has a non-identity link function: After clustering the reference model's posterior draws, we need to aggregate the fitted values which already take the offsets into account instead of taking the offsets into account after aggregating the fitted values which do *not* take the offsets into account. (GitHub: **TODO** (insert PR number))
+* Fix a bug for offsets in cases where `family` (see `init_refmodel()`) has a non-identity link function: After clustering the reference model's posterior draws, we need to aggregate (within a given cluster) the reference model's fitted values which already take the offsets into account instead of taking the offsets into account after aggregating the fitted values which do *not* take the offsets into account. This fix should affect results only in a very slight manner. Due to **projpred**'s internal adjustment for numerical stability when averaging a quantity across the draws within a given cluster, this also changes the projected residual standard deviations in Gaussian models in the order of `1e-10`. (GitHub: #374)
 
 # projpred 2.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Introduction of the augmented-data projection [(Weber and Vehtari, 2023)](https://doi.org/10.48550/arXiv.2301.01660) (see section ["Supported types of models"](https://mc-stan.org/projpred/articles/projpred.html#modtypes) of the main vignette for details). (GitHub: #70, #322)
 * Introduction of the latent projection [(Catalina et al., 2021)](https://doi.org/10.48550/arXiv.2109.04702) (see section ["Supported types of models"](https://mc-stan.org/projpred/articles/projpred.html#modtypes) of the main vignette and the new [latent-projection vignette](https://mc-stan.org/projpred/articles/latent.html) for details). (GitHub: #372)
 
+## Bug fixes
+
+* Fix a bug for offsets in cases where `family` (see `init_refmodel()`) has a non-identity link function: After clustering the reference model's posterior draws, we need to aggregate the fitted values which already take the offsets into account instead of taking the offsets into account after aggregating the fitted values which do *not* take the offsets into account. (GitHub: **TODO** (insert PR number))
+
 # projpred 2.3.0
 
 ## Major changes

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -599,11 +599,11 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       ## reweight the clusters/samples according to the psis-loo weights
       p_sel <- .get_p_clust(
         family = refmodel$family, eta = eta, mu = mu, mu_offs = mu_offs,
-        dis = dis, wsample = exp(lw[, i]), cl = cl_sel, offs = refmodel$offset
+        dis = dis, wsample = exp(lw[, i]), cl = cl_sel
       )
       p_pred <- .get_p_clust(
         family = refmodel$family, eta = eta, mu = mu, mu_offs = mu_offs,
-        dis = dis, wsample = exp(lw[, i]), cl = cl_pred, offs = refmodel$offset
+        dis = dis, wsample = exp(lw[, i]), cl = cl_pred
       )
 
       ## perform selection with the reweighted clusters/samples


### PR DESCRIPTION
This fixes a bug occurring when aggregating offset-dependent quantities within a cluster (see the newly added `NEWS.md` entry for details).