### PR TITLE
Set mclogit method to PQL

### DIFF
--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -847,7 +847,8 @@ fit_categ_mlvl <- function(formula, projpred_formula_no_random,
            weights = weights,
            model = FALSE,
            x = FALSE,
-           y = FALSE),
+           y = FALSE,
+           method = "PQL"),
       dot_args
     ))
   })


### PR DESCRIPTION
This sets the mclogit method to PQL explicitly (PQL is the default, but see the commit message for details for why adding this explicitly is more desirable).