### PR TITLE
Argument for including/excluding offsets in `ref_predfun()`

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -292,13 +292,9 @@ proj_linpred_aux <- function(proj, newdata, offset, weights, transform = FALSE,
         newdata_lat <- proj$refmodel$fetch_data()
         newdata_lat$projpred_internal_offs_stanreg <- offset
       }
-      # Use `ref_predfun_usr` here (instead of `ref_predfun`) to include
-      # offsets:
-      refprd_with_offs <- get("ref_predfun_usr",
-                              envir = environment(proj$refmodel$ref_predfun))
-      ynew <- rowMeans(unname(
-        refprd_with_offs(fit = proj$refmodel$fit, newdata = newdata_lat)
-      ))
+      ynew <- rowMeans(proj$refmodel$ref_predfun(fit = proj$refmodel$fit,
+                                                 newdata = newdata_lat,
+                                                 excl_offs = FALSE))
     } else {
       ynew <- eval_lhs(formula = proj$refmodel$formula, data = newdata)
     }

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -327,17 +327,10 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
                "`d_test$data`, but that column already exists. Please rename ",
                "this column in `d_test$data` and try again.")
         }
-        # Note: Here, the specific values assigned to
-        # `newdata_for_ref$projpred_internal_offs_stanreg` don't matter as they
-        # are subtracted later within ref_predfun() anyway.
         newdata_for_ref$projpred_internal_offs_stanreg <- d_test$offset
       }
-      eta_test <- refmodel$ref_predfun(refmodel$fit, newdata = newdata_for_ref)
-      if (refmodel$family$family %in% fams_neg_linpred()) {
-        eta_test <- eta_test - d_test$offset
-      } else {
-        eta_test <- eta_test + d_test$offset
-      }
+      eta_test <- refmodel$ref_predfun(refmodel$fit, newdata = newdata_for_ref,
+                                       excl_offs = FALSE)
       mu_test <- refmodel$family$linkinv(eta_test)
     }
     ref <- .weighted_summary_means(


### PR DESCRIPTION
This adds an argument for including or excluding offsets in a `refmodel`'s `ref_predfun()`, which allowed to simplify code at multiple places.