### PR TITLE
Fix bug where trying to ensure finite `log()` values

### DIFF
--- a/R/latent.R
+++ b/R/latent.R
@@ -27,8 +27,9 @@ latent_ll_oscale_binom_nocats <- function(ilpreds, y_oscale,
                                           wobs = rep(1, length(y_oscale)),
                                           cl_ref,
                                           wdraws_ref = rep(1, length(cl_ref))) {
-  # Assign some nonzero value to have a finite log() value:
-  ilpreds[ilpreds %in% c(0, 1)] <- .Machine$double.eps
+  # Ensure finite log() values:
+  ilpreds[ilpreds %in% c(0)] <- .Machine$double.eps
+  ilpreds[ilpreds %in% c(1)] <- 1 - .Machine$double.eps
 
   ilpreds <- t(ilpreds)
   ll_unw <- y_oscale * log(ilpreds) + (1 - y_oscale) * log(1 - ilpreds)


### PR DESCRIPTION
This fixes a bug in the internal function `latent_ll_oscale_binom_nocats()` added by the latent projection. Since the latent projection has just been merged into `master`, a `NEWS.md` entry for this fix is not added.