### PR TITLE
Options to integrate out group-level effects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 * Introduction of the augmented-data projection [(Weber and Vehtari, 2023)](https://doi.org/10.48550/arXiv.2301.01660) (see section ["Supported types of models"](https://mc-stan.org/projpred/articles/projpred.html#modtypes) of the main vignette for details). (GitHub: #70, #322)
 * Introduction of the latent projection [(Catalina et al., 2021)](https://doi.org/10.48550/arXiv.2109.04702) (see section ["Supported types of models"](https://mc-stan.org/projpred/articles/projpred.html#modtypes) of the main vignette and the new [latent-projection vignette](https://mc-stan.org/projpred/articles/latent.html) for details). (GitHub: #372)
-* When predicting from a multilevel model (both, from a multilevel reference model or from a multilevel submodel), group-level effects are now "integrated out" by considering all group levels (even those that already exist in the original dataset) as *new* group levels and by drawing group-level effects for all these "new" group levels randomly. (GitHub: **TODO** (insert PR number))
+* When predicting from a multilevel model (both, from a multilevel reference model or from a multilevel submodel), group-level effects are now "integrated out" by considering all group levels (even those that already exist in the original dataset) as *new* group levels and by drawing group-level effects for all these "new" group levels randomly. Accordingly, `as.matrix.projection()` does not return the group-level effects anymore (the hierarchical variance components are still returned, though). (GitHub: **TODO** (insert PR number))
 
 ## Minor changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 * Introduction of the augmented-data projection [(Weber and Vehtari, 2023)](https://doi.org/10.48550/arXiv.2301.01660) (see section ["Supported types of models"](https://mc-stan.org/projpred/articles/projpred.html#modtypes) of the main vignette for details). (GitHub: #70, #322)
 * Introduction of the latent projection [(Catalina et al., 2021)](https://doi.org/10.48550/arXiv.2109.04702) (see section ["Supported types of models"](https://mc-stan.org/projpred/articles/projpred.html#modtypes) of the main vignette and the new [latent-projection vignette](https://mc-stan.org/projpred/articles/latent.html) for details). (GitHub: #372)
-* In case of multilevel models, **projpred** now has two global options that may be relevant for users: `projpred.mlvl_prd_new` and `projpred.mlvl_prj_ref_new`. These are explained in detail in the general package documentation (available [online](https://mc-stan.org/projpred/reference/projpred-package.html) or by typing `` ?`projpred-package` ``). (GitHub: #379)
+* In case of multilevel models, **projpred** now has two global options that may be relevant for users: `projpred.mlvl_pred_new` and `projpred.mlvl_proj_ref_new`. These are explained in detail in the general package documentation (available [online](https://mc-stan.org/projpred/reference/projpred-package.html) or by typing `` ?`projpred-package` ``). (GitHub: #379)
 
 ## Minor changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 * Introduction of the augmented-data projection [(Weber and Vehtari, 2023)](https://doi.org/10.48550/arXiv.2301.01660) (see section ["Supported types of models"](https://mc-stan.org/projpred/articles/projpred.html#modtypes) of the main vignette for details). (GitHub: #70, #322)
 * Introduction of the latent projection [(Catalina et al., 2021)](https://doi.org/10.48550/arXiv.2109.04702) (see section ["Supported types of models"](https://mc-stan.org/projpred/articles/projpred.html#modtypes) of the main vignette and the new [latent-projection vignette](https://mc-stan.org/projpred/articles/latent.html) for details). (GitHub: #372)
-* When predicting from a multilevel model (both, from a multilevel reference model or from a multilevel submodel), group-level effects are now "integrated out" by considering all group levels (even those that already exist in the original dataset) as *new* group levels and by drawing group-level effects for all these "new" group levels randomly. Accordingly, `as.matrix.projection()` does not return the group-level effects anymore (the hierarchical variance components are still returned, though). (GitHub: **TODO** (insert PR number))
+* In case of multilevel models, **projpred** now has two global options that may be relevant for users: `projpred.mlvl_prd_new` and `projpred.mlvl_prj_ref_new`. These are explained in detail in the general package documentation (available [online](https://mc-stan.org/projpred/reference/projpred-package.html) or by typing `` ?`projpred-package` ``). (GitHub: #379)
 
 ## Minor changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 * Introduction of the augmented-data projection [(Weber and Vehtari, 2023)](https://doi.org/10.48550/arXiv.2301.01660) (see section ["Supported types of models"](https://mc-stan.org/projpred/articles/projpred.html#modtypes) of the main vignette for details). (GitHub: #70, #322)
 * Introduction of the latent projection [(Catalina et al., 2021)](https://doi.org/10.48550/arXiv.2109.04702) (see section ["Supported types of models"](https://mc-stan.org/projpred/articles/projpred.html#modtypes) of the main vignette and the new [latent-projection vignette](https://mc-stan.org/projpred/articles/latent.html) for details). (GitHub: #372)
+* When predicting from a multilevel model (both, from a multilevel reference model or from a multilevel submodel), group-level effects are now "integrated out" by considering all group levels (even those that already exist in the original dataset) as *new* group levels and by drawing group-level effects for all these "new" group levels randomly. (GitHub: **TODO** (insert PR number))
 
 ## Minor changes
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -369,7 +369,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     y_lat_E <- loo::E_loo(
       t(refmodel$ref_predfun(
         refmodel$fit, excl_offs = FALSE,
-        mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
+        mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)
       )),
       psis_object = psisloo,
       log_ratios = -loglik_forPSIS
@@ -677,7 +677,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     return(summ_k)
   })
   if (formula_contains_group_terms(refmodel$formula) &&
-      getOption("projpred.mlvl_prd_new", FALSE)) {
+      getOption("projpred.mlvl_pred_new", FALSE)) {
     # Need to use `mlvl_allrandom = TRUE` (`mu_offs` is based on
     # `mlvl_allrandom = FALSE`):
     eta_offs_mlvlRan <- refmodel$ref_predfun(refmodel$fit, excl_offs = FALSE)
@@ -708,7 +708,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     lppd_ref <- apply(loglik_lat + lw, 2, log_sum_exp)
   } else {
     if (formula_contains_group_terms(refmodel$formula) &&
-        getOption("projpred.mlvl_prd_new", FALSE)) {
+        getOption("projpred.mlvl_pred_new", FALSE)) {
       # Need to use `mlvl_allrandom = TRUE` (`loo_ref_oscale` is based on
       # `mlvl_allrandom = FALSE`):
       loglik_mlvlRan <- t(refmodel$family$ll_fun(
@@ -722,7 +722,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   summ_ref <- list(lppd = lppd_ref, mu = mu_ref)
   if (refmodel$family$for_latent) {
     if (formula_contains_group_terms(refmodel$formula) &&
-        getOption("projpred.mlvl_prd_new", FALSE)) {
+        getOption("projpred.mlvl_pred_new", FALSE)) {
       # Need to use `mlvl_allrandom = TRUE` (`mu_offs_oscale` is based on
       # `mlvl_allrandom = FALSE`):
       mu_offs_mlvlRan_oscale <- refmodel$family$latent_ilink(
@@ -759,7 +759,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
                   fixed = TRUE)
     )
     if (formula_contains_group_terms(refmodel$formula) &&
-        getOption("projpred.mlvl_prd_new", FALSE)) {
+        getOption("projpred.mlvl_pred_new", FALSE)) {
       # Need to use `mlvl_allrandom = TRUE` (`loo_ref_oscale` is based on
       # `mlvl_allrandom = FALSE`):
       loglik_mlvlRan <- refmodel$family$latent_ll_oscale(

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -366,11 +366,14 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     # `colMeans(posterior_linpred())` to the original (full-data) reference
     # model fit, so using `refmodel$y` would induce a dependency between
     # training and test data:
-    y_lat_E <- loo::E_loo(t(refmodel$ref_predfun(refmodel$fit,
-                                                 excl_offs = FALSE,
-                                                 mlvl_allrandom = FALSE)),
-                          psis_object = psisloo,
-                          log_ratios = -loglik_forPSIS)
+    y_lat_E <- loo::E_loo(
+      t(refmodel$ref_predfun(
+        refmodel$fit, excl_offs = FALSE,
+        mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
+      )),
+      psis_object = psisloo,
+      log_ratios = -loglik_forPSIS
+    )
     if (any(y_lat_E$pareto_k > 0.7)) {
       warning("In the recalculation of the latent response values, ",
               sum(y_lat_E$pareto_k > 0.7), " (of ", n, ") Pareto k-value(s) ",
@@ -673,7 +676,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     }
     return(summ_k)
   })
-  if (formula_contains_group_terms(refmodel$formula)) {
+  if (formula_contains_group_terms(refmodel$formula) &&
+      getOption("projpred.mlvl_prd_new", FALSE)) {
     # Need to use `mlvl_allrandom = TRUE` (`mu_offs` is based on
     # `mlvl_allrandom = FALSE`):
     eta_offs_mlvlRan <- refmodel$ref_predfun(refmodel$fit, excl_offs = FALSE)
@@ -703,7 +707,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     ))
     lppd_ref <- apply(loglik_lat + lw, 2, log_sum_exp)
   } else {
-    if (formula_contains_group_terms(refmodel$formula)) {
+    if (formula_contains_group_terms(refmodel$formula) &&
+        getOption("projpred.mlvl_prd_new", FALSE)) {
       # Need to use `mlvl_allrandom = TRUE` (`loo_ref_oscale` is based on
       # `mlvl_allrandom = FALSE`):
       loglik_mlvlRan <- t(refmodel$family$ll_fun(
@@ -716,7 +721,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   }
   summ_ref <- list(lppd = lppd_ref, mu = mu_ref)
   if (refmodel$family$for_latent) {
-    if (formula_contains_group_terms(refmodel$formula)) {
+    if (formula_contains_group_terms(refmodel$formula) &&
+        getOption("projpred.mlvl_prd_new", FALSE)) {
       # Need to use `mlvl_allrandom = TRUE` (`mu_offs_oscale` is based on
       # `mlvl_allrandom = FALSE`):
       mu_offs_mlvlRan_oscale <- refmodel$family$latent_ilink(
@@ -752,7 +758,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       class = sub("augmat", "augvec", oldClass(mu_offs_mlvlRan_oscale),
                   fixed = TRUE)
     )
-    if (formula_contains_group_terms(refmodel$formula)) {
+    if (formula_contains_group_terms(refmodel$formula) &&
+        getOption("projpred.mlvl_prd_new", FALSE)) {
       # Need to use `mlvl_allrandom = TRUE` (`loo_ref_oscale` is based on
       # `mlvl_allrandom = FALSE`):
       loglik_mlvlRan <- refmodel$family$latent_ll_oscale(

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -367,7 +367,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     # model fit, so using `refmodel$y` would induce a dependency between
     # training and test data:
     y_lat_E <- loo::E_loo(t(refmodel$ref_predfun(refmodel$fit,
-                                                 excl_offs = FALSE)),
+                                                 excl_offs = FALSE,
+                                                 mlvl_allrandom = FALSE)),
                           psis_object = psisloo,
                           log_ratios = -loglik_forPSIS)
     if (any(y_lat_E$pareto_k > 0.7)) {

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -679,7 +679,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   if (formula_contains_group_terms(refmodel$formula) &&
       getOption("projpred.mlvl_pred_new", FALSE)) {
     # Need to use `mlvl_allrandom = TRUE` (`mu_offs` is based on
-    # `mlvl_allrandom = FALSE`):
+    # `mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)`):
     eta_offs_mlvlRan <- refmodel$ref_predfun(refmodel$fit, excl_offs = FALSE)
     mu_offs_mlvlRan <- refmodel$family$linkinv(eta_offs_mlvlRan)
   } else {
@@ -710,7 +710,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     if (formula_contains_group_terms(refmodel$formula) &&
         getOption("projpred.mlvl_pred_new", FALSE)) {
       # Need to use `mlvl_allrandom = TRUE` (`loo_ref_oscale` is based on
-      # `mlvl_allrandom = FALSE`):
+      # `mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)`):
       loglik_mlvlRan <- t(refmodel$family$ll_fun(
         mu_offs_mlvlRan, dis, refmodel$y, refmodel$wobs
       ))
@@ -724,7 +724,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     if (formula_contains_group_terms(refmodel$formula) &&
         getOption("projpred.mlvl_pred_new", FALSE)) {
       # Need to use `mlvl_allrandom = TRUE` (`mu_offs_oscale` is based on
-      # `mlvl_allrandom = FALSE`):
+      # `mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)`):
       mu_offs_mlvlRan_oscale <- refmodel$family$latent_ilink(
         t(mu_offs_mlvlRan), cl_ref = seq_along(refmodel$wsample),
         wdraws_ref = refmodel$wsample
@@ -761,7 +761,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     if (formula_contains_group_terms(refmodel$formula) &&
         getOption("projpred.mlvl_pred_new", FALSE)) {
       # Need to use `mlvl_allrandom = TRUE` (`loo_ref_oscale` is based on
-      # `mlvl_allrandom = FALSE`):
+      # `mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)`):
       loglik_mlvlRan <- refmodel$family$latent_ll_oscale(
         mu_offs_mlvlRan_oscale_odim, y_oscale = refmodel$y_oscale,
         wobs = refmodel$wobs, cl_ref = seq_along(refmodel$wsample),

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -1199,7 +1199,7 @@ repair_re.merMod <- function(object, newdata) {
         stop("Could not find column `", vnm, "` in `newdata`.")
       }
     }
-    from_new <- levels(as.factor(newdata[, vnm]))
+    from_new <- unique(newdata[, vnm])
     list(comb = union(from_fit, from_new),
          new = from_new)
   })
@@ -1264,7 +1264,7 @@ repair_re.clmm <- function(object, newdata) {
         stop("Could not find column `", vnm, "` in `newdata`.")
       }
     }
-    from_new <- levels(as.factor(newdata[, vnm]))
+    from_new <- unique(newdata[, vnm])
     list(comb = union(from_fit, from_new),
          new = from_new)
   })
@@ -1363,7 +1363,7 @@ repair_re.mmblogit <- function(object, newdata) {
     if (!vnm %in% names(newdata)) {
       stop("Could not find column `", vnm, "` in `newdata`.")
     }
-    from_new <- levels(as.factor(newdata[, vnm]))
+    from_new <- unique(newdata[, vnm])
     list(comb = union(from_fit, from_new),
          new = from_new)
   })

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -969,7 +969,7 @@ subprd <- function(fits, newdata) {
         ###
       )
     } else if (is_glmm) {
-      if (getOption("projpred.mlvl_prd_new", FALSE)) {
+      if (getOption("projpred.mlvl_pred_new", FALSE)) {
         re_fml_predict <- ~0
       } else {
         re_fml_predict <- NULL
@@ -1174,7 +1174,7 @@ repair_re <- function(object, newdata) {
 
 # For objects of class `merMod`, the following repair_re() method will draw the
 # random effects for new group levels from a (multivariate) Gaussian
-# distribution, but option `projpred.mlvl_prd_new` determines whether existing
+# distribution, but option `projpred.mlvl_pred_new` determines whether existing
 # group levels are also considered as new group levels.
 #
 # License/copyright notice: repair_re.merMod() is inspired by and uses code
@@ -1219,7 +1219,7 @@ repair_re.merMod <- function(object, newdata) {
   })
   # In case of duplicated levels across group variables, later code would have
   # to be adapted:
-  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+  if (getOption("projpred.mlvl_pred_new", FALSE)) {
     el_nm_mer <- "new"
   } else {
     el_nm_mer <- "comb"
@@ -1240,7 +1240,7 @@ repair_re.merMod <- function(object, newdata) {
   VarCorr_tmp <- lme4::VarCorr(object)
   for (vnm in vnms) {
     lvls_new <- lvls_list[[vnm]]$new
-    if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+    if (!getOption("projpred.mlvl_pred_new", FALSE)) {
       lvls_exist <- lvls_list[[vnm]]$exist
       lvls_new <- setdiff(lvls_new, lvls_exist)
       ranefs_prep$b[names(ranefs_prep$b) %in% lvls_exist] <- 0
@@ -1260,7 +1260,7 @@ repair_re.merMod <- function(object, newdata) {
 # For objects of class `clmm`, the following repair_re() method will re-use the
 # estimated random effects for existing group levels and will draw the random
 # effects for new group levels from a (multivariate) Gaussian distribution, but
-# option `projpred.mlvl_prd_new` determines whether existing group levels are
+# option `projpred.mlvl_pred_new` determines whether existing group levels are
 # also considered as new group levels.
 #
 # License/copyright notice: repair_re.clmm() is inspired by and uses code
@@ -1321,7 +1321,7 @@ repair_re.clmm <- function(object, newdata) {
   VarCorr_tmp <- ordinal::VarCorr(object)
   for (vnm in vnms) {
     lvls_new <- lvls_list[[vnm]]$new
-    if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+    if (!getOption("projpred.mlvl_pred_new", FALSE)) {
       lvls_exist <- lvls_list[[vnm]]$exist
       lvls_new <- setdiff(lvls_new, lvls_exist)
     }
@@ -1340,7 +1340,7 @@ repair_re.clmm <- function(object, newdata) {
 # For objects of class `mmblogit`, the following repair_re() method will re-use
 # the estimated random effects for existing group levels and will draw the
 # random effects for new group levels from a (multivariate) Gaussian
-# distribution, but option `projpred.mlvl_prd_new` determines whether existing
+# distribution, but option `projpred.mlvl_pred_new` determines whether existing
 # group levels are also considered as new group levels.
 #
 # License/copyright notice: repair_re.mmblogit() is inspired by and uses code
@@ -1455,7 +1455,7 @@ repair_re.mmblogit <- function(object, newdata) {
   }
   for (vnm in vnms) {
     lvls_new <- lvls_list[[vnm]]$new
-    if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+    if (!getOption("projpred.mlvl_pred_new", FALSE)) {
       lvls_exist <- lvls_list[[vnm]]$exist
       lvls_new <- setdiff(lvls_new, lvls_exist)
     }

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -1200,6 +1200,12 @@ repair_re.merMod <- function(object, newdata) {
       }
     }
     from_new <- unique(newdata[, vnm])
+    if (is.factor(from_new)) {
+      # Strictly speaking, this is not necessary (currently), but include it for
+      # safety reasons, in case downstream code is changed in the future (or in
+      # case the behavior of `factor`s in R is changed in general):
+      from_new <- as.character(from_new)
+    }
     list(comb = union(from_fit, from_new),
          new = from_new)
   })
@@ -1265,6 +1271,12 @@ repair_re.clmm <- function(object, newdata) {
       }
     }
     from_new <- unique(newdata[, vnm])
+    if (is.factor(from_new)) {
+      # Strictly speaking, this is not necessary (currently), but include it for
+      # safety reasons, in case downstream code is changed in the future (or in
+      # case the behavior of `factor`s in R is changed in general):
+      from_new <- as.character(from_new)
+    }
     list(comb = union(from_fit, from_new),
          new = from_new)
   })
@@ -1364,6 +1376,12 @@ repair_re.mmblogit <- function(object, newdata) {
       stop("Could not find column `", vnm, "` in `newdata`.")
     }
     from_new <- unique(newdata[, vnm])
+    if (is.factor(from_new)) {
+      # Strictly speaking, this is not necessary (currently), but include it for
+      # safety reasons, in case downstream code is changed in the future (or in
+      # case the behavior of `factor`s in R is changed in general):
+      from_new <- as.character(from_new)
+    }
     list(comb = union(from_fit, from_new),
          new = from_new)
   })

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -1367,6 +1367,13 @@ repair_re.mmblogit <- function(object, newdata) {
     list(comb = union(from_fit, from_new),
          new = from_new)
   })
+  # In case of duplicated levels across group variables, later code would have
+  # to be adapted:
+  if (length(lvls_list) >= 2 &&
+      !all(utils::combn(lvls_list, 2, empty_intersection_new))) {
+    stop("Currently, projpred requires all variables with group-level effects ",
+         "to have disjoint level sets.")
+  }
   # Create the lme4-type random-effects formula needed by mkNewReTrms_man():
   if (utils::packageVersion("mclogit") < "0.9") {
     re_fml <- update(object$random$formula,

--- a/R/methods.R
+++ b/R/methods.R
@@ -292,10 +292,12 @@ proj_linpred_aux <- function(proj, newdata, offset, weights, transform = FALSE,
         newdata_lat <- proj$refmodel$fetch_data()
         newdata_lat$projpred_internal_offs_stanreg <- offset
       }
-      ynew <- rowMeans(proj$refmodel$ref_predfun(fit = proj$refmodel$fit,
-                                                 newdata = newdata_lat,
-                                                 excl_offs = FALSE,
-                                                 mlvl_allrandom = FALSE))
+      ynew <- rowMeans(proj$refmodel$ref_predfun(
+        fit = proj$refmodel$fit,
+        newdata = newdata_lat,
+        excl_offs = FALSE,
+        mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
+      ))
     } else {
       ynew <- eval_lhs(formula = proj$refmodel$formula, data = newdata)
     }
@@ -1303,6 +1305,66 @@ mknms_VarCorr <- function(nms, nms_lats = NULL, nm_scheme, coef_nms) {
   return(nms)
 }
 
+# Make the parameter names for group-level effects adhere to the naming scheme
+# `nm_scheme`:
+mknms_ranef <- function(nms, nms_lats = NULL, nm_scheme, coef_nms) {
+  if (!is.null(nms_lats)) {
+    stopifnot(nm_scheme == "brms")
+  }
+  if (nm_scheme == "brms") {
+    nms <- mknms_icpt(nms, nm_scheme = nm_scheme)
+  }
+  for (coef_nms_idx in seq_along(coef_nms)) {
+    coef_nms_i <- coef_nms[[coef_nms_idx]]
+    if (nm_scheme == "brms") {
+      coef_nms_i <- mknms_icpt(coef_nms_i, nm_scheme = nm_scheme)
+    }
+    # Escape special characters in the coefficient names and collapse them with
+    # "|":
+    coef_nms_i_esc <- paste(gsub("\\)", "\\\\)",
+                                 gsub("\\(", "\\\\(",
+                                      gsub("\\.", "\\\\.", coef_nms_i))),
+                            collapse = "|")
+    if (nm_scheme == "brms") {
+      # Put the part following the group name in square brackets, reorder its
+      # two subparts (coefficient name and group level), and separate them by
+      # comma:
+      nms <- sub(paste0("\\.(", coef_nms_i_esc, ")\\.(.*)$"),
+                 "[\\2,\\1]",
+                 nms)
+    } else if (nm_scheme == "rstanarm") {
+      grp_nm_i <- names(coef_nms)[coef_nms_idx]
+      # Escape special characters in the group name:
+      grp_nm_i_esc <- gsub("\\)", "\\\\)",
+                           gsub("\\(", "\\\\(",
+                                gsub("\\.", "\\\\.", grp_nm_i)))
+      # Re-arrange as required:
+      nms <- sub(paste0("^(", grp_nm_i_esc, ")\\.(", coef_nms_i_esc, ")\\."),
+                 "\\2 \\1:",
+                 nms)
+    }
+  }
+  if (nm_scheme == "brms") {
+    nms <- paste0("r_", nms)
+  } else if (nm_scheme == "rstanarm") {
+    nms <- paste0("b[", nms, "]")
+  }
+  if (!is.null(nms_lats)) {
+    # Escape special characters in the latent category names and collapse them
+    # with "|":
+    nms_lats_esc <- paste(gsub("\\)", "\\\\)",
+                               gsub("\\(", "\\\\(",
+                                    gsub("\\.", "\\\\.", nms_lats))),
+                          collapse = "|")
+    # Put the string `mu` in front of the latent category names, remove the
+    # following tilde, and place all this in front of the first square bracket:
+    nms <- gsub(paste0("\\[(.*),(", nms_lats_esc, ")~"),
+                "__mu\\2[\\1,",
+                nms)
+  }
+  return(nms)
+}
+
 # Make the parameter names for the thresholds of an ordinal model adhere to the
 # naming scheme `nm_scheme`:
 mknms_thres <- function(nms, nm_scheme) {
@@ -1378,6 +1440,46 @@ proc_VarCorr <- function(group_vc_raw, nms_lats = NULL, ...) {
   return(group_vc)
 }
 
+# To process the raw group-level effects themselves (from a submodel fit):
+proc_ranef <- function(group_ef_raw, nms_lats = NULL, ncoefs, grps_lvls, VarCov,
+                       ...) {
+  if (!is.null(nms_lats)) {
+    coef_nms <- list(...)$coef_nms
+    stopifnot(!is.null(coef_nms))
+    nlats <- length(nms_lats)
+    group_ef_raw <- lapply(setNames(nm = names(group_ef_raw)), function(vnm) {
+      ranef_tmp <- group_ef_raw[[vnm]]
+      if (utils::packageVersion("mclogit") < "0.9") {
+        ncoefs_vnm <- ncoefs
+      } else {
+        ncoefs_vnm <- ncoefs[vnm]
+      }
+      # Coerce the random effects into the same format as the output of ranef()
+      # from packages 'lme4' and 'ordinal':
+      ranef_tmp <- matrix(ranef_tmp,
+                          nrow = nlats * ncoefs_vnm,
+                          ncol = length(grps_lvls[[vnm]]),
+                          dimnames = list(coef_nms[[vnm]],
+                                          grps_lvls[[vnm]]))
+      return(as.data.frame(t(ranef_tmp)))
+    })
+  }
+  group_ef <- unlist(lapply(group_ef_raw, function(ranef_df) {
+    ranef_mat <- as.matrix(ranef_df)
+    setNames(
+      as.vector(ranef_mat),
+      apply(expand.grid(rownames(ranef_mat),
+                        colnames(ranef_mat)),
+            1,
+            function(row_col_nm) {
+              paste(rev(row_col_nm), collapse = ".")
+            })
+    )
+  }))
+  names(group_ef) <- mknms_ranef(names(group_ef), nms_lats = nms_lats, ...)
+  return(group_ef)
+}
+
 # An (internal) generic for extracting the coefficients and any other parameter
 # estimates from a submodel fit.
 get_subparams <- function(x, ...) {
@@ -1422,7 +1524,15 @@ get_subparams.lmerMod <- function(x, ...) {
   group_vc <- proc_VarCorr(group_vc_raw,
                            coef_nms = lapply(group_vc_raw, rownames), ...)
 
-  return(c(population_effects, group_vc))
+  subparams <- c(population_effects, group_vc)
+
+  if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+    group_ef <- proc_ranef(lme4::ranef(x, condVar = FALSE),
+                           coef_nms = lapply(group_vc_raw, rownames), ...)
+    subparams <- c(subparams, group_ef)
+  }
+
+  return(subparams)
 }
 
 #' @noRd
@@ -1455,7 +1565,15 @@ get_subparams.clmm <- function(x, ...) {
   group_vc <- proc_VarCorr(group_vc_raw,
                            coef_nms = lapply(group_vc_raw, rownames), ...)
 
-  return(c(thres, replace_population_names(x$beta, ...), group_vc))
+  subparams <- c(thres, replace_population_names(x$beta, ...), group_vc)
+
+  if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+    group_ef <- proc_ranef(ordinal::ranef(x),
+                           coef_nms = lapply(group_vc_raw, rownames), ...)
+    subparams <- c(subparams, group_ef)
+  }
+
+  return(subparams)
 }
 
 #' @noRd
@@ -1487,19 +1605,29 @@ get_subparams.mmblogit <- function(x, ...) {
   group_vc <- proc_VarCorr(group_vc_raw, nms_lats = colnames(x$D),
                            coef_nms = lapply(group_vc_raw, rownames), ...)
 
-  if (utils::packageVersion("mclogit") < "0.9") {
-    ncoefs_all <- length(all.vars(x$random$formula)) + 1L
-  } else {
-    ncoefs_all <- sapply(
-      setNames(x$random, names(x$groups)),
-      function(re_info_i) {
-        length(all.vars(re_info_i$formula)) + 1L
-      }
-    )
+  nms <- mknms_categ(dimnames(coefs), ...)
+  subparams <- c(setNames(as.vector(coefs), nms), group_vc)
+
+  if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+    if (utils::packageVersion("mclogit") < "0.9") {
+      ncoefs_all <- length(all.vars(x$random$formula)) + 1L
+    } else {
+      ncoefs_all <- sapply(
+        setNames(x$random, names(x$groups)),
+        function(re_info_i) {
+          length(all.vars(re_info_i$formula)) + 1L
+        }
+      )
+    }
+    group_ef <- proc_ranef(setNames(x$random.effects, names(x$groups)),
+                           nms_lats = colnames(x$D),
+                           ncoefs = ncoefs_all,
+                           grps_lvls = lapply(x$groups, levels),
+                           coef_nms = lapply(group_vc_raw, rownames), ...)
+    subparams <- c(subparams, group_ef)
   }
 
-  nms <- mknms_categ(dimnames(coefs), ...)
-  return(c(setNames(as.vector(coefs), nms), group_vc))
+  return(subparams)
 }
 
 #' Extract projected parameter draws

--- a/R/methods.R
+++ b/R/methods.R
@@ -46,7 +46,7 @@
 #'   multilevel submodel (however, not yet in case of a GAMM) and for drawing
 #'   from the predictive distributions of the submodel(s) in case of
 #'   [proj_predict()]. If a clustered projection was performed, then in
-#'   [proj_predict()], `.seed` is also used for drawing from the set of the
+#'   [proj_predict()], `.seed` is also used for drawing from the set of
 #'   projected clusters of posterior draws (see argument `nresample_clusters`).
 #' @param resp_oscale Only relevant for the latent projection. A single logical
 #'   value indicating whether to draw from the posterior-projection predictive

--- a/R/methods.R
+++ b/R/methods.R
@@ -294,7 +294,8 @@ proj_linpred_aux <- function(proj, newdata, offset, weights, transform = FALSE,
       }
       ynew <- rowMeans(proj$refmodel$ref_predfun(fit = proj$refmodel$fit,
                                                  newdata = newdata_lat,
-                                                 excl_offs = FALSE))
+                                                 excl_offs = FALSE,
+                                                 mlvl_allrandom = FALSE))
     } else {
       ynew <- eval_lhs(formula = proj$refmodel$formula, data = newdata)
     }

--- a/R/methods.R
+++ b/R/methods.R
@@ -296,7 +296,7 @@ proj_linpred_aux <- function(proj, newdata, offset, weights, transform = FALSE,
         fit = proj$refmodel$fit,
         newdata = newdata_lat,
         excl_offs = FALSE,
-        mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
+        mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)
       ))
     } else {
       ynew <- eval_lhs(formula = proj$refmodel$formula, data = newdata)
@@ -1526,7 +1526,7 @@ get_subparams.lmerMod <- function(x, ...) {
 
   subparams <- c(population_effects, group_vc)
 
-  if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+  if (!getOption("projpred.mlvl_pred_new", FALSE)) {
     group_ef <- proc_ranef(lme4::ranef(x, condVar = FALSE),
                            coef_nms = lapply(group_vc_raw, rownames), ...)
     subparams <- c(subparams, group_ef)
@@ -1567,7 +1567,7 @@ get_subparams.clmm <- function(x, ...) {
 
   subparams <- c(thres, replace_population_names(x$beta, ...), group_vc)
 
-  if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+  if (!getOption("projpred.mlvl_pred_new", FALSE)) {
     group_ef <- proc_ranef(ordinal::ranef(x),
                            coef_nms = lapply(group_vc_raw, rownames), ...)
     subparams <- c(subparams, group_ef)
@@ -1608,7 +1608,7 @@ get_subparams.mmblogit <- function(x, ...) {
   nms <- mknms_categ(dimnames(coefs), ...)
   subparams <- c(setNames(as.vector(coefs), nms), group_vc)
 
-  if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+  if (!getOption("projpred.mlvl_pred_new", FALSE)) {
     if (utils::packageVersion("mclogit") < "0.9") {
       ncoefs_all <- length(all.vars(x$random$formula)) + 1L
     } else {

--- a/R/project.R
+++ b/R/project.R
@@ -41,7 +41,7 @@
 #'   this seed is used for clustering the reference model's posterior draws (if
 #'   `!is.null(nclusters)`) and for drawing new group-level effects when
 #'   predicting from a multilevel submodel (however, not yet in case of a GAMM)
-#'   and having global option `projpred.mlvl_prd_new` set to `TRUE`. (Such a
+#'   and having global option `projpred.mlvl_pred_new` set to `TRUE`. (Such a
 #'   prediction takes place when calculating output elements `dis` and `ce`.)
 #' @inheritParams varsel
 #' @param ... Arguments passed to [get_refmodel()] (if [get_refmodel()] is

--- a/R/project.R
+++ b/R/project.R
@@ -39,7 +39,10 @@
 #'   results can be obtained again if needed. Passed to argument `seed` of
 #'   [set.seed()], but can also be `NA` to not call [set.seed()] at all. Here,
 #'   this seed is used for clustering the reference model's posterior draws (if
-#'   `!is.null(nclusters)`).
+#'   `!is.null(nclusters)`) and for drawing new group-level effects when
+#'   predicting from a multilevel submodel (however, not yet in case of a GAMM).
+#'   (Such a prediction takes place when calculating output elements `dis` and
+#'   `ce`.)
 #' @inheritParams varsel
 #' @param ... Arguments passed to [get_refmodel()] (if [get_refmodel()] is
 #'   actually used; see argument `object`) as well as to the divergence

--- a/R/project.R
+++ b/R/project.R
@@ -40,9 +40,9 @@
 #'   [set.seed()], but can also be `NA` to not call [set.seed()] at all. Here,
 #'   this seed is used for clustering the reference model's posterior draws (if
 #'   `!is.null(nclusters)`) and for drawing new group-level effects when
-#'   predicting from a multilevel submodel (however, not yet in case of a GAMM).
-#'   (Such a prediction takes place when calculating output elements `dis` and
-#'   `ce`.)
+#'   predicting from a multilevel submodel (however, not yet in case of a GAMM)
+#'   and having global option `projpred.mlvl_prd_new` set to `TRUE`. (Such a
+#'   prediction takes place when calculating output elements `dis` and `ce`.)
 #' @inheritParams varsel
 #' @param ... Arguments passed to [get_refmodel()] (if [get_refmodel()] is
 #'   actually used; see argument `object`) as well as to the divergence

--- a/R/projpred-package.R
+++ b/R/projpred-package.R
@@ -76,6 +76,32 @@
 #' in turn may crash the R session. Thus, we currently cannot recommend the
 #' parallelization for models other than GLMs.
 #'
+#' For multilevel models, \pkg{projpred} offers two global options that may be
+#' revelant for users: `projpred.mlvl_prd_new` and `projpred.mlvl_prj_ref_new`.
+#' When setting `projpred.mlvl_prd_new` to `TRUE` (default is `FALSE`), then at
+#' prediction time, \pkg{projpred} will treat group levels existing in the
+#' training data as *new* group levels, implying that their group-level effects
+#' are drawn randomly from a (multivariate) Gaussian distribution. This concerns
+#' both, the reference model and the (i.e., any) submodel. Furthermore, setting
+#' `projpred.mlvl_prd_new` to `TRUE` causes `as.matrix.projection()` to omit the
+#' projected group-level effects (for the group levels from the original
+#' dataset). When setting `projpred.mlvl_prj_ref_new` to `TRUE` (default is
+#' `FALSE`), then at projection time, the reference model's fitted values (that
+#' the submodels fit to) will be computed by treating the group levels from the
+#' original dataset as *new* group levels, implying that their group-level
+#' effects will be drawn randomly from a (multivariate) Gaussian distribution
+#' (as long as the reference model is a multilevel model, which---for custom
+#' reference models---does not need to be the case). This also affects the
+#' latent response values for a latent projection correspondingly. Setting
+#' `projpred.mlvl_prd_new` to `TRUE` makes sense, e.g., when the prediction task
+#' is such that any group level will be treated as a new one. Typically, setting
+#' `projpred.mlvl_prj_ref_new` to `TRUE` only makes sense when
+#' `projpred.mlvl_prd_new` is already set to `TRUE`. In that case, the default
+#' of `FALSE` for `projpred.mlvl_prj_ref_new` ensures that at projection time,
+#' the submodels fit to the best possible fitted values from the reference
+#' model, and setting `projpred.mlvl_prj_ref_new` to `TRUE` would make sense if
+#' the group-level effects should be integrated out completely.
+#'
 #' @details
 #'
 #' # Functions

--- a/R/projpred-package.R
+++ b/R/projpred-package.R
@@ -77,15 +77,16 @@
 #' parallelization for models other than GLMs.
 #'
 #' For multilevel models, \pkg{projpred} offers two global options that may be
-#' revelant for users: `projpred.mlvl_prd_new` and `projpred.mlvl_prj_ref_new`.
-#' When setting `projpred.mlvl_prd_new` to `TRUE` (default is `FALSE`), then at
+#' revelant for users: `projpred.mlvl_pred_new` and
+#' `projpred.mlvl_proj_ref_new`. When setting `projpred.mlvl_pred_new` to `TRUE`
+#' (default is `FALSE`), then at
 #' *prediction* time, \pkg{projpred} will treat group levels existing in the
 #' training data as *new* group levels, implying that their group-level effects
 #' are drawn randomly from a (multivariate) Gaussian distribution. This concerns
 #' both, the reference model and the (i.e., any) submodel. Furthermore, setting
-#' `projpred.mlvl_prd_new` to `TRUE` causes `as.matrix.projection()` to omit the
-#' projected group-level effects (for the group levels from the original
-#' dataset). When setting `projpred.mlvl_prj_ref_new` to `TRUE` (default is
+#' `projpred.mlvl_pred_new` to `TRUE` causes `as.matrix.projection()` to omit
+#' the projected group-level effects (for the group levels from the original
+#' dataset). When setting `projpred.mlvl_proj_ref_new` to `TRUE` (default is
 #' `FALSE`), then at *projection* time, the reference model's fitted values
 #' (that the submodels fit to) will be computed by treating the group levels
 #' from the original dataset as *new* group levels, implying that their
@@ -93,13 +94,13 @@
 #' distribution (as long as the reference model is a multilevel model,
 #' which---for custom reference models---does not need to be the case). This
 #' also affects the latent response values for a latent projection
-#' correspondingly. Setting `projpred.mlvl_prd_new` to `TRUE` makes sense, e.g.,
-#' when the prediction task is such that any group level will be treated as a
-#' new one. Typically, setting `projpred.mlvl_prj_ref_new` to `TRUE` only makes
-#' sense when `projpred.mlvl_prd_new` is already set to `TRUE`. In that case,
-#' the default of `FALSE` for `projpred.mlvl_prj_ref_new` ensures that at
+#' correspondingly. Setting `projpred.mlvl_pred_new` to `TRUE` makes sense,
+#' e.g., when the prediction task is such that any group level will be treated
+#' as a new one. Typically, setting `projpred.mlvl_proj_ref_new` to `TRUE` only
+#' makes sense when `projpred.mlvl_pred_new` is already set to `TRUE`. In that
+#' case, the default of `FALSE` for `projpred.mlvl_proj_ref_new` ensures that at
 #' projection time, the submodels fit to the best possible fitted values from
-#' the reference model, and setting `projpred.mlvl_prj_ref_new` to `TRUE` would
+#' the reference model, and setting `projpred.mlvl_proj_ref_new` to `TRUE` would
 #' make sense if the group-level effects should be integrated out completely.
 #'
 #' @details

--- a/R/projpred-package.R
+++ b/R/projpred-package.R
@@ -79,28 +79,28 @@
 #' For multilevel models, \pkg{projpred} offers two global options that may be
 #' revelant for users: `projpred.mlvl_prd_new` and `projpred.mlvl_prj_ref_new`.
 #' When setting `projpred.mlvl_prd_new` to `TRUE` (default is `FALSE`), then at
-#' prediction time, \pkg{projpred} will treat group levels existing in the
+#' *prediction* time, \pkg{projpred} will treat group levels existing in the
 #' training data as *new* group levels, implying that their group-level effects
 #' are drawn randomly from a (multivariate) Gaussian distribution. This concerns
 #' both, the reference model and the (i.e., any) submodel. Furthermore, setting
 #' `projpred.mlvl_prd_new` to `TRUE` causes `as.matrix.projection()` to omit the
 #' projected group-level effects (for the group levels from the original
 #' dataset). When setting `projpred.mlvl_prj_ref_new` to `TRUE` (default is
-#' `FALSE`), then at projection time, the reference model's fitted values (that
-#' the submodels fit to) will be computed by treating the group levels from the
-#' original dataset as *new* group levels, implying that their group-level
-#' effects will be drawn randomly from a (multivariate) Gaussian distribution
-#' (as long as the reference model is a multilevel model, which---for custom
-#' reference models---does not need to be the case). This also affects the
-#' latent response values for a latent projection correspondingly. Setting
-#' `projpred.mlvl_prd_new` to `TRUE` makes sense, e.g., when the prediction task
-#' is such that any group level will be treated as a new one. Typically, setting
-#' `projpred.mlvl_prj_ref_new` to `TRUE` only makes sense when
-#' `projpred.mlvl_prd_new` is already set to `TRUE`. In that case, the default
-#' of `FALSE` for `projpred.mlvl_prj_ref_new` ensures that at projection time,
-#' the submodels fit to the best possible fitted values from the reference
-#' model, and setting `projpred.mlvl_prj_ref_new` to `TRUE` would make sense if
-#' the group-level effects should be integrated out completely.
+#' `FALSE`), then at *projection* time, the reference model's fitted values
+#' (that the submodels fit to) will be computed by treating the group levels
+#' from the original dataset as *new* group levels, implying that their
+#' group-level effects will be drawn randomly from a (multivariate) Gaussian
+#' distribution (as long as the reference model is a multilevel model,
+#' which---for custom reference models---does not need to be the case). This
+#' also affects the latent response values for a latent projection
+#' correspondingly. Setting `projpred.mlvl_prd_new` to `TRUE` makes sense, e.g.,
+#' when the prediction task is such that any group level will be treated as a
+#' new one. Typically, setting `projpred.mlvl_prj_ref_new` to `TRUE` only makes
+#' sense when `projpred.mlvl_prd_new` is already set to `TRUE`. In that case,
+#' the default of `FALSE` for `projpred.mlvl_prj_ref_new` ensures that at
+#' projection time, the submodels fit to the best possible fitted values from
+#' the reference model, and setting `projpred.mlvl_prj_ref_new` to `TRUE` would
+#' make sense if the group-level effects should be integrated out completely.
 #'
 #' @details
 #'

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1075,7 +1075,11 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
           ex_lvl <- newdata[[vnm]] %in% lvls_list[[vnm]]$exist
           if (is.numeric(newdata[[vnm]])) {
             stopifnot(is.numeric(data[[vnm]]))
-            newdata[[vnm]][ex_lvl] <- max(lvls_list[[vnm]]$comb) +
+            if (!all(lvls_list[[vnm]]$exist >= 0)) {
+              stop("In case of a numeric group variable, projpred requires ",
+                   "this to have values >= 0.")
+            }
+            newdata[[vnm]][ex_lvl] <- max(lvls_list[[vnm]]$comb) + 1L +
               newdata[[vnm]][ex_lvl]
           } else if (is.character(newdata[[vnm]]) ||
                      is.factor(newdata[[vnm]])) {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -379,7 +379,7 @@ NULL
 #'
 #'   In case of a multilevel reference model, group-level effects for new group
 #'   levels are drawn randomly from a (multivariate) Gaussian distribution. When
-#'   setting `projpred.mlvl_prd_new` to `TRUE`, all group levels from `newdata`
+#'   setting `projpred.mlvl_pred_new` to `TRUE`, all group levels from `newdata`
 #'   (even those that already exist in the original dataset) are treated as new
 #'   group levels (if `is.null(newdata)`, all group levels from the original
 #'   dataset are considered as new group levels in that case).
@@ -571,7 +571,7 @@ predict.refmodel <- function(object, newdata = NULL, ynew = NULL,
             fit = object$fit,
             newdata = newdata_lat,
             excl_offs = FALSE,
-            mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
+            mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)
           ))
         }
       }
@@ -1051,7 +1051,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     # performs some preparations for the augmented-data projection:
     ref_predfun_usr <- ref_predfun
     ref_predfun <- function(fit, newdata = NULL, excl_offs = TRUE,
-                            mlvl_allrandom = getOption("projpred.mlvl_prd_new",
+                            mlvl_allrandom = getOption("projpred.mlvl_pred_new",
                                                        FALSE)) {
       if (length(fml_extractions$group_terms) > 0 && mlvl_allrandom) {
         # Need to replace existing group levels by dummy ones to ensure that we
@@ -1164,7 +1164,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
       warning("Ignoring argument `ref_predfun` because `object` is `NULL`.")
     }
     ref_predfun <- function(fit, newdata = NULL, excl_offs = TRUE,
-                            mlvl_allrandom = getOption("projpred.mlvl_prd_new",
+                            mlvl_allrandom = getOption("projpred.mlvl_pred_new",
                                                        FALSE)) {
       stopifnot(is.null(fit))
       if (is.null(newdata)) {
@@ -1241,7 +1241,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   if (family$for_latent) {
     y <- rowMeans(ref_predfun(
       object, excl_offs = FALSE,
-      mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
+      mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)
     ))
     y_oscale <- model_data$y
     if (is.null(family$cats) &&
@@ -1352,7 +1352,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   # categories (at each observation and each posterior draw).
   if (proper_model) {
     eta <- ref_predfun(
-      object, mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
+      object, mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)
     )
     mu <- family$linkinv(eta)
   } else {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1153,7 +1153,8 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     if (!is.null(ref_predfun)) {
       warning("Ignoring argument `ref_predfun` because `object` is `NULL`.")
     }
-    ref_predfun <- function(fit, newdata = NULL, excl_offs = TRUE) {
+    ref_predfun <- function(fit, newdata = NULL, excl_offs = TRUE,
+                            mlvl_allrandom = TRUE) {
       stopifnot(is.null(fit))
       if (is.null(newdata)) {
         return(matrix(rep(NA_real_, nrow(data))))

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1074,7 +1074,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
         for (vnm in vnms) {
           ex_lvl <- newdata[[vnm]] %in% lvls_list[[vnm]]$exist
           if (is.numeric(newdata[[vnm]])) {
-            newdata[[vnm]][ex_lvl] <- max(c(data[[vnm]], newdata[[vnm]])) +
+            newdata[[vnm]][ex_lvl] <- max(lvls_list[[vnm]]$comb) +
               newdata[[vnm]][ex_lvl]
           } else if (is.character(newdata[[vnm]]) ||
                      is.factor(newdata[[vnm]])) {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1033,9 +1033,9 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     # some ordinal families). This is done here by defining the final
     # ref_predfun() as a wrapper function around the user-supplied (or
     # automatically derived) preliminary ref_predfun(). This wrapper function
-    # also ensures that we draw new group-level effects for *all* group levels
-    # (existing and new ones) and performs some preparations for the
-    # augmented-data projection:
+    # also ensures that in the default case `mlvl_allrandom = TRUE`, we draw new
+    # group-level effects for *all* group levels (existing and new ones) and
+    # performs some preparations for the augmented-data projection:
     ref_predfun_usr <- ref_predfun
     ref_predfun <- function(fit, newdata = NULL, excl_offs = TRUE,
                             mlvl_allrandom = TRUE) {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1083,7 +1083,9 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
               newdata[[vnm]][ex_lvl]
           } else if (is.character(newdata[[vnm]]) ||
                      is.factor(newdata[[vnm]])) {
-            dummy_lvls_ex <- paste0("projpred_DUMMY_", newdata[[vnm]][ex_lvl])
+            timestamp <- gsub("\\.", "", as.character(as.numeric(Sys.time())))
+            dummy_lvls_ex <- paste("projpred_DUMMY", timestamp,
+                                   newdata[[vnm]][ex_lvl], sep = "_")
             if (is.factor(newdata[[vnm]])) {
               orig_lvls <- levels(newdata[[vnm]])
               orig_ord <- is.ordered(newdata[[vnm]])
@@ -1094,9 +1096,9 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
             }
             dummy_lvls <- unique(dummy_lvls_ex)
             if (any(dummy_lvls %in% lvls_list[[vnm]]$comb)) {
-              stop("Need to assign dummy levels to existing group levels, but ",
-                   "encountered a conflict. Please try again or rename the ",
-                   "group levels.")
+              stop("Need to assign dummy levels to existing group levels of ",
+                   "variable `", vnm, "`, but encountered a conflict. Please ",
+                   "try again or rename the group levels.")
             }
             newdata[[vnm]][ex_lvl] <- dummy_lvls_ex
             if (!is.null(orig_lvls) && !is.null(orig_ord)) {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1020,11 +1020,15 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     }
     if (family$for_augdat && family$family == "binomial") {
       ref_predfun_mat <- ref_predfun
-      ref_predfun <- function(fit, newdata = NULL) {
+      # The assignment to a dummy object is just needed to avoid a `NOTE` in `R
+      # CMD check`, namely "init_refmodel: multiple local function definitions
+      # for 'ref_predfun' with different formal arguments":
+      ref_predfun_dummy <- function(fit, newdata = NULL) {
         linpred1 <- ref_predfun_mat(fit = fit, newdata = newdata)
         linpred1 <- t(linpred1)
         return(array(linpred1, dim = c(dim(linpred1), 1L)))
       }
+      ref_predfun <- ref_predfun_dummy
     }
     # Since posterior_linpred() is supposed to include any offsets, but in
     # general (i.e., in the default case `excl_offs = TRUE`, see below),

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1074,6 +1074,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
         for (vnm in vnms) {
           ex_lvl <- newdata[[vnm]] %in% lvls_list[[vnm]]$exist
           if (is.numeric(newdata[[vnm]])) {
+            stopifnot(is.numeric(data[[vnm]]))
             newdata[[vnm]][ex_lvl] <- max(lvls_list[[vnm]]$comb) +
               newdata[[vnm]][ex_lvl]
           } else if (is.character(newdata[[vnm]]) ||

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -377,6 +377,13 @@ NULL
 #'
 #' @details Argument `weightsnew` is only relevant if `!is.null(ynew)`.
 #'
+#'   In case of a multilevel reference model, group-level effects are
+#'   "integrated out" by considering all group levels from `newdata` (even those
+#'   that already exist in the original dataset) as *new* group levels (if
+#'   `is.null(newdata)`, all group levels from the original dataset are
+#'   considered as new group levels) and by drawing group-level effects for all
+#'   these "new" group levels randomly.
+#'
 #' @return In the following, \eqn{N}, \eqn{C_{\mathrm{cat}}}{C_cat}, and
 #'   \eqn{C_{\mathrm{lat}}}{C_lat} from help topic [refmodel-init-get] are used.
 #'   Furthermore, let \eqn{C} denote either \eqn{C_{\mathrm{cat}}}{C_cat} (if

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1056,6 +1056,17 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
           }
           from_fit <- unique(data[, vnm])
           from_new <- unique(newdata[, vnm])
+
+          # Strictly speaking, this is not necessary (currently), but include it
+          # for safety reasons, in case downstream code is changed in the future
+          # (or in case the behavior of `factor`s in R is changed in general):
+          if (is.factor(from_fit)) {
+            from_fit <- as.character(from_fit)
+          }
+          if (is.factor(from_new)) {
+            from_new <- as.character(from_new)
+          }
+
           list(comb = union(from_fit, from_new),
                exist = from_fit,
                new = from_new)

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -562,7 +562,8 @@ predict.refmodel <- function(object, newdata = NULL, ynew = NULL,
           }
           ynew <- rowMeans(object$ref_predfun(fit = object$fit,
                                               newdata = newdata_lat,
-                                              excl_offs = FALSE))
+                                              excl_offs = FALSE,
+                                              mlvl_allrandom = FALSE))
         }
       }
       loglik <- object$family$ll_fun(
@@ -1036,8 +1037,9 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     # (existing and new ones) and performs some preparations for the
     # augmented-data projection:
     ref_predfun_usr <- ref_predfun
-    ref_predfun <- function(fit, newdata = NULL, excl_offs = TRUE) {
-      if (length(fml_extractions$group_terms) > 0) {
+    ref_predfun <- function(fit, newdata = NULL, excl_offs = TRUE,
+                            mlvl_allrandom = TRUE) {
+      if (length(fml_extractions$group_terms) > 0 && mlvl_allrandom) {
         # Need to replace existing group levels by dummy ones to ensure that we
         # draw new group-level effects for *all* group levels (existing and new
         # ones):
@@ -1203,7 +1205,8 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   weights <- model_data$weights
   offset <- model_data$offset
   if (family$for_latent) {
-    y <- rowMeans(ref_predfun(object, excl_offs = FALSE))
+    y <- rowMeans(ref_predfun(object, excl_offs = FALSE,
+                              mlvl_allrandom = FALSE))
     y_oscale <- model_data$y
     if (is.null(family$cats) &&
         (is.factor(y_oscale) || is.character(y_oscale) ||
@@ -1312,7 +1315,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   # augmented-rows matrix containing the probabilities for each of the response
   # categories (at each observation and each posterior draw).
   if (proper_model) {
-    eta <- ref_predfun(object)
+    eta <- ref_predfun(object, mlvl_allrandom = FALSE)
     mu <- family$linkinv(eta)
   } else {
     if (family$family != "binomial") {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1381,13 +1381,16 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   # Miscellaneous -----------------------------------------------------------
 
   ndraws <- ncol(mu)
+  warn_allrandom_dis <- getOption("projpred.warn_allrandom_dis", TRUE)
   if (is.null(dis)) {
     if (family$for_latent && proper_model) {
       if (!is.null(family$link_oscale)) {
         if (family$link_oscale %in% c("probit", "probit_approx")) {
           dis <- rep(1, ndraws)
+          warn_allrandom_dis <- FALSE
         } else if (family$link_oscale %in% c("logit", "logistic")) {
           dis <- rep(1.6, ndraws)
+          warn_allrandom_dis <- FALSE
         } else {
           dis <- rep(NA, ndraws)
         }
@@ -1414,6 +1417,19 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     }
   } else {
     stopifnot(length(dis) == ndraws)
+  }
+  if (getOption("projpred.mlvl_pred_new", FALSE) && warn_allrandom_dis &&
+      !all(is.na(dis))) {
+    warning("Option `projpred.mlvl_pred_new` has been set to `TRUE`, but the ",
+            "reference model includes non-trivial dispersion parameter ",
+            "values. Since option `projpred.mlvl_pred_new` also affects the ",
+            "projected dispersion parameter values, you need to ensure ",
+            "yourself that the reference model's dispersion parameter values ",
+            "are the correct ones in the sense that they should typically ",
+            "result from integrating out group-level effects. In case of the ",
+            "latent projection, a remedy is to switch to response-scale ",
+            "analyses as they do not make use of the latent projected ",
+            "dispersion parameter values.")
   }
 
   # Equal sample (draws) weights by default:

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -317,7 +317,8 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
     }
   } else {
     if (d_test$type == "train") {
-      if (formula_contains_group_terms(refmodel$formula)) {
+      if (formula_contains_group_terms(refmodel$formula) &&
+          getOption("projpred.mlvl_prd_new", FALSE)) {
         # Need to use `mlvl_allrandom = TRUE` (`refmodel$mu_offs` is based on
         # `mlvl_allrandom = FALSE`):
         eta_test <- refmodel$ref_predfun(refmodel$fit, excl_offs = FALSE)

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -318,7 +318,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
   } else {
     if (d_test$type == "train") {
       if (formula_contains_group_terms(refmodel$formula) &&
-          getOption("projpred.mlvl_prd_new", FALSE)) {
+          getOption("projpred.mlvl_pred_new", FALSE)) {
         # Need to use `mlvl_allrandom = TRUE` (`refmodel$mu_offs` is based on
         # `mlvl_allrandom = FALSE`):
         eta_test <- refmodel$ref_predfun(refmodel$fit, excl_offs = FALSE)

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -320,7 +320,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
       if (formula_contains_group_terms(refmodel$formula) &&
           getOption("projpred.mlvl_pred_new", FALSE)) {
         # Need to use `mlvl_allrandom = TRUE` (`refmodel$mu_offs` is based on
-        # `mlvl_allrandom = FALSE`):
+        # `mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)`):
         eta_test <- refmodel$ref_predfun(refmodel$fit, excl_offs = FALSE)
         mu_test <- refmodel$family$linkinv(eta_test)
       } else {

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -317,7 +317,14 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
     }
   } else {
     if (d_test$type == "train") {
-      mu_test <- refmodel$mu_offs
+      if (formula_contains_group_terms(refmodel$formula)) {
+        # Need to use `mlvl_allrandom = TRUE` (`refmodel$mu_offs` is based on
+        # `mlvl_allrandom = FALSE`):
+        eta_test <- refmodel$ref_predfun(refmodel$fit, excl_offs = FALSE)
+        mu_test <- refmodel$family$linkinv(eta_test)
+      } else {
+        mu_test <- refmodel$mu_offs
+      }
     } else {
       newdata_for_ref <- d_test$data
       if (inherits(refmodel$fit, "stanreg") &&

--- a/man/pred-projection.Rd
+++ b/man/pred-projection.Rd
@@ -72,7 +72,7 @@ this seed is used for drawing new group-level effects in case of a
 multilevel submodel (however, not yet in case of a GAMM) and for drawing
 from the predictive distributions of the submodel(s) in case of
 \code{\link[=proj_predict]{proj_predict()}}. If a clustered projection was performed, then in
-\code{\link[=proj_predict]{proj_predict()}}, \code{.seed} is also used for drawing from the set of the
+\code{\link[=proj_predict]{proj_predict()}}, \code{.seed} is also used for drawing from the set of
 projected clusters of posterior draws (see argument \code{nresample_clusters}).}
 
 \item{...}{Arguments passed to \code{\link[=project]{project()}} if \code{object} is not already an

--- a/man/predict.refmodel.Rd
+++ b/man/predict.refmodel.Rd
@@ -88,10 +88,10 @@ response scale, or the log predictive density.
 \details{
 Argument \code{weightsnew} is only relevant if \code{!is.null(ynew)}.
 
-In case of a multilevel reference model, group-level effects are
-"integrated out" by considering all group levels from \code{newdata} (even those
-that already exist in the original dataset) as \emph{new} group levels (if
-\code{is.null(newdata)}, all group levels from the original dataset are
-considered as new group levels) and by drawing group-level effects for all
-these "new" group levels randomly.
+In case of a multilevel reference model, group-level effects for new group
+levels are drawn randomly from a (multivariate) Gaussian distribution. When
+setting \code{projpred.mlvl_prd_new} to \code{TRUE}, all group levels from \code{newdata}
+(even those that already exist in the original dataset) are treated as new
+group levels (if \code{is.null(newdata)}, all group levels from the original
+dataset are considered as new group levels in that case).
 }

--- a/man/predict.refmodel.Rd
+++ b/man/predict.refmodel.Rd
@@ -90,7 +90,7 @@ Argument \code{weightsnew} is only relevant if \code{!is.null(ynew)}.
 
 In case of a multilevel reference model, group-level effects for new group
 levels are drawn randomly from a (multivariate) Gaussian distribution. When
-setting \code{projpred.mlvl_prd_new} to \code{TRUE}, all group levels from \code{newdata}
+setting \code{projpred.mlvl_pred_new} to \code{TRUE}, all group levels from \code{newdata}
 (even those that already exist in the original dataset) are treated as new
 group levels (if \code{is.null(newdata)}, all group levels from the original
 dataset are considered as new group levels in that case).

--- a/man/predict.refmodel.Rd
+++ b/man/predict.refmodel.Rd
@@ -87,4 +87,11 @@ response scale, or the log predictive density.
 }
 \details{
 Argument \code{weightsnew} is only relevant if \code{!is.null(ynew)}.
+
+In case of a multilevel reference model, group-level effects are
+"integrated out" by considering all group levels from \code{newdata} (even those
+that already exist in the original dataset) as \emph{new} group levels (if
+\code{is.null(newdata)}, all group levels from the original dataset are
+considered as new group levels) and by drawing group-level effects for all
+these "new" group levels randomly.
 }

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -57,7 +57,10 @@ class \code{datafit} (in which case one cluster is used). For the meaning of
 results can be obtained again if needed. Passed to argument \code{seed} of
 \code{\link[=set.seed]{set.seed()}}, but can also be \code{NA} to not call \code{\link[=set.seed]{set.seed()}} at all. Here,
 this seed is used for clustering the reference model's posterior draws (if
-\code{!is.null(nclusters)}).}
+\code{!is.null(nclusters)}) and for drawing new group-level effects when
+predicting from a multilevel submodel (however, not yet in case of a GAMM).
+(Such a prediction takes place when calculating output elements \code{dis} and
+\code{ce}.)}
 
 \item{regul}{A number giving the amount of ridge regularization when
 projecting onto (i.e., fitting) submodels which are GLMs. Usually there is

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -59,7 +59,7 @@ results can be obtained again if needed. Passed to argument \code{seed} of
 this seed is used for clustering the reference model's posterior draws (if
 \code{!is.null(nclusters)}) and for drawing new group-level effects when
 predicting from a multilevel submodel (however, not yet in case of a GAMM)
-and having global option \code{projpred.mlvl_prd_new} set to \code{TRUE}. (Such a
+and having global option \code{projpred.mlvl_pred_new} set to \code{TRUE}. (Such a
 prediction takes place when calculating output elements \code{dis} and \code{ce}.)}
 
 \item{regul}{A number giving the amount of ridge regularization when

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -58,9 +58,9 @@ results can be obtained again if needed. Passed to argument \code{seed} of
 \code{\link[=set.seed]{set.seed()}}, but can also be \code{NA} to not call \code{\link[=set.seed]{set.seed()}} at all. Here,
 this seed is used for clustering the reference model's posterior draws (if
 \code{!is.null(nclusters)}) and for drawing new group-level effects when
-predicting from a multilevel submodel (however, not yet in case of a GAMM).
-(Such a prediction takes place when calculating output elements \code{dis} and
-\code{ce}.)}
+predicting from a multilevel submodel (however, not yet in case of a GAMM)
+and having global option \code{projpred.mlvl_prd_new} set to \code{TRUE}. (Such a
+prediction takes place when calculating output elements \code{dis} and \code{ce}.)}
 
 \item{regul}{A number giving the amount of ridge regularization when
 projecting onto (i.e., fitting) submodels which are GLMs. Usually there is

--- a/man/projpred-package.Rd
+++ b/man/projpred-package.Rd
@@ -77,15 +77,16 @@ in turn may crash the R session. Thus, we currently cannot recommend the
 parallelization for models other than GLMs.
 
 For multilevel models, \pkg{projpred} offers two global options that may be
-revelant for users: \code{projpred.mlvl_prd_new} and \code{projpred.mlvl_prj_ref_new}.
-When setting \code{projpred.mlvl_prd_new} to \code{TRUE} (default is \code{FALSE}), then at
+revelant for users: \code{projpred.mlvl_pred_new} and
+\code{projpred.mlvl_proj_ref_new}. When setting \code{projpred.mlvl_pred_new} to \code{TRUE}
+(default is \code{FALSE}), then at
 \emph{prediction} time, \pkg{projpred} will treat group levels existing in the
 training data as \emph{new} group levels, implying that their group-level effects
 are drawn randomly from a (multivariate) Gaussian distribution. This concerns
 both, the reference model and the (i.e., any) submodel. Furthermore, setting
-\code{projpred.mlvl_prd_new} to \code{TRUE} causes \code{as.matrix.projection()} to omit the
-projected group-level effects (for the group levels from the original
-dataset). When setting \code{projpred.mlvl_prj_ref_new} to \code{TRUE} (default is
+\code{projpred.mlvl_pred_new} to \code{TRUE} causes \code{as.matrix.projection()} to omit
+the projected group-level effects (for the group levels from the original
+dataset). When setting \code{projpred.mlvl_proj_ref_new} to \code{TRUE} (default is
 \code{FALSE}), then at \emph{projection} time, the reference model's fitted values
 (that the submodels fit to) will be computed by treating the group levels
 from the original dataset as \emph{new} group levels, implying that their
@@ -93,13 +94,13 @@ group-level effects will be drawn randomly from a (multivariate) Gaussian
 distribution (as long as the reference model is a multilevel model,
 which---for custom reference models---does not need to be the case). This
 also affects the latent response values for a latent projection
-correspondingly. Setting \code{projpred.mlvl_prd_new} to \code{TRUE} makes sense, e.g.,
-when the prediction task is such that any group level will be treated as a
-new one. Typically, setting \code{projpred.mlvl_prj_ref_new} to \code{TRUE} only makes
-sense when \code{projpred.mlvl_prd_new} is already set to \code{TRUE}. In that case,
-the default of \code{FALSE} for \code{projpred.mlvl_prj_ref_new} ensures that at
+correspondingly. Setting \code{projpred.mlvl_pred_new} to \code{TRUE} makes sense,
+e.g., when the prediction task is such that any group level will be treated
+as a new one. Typically, setting \code{projpred.mlvl_proj_ref_new} to \code{TRUE} only
+makes sense when \code{projpred.mlvl_pred_new} is already set to \code{TRUE}. In that
+case, the default of \code{FALSE} for \code{projpred.mlvl_proj_ref_new} ensures that at
 projection time, the submodels fit to the best possible fitted values from
-the reference model, and setting \code{projpred.mlvl_prj_ref_new} to \code{TRUE} would
+the reference model, and setting \code{projpred.mlvl_proj_ref_new} to \code{TRUE} would
 make sense if the group-level effects should be integrated out completely.
 }
 \section{Functions}{

--- a/man/projpred-package.Rd
+++ b/man/projpred-package.Rd
@@ -79,28 +79,28 @@ parallelization for models other than GLMs.
 For multilevel models, \pkg{projpred} offers two global options that may be
 revelant for users: \code{projpred.mlvl_prd_new} and \code{projpred.mlvl_prj_ref_new}.
 When setting \code{projpred.mlvl_prd_new} to \code{TRUE} (default is \code{FALSE}), then at
-prediction time, \pkg{projpred} will treat group levels existing in the
+\emph{prediction} time, \pkg{projpred} will treat group levels existing in the
 training data as \emph{new} group levels, implying that their group-level effects
 are drawn randomly from a (multivariate) Gaussian distribution. This concerns
 both, the reference model and the (i.e., any) submodel. Furthermore, setting
 \code{projpred.mlvl_prd_new} to \code{TRUE} causes \code{as.matrix.projection()} to omit the
 projected group-level effects (for the group levels from the original
 dataset). When setting \code{projpred.mlvl_prj_ref_new} to \code{TRUE} (default is
-\code{FALSE}), then at projection time, the reference model's fitted values (that
-the submodels fit to) will be computed by treating the group levels from the
-original dataset as \emph{new} group levels, implying that their group-level
-effects will be drawn randomly from a (multivariate) Gaussian distribution
-(as long as the reference model is a multilevel model, which---for custom
-reference models---does not need to be the case). This also affects the
-latent response values for a latent projection correspondingly. Setting
-\code{projpred.mlvl_prd_new} to \code{TRUE} makes sense, e.g., when the prediction task
-is such that any group level will be treated as a new one. Typically, setting
-\code{projpred.mlvl_prj_ref_new} to \code{TRUE} only makes sense when
-\code{projpred.mlvl_prd_new} is already set to \code{TRUE}. In that case, the default
-of \code{FALSE} for \code{projpred.mlvl_prj_ref_new} ensures that at projection time,
-the submodels fit to the best possible fitted values from the reference
-model, and setting \code{projpred.mlvl_prj_ref_new} to \code{TRUE} would make sense if
-the group-level effects should be integrated out completely.
+\code{FALSE}), then at \emph{projection} time, the reference model's fitted values
+(that the submodels fit to) will be computed by treating the group levels
+from the original dataset as \emph{new} group levels, implying that their
+group-level effects will be drawn randomly from a (multivariate) Gaussian
+distribution (as long as the reference model is a multilevel model,
+which---for custom reference models---does not need to be the case). This
+also affects the latent response values for a latent projection
+correspondingly. Setting \code{projpred.mlvl_prd_new} to \code{TRUE} makes sense, e.g.,
+when the prediction task is such that any group level will be treated as a
+new one. Typically, setting \code{projpred.mlvl_prj_ref_new} to \code{TRUE} only makes
+sense when \code{projpred.mlvl_prd_new} is already set to \code{TRUE}. In that case,
+the default of \code{FALSE} for \code{projpred.mlvl_prj_ref_new} ensures that at
+projection time, the submodels fit to the best possible fitted values from
+the reference model, and setting \code{projpred.mlvl_prj_ref_new} to \code{TRUE} would
+make sense if the group-level effects should be integrated out completely.
 }
 \section{Functions}{
 \describe{

--- a/man/projpred-package.Rd
+++ b/man/projpred-package.Rd
@@ -75,6 +75,32 @@ for GLMs, but for all other models, the fitted model objects are quite big,
 which---when running in parallel---may lead to excessive memory usage which
 in turn may crash the R session. Thus, we currently cannot recommend the
 parallelization for models other than GLMs.
+
+For multilevel models, \pkg{projpred} offers two global options that may be
+revelant for users: \code{projpred.mlvl_prd_new} and \code{projpred.mlvl_prj_ref_new}.
+When setting \code{projpred.mlvl_prd_new} to \code{TRUE} (default is \code{FALSE}), then at
+prediction time, \pkg{projpred} will treat group levels existing in the
+training data as \emph{new} group levels, implying that their group-level effects
+are drawn randomly from a (multivariate) Gaussian distribution. This concerns
+both, the reference model and the (i.e., any) submodel. Furthermore, setting
+\code{projpred.mlvl_prd_new} to \code{TRUE} causes \code{as.matrix.projection()} to omit the
+projected group-level effects (for the group levels from the original
+dataset). When setting \code{projpred.mlvl_prj_ref_new} to \code{TRUE} (default is
+\code{FALSE}), then at projection time, the reference model's fitted values (that
+the submodels fit to) will be computed by treating the group levels from the
+original dataset as \emph{new} group levels, implying that their group-level
+effects will be drawn randomly from a (multivariate) Gaussian distribution
+(as long as the reference model is a multilevel model, which---for custom
+reference models---does not need to be the case). This also affects the
+latent response values for a latent projection correspondingly. Setting
+\code{projpred.mlvl_prd_new} to \code{TRUE} makes sense, e.g., when the prediction task
+is such that any group level will be treated as a new one. Typically, setting
+\code{projpred.mlvl_prj_ref_new} to \code{TRUE} only makes sense when
+\code{projpred.mlvl_prd_new} is already set to \code{TRUE}. In that case, the default
+of \code{FALSE} for \code{projpred.mlvl_prj_ref_new} ensures that at projection time,
+the submodels fit to the best possible fitted values from the reference
+model, and setting \code{projpred.mlvl_prj_ref_new} to \code{TRUE} would make sense if
+the group-level effects should be integrated out completely.
 }
 \section{Functions}{
 \describe{

--- a/tests/testthat/helpers/getters.R
+++ b/tests/testthat/helpers/getters.R
@@ -79,7 +79,7 @@ get_dat <- function(tstsetup, dat_crr = dat, offs_ylat = 0, ...) {
     y_nm <- stdize_lhs(prjs[[tstsetup]]$refmodel$formula)$y_nm
     dat_crr[[y_nm]] <- rowMeans(prjs[[tstsetup]]$refmodel$ref_predfun(
       fit = prjs[[tstsetup]]$refmodel$fit, newdata = dat_crr, excl_offs = FALSE,
-      mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
+      mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)
     ))
   }
   return(dat_crr)

--- a/tests/testthat/helpers/getters.R
+++ b/tests/testthat/helpers/getters.R
@@ -79,7 +79,7 @@ get_dat <- function(tstsetup, dat_crr = dat, offs_ylat = 0, ...) {
     y_nm <- stdize_lhs(prjs[[tstsetup]]$refmodel$formula)$y_nm
     dat_crr[[y_nm]] <- rowMeans(prjs[[tstsetup]]$refmodel$ref_predfun(
       fit = prjs[[tstsetup]]$refmodel$fit, newdata = dat_crr, excl_offs = FALSE,
-      mlvl_allrandom = FALSE
+      mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
     ))
   }
   return(dat_crr)

--- a/tests/testthat/helpers/getters.R
+++ b/tests/testthat/helpers/getters.R
@@ -78,13 +78,14 @@ get_dat <- function(tstsetup, dat_crr = dat, offs_ylat = 0, ...) {
     }
     y_nm <- stdize_lhs(prjs[[tstsetup]]$refmodel$formula)$y_nm
     # Use `ref_predfun_usr` here (instead of `ref_predfun`) to include
-    # offsets:
-    refprd_with_offs <- get(
+    # offsets and group-level effects for existing group levels:
+    refprd_with_offs_grplvl <- get(
       "ref_predfun_usr",
       envir = environment(prjs[[tstsetup]]$refmodel$ref_predfun)
     )
     dat_crr[[y_nm]] <- rowMeans(unname(
-      refprd_with_offs(fit = prjs[[tstsetup]]$refmodel$fit, newdata = dat_crr)
+      refprd_with_offs_grplvl(fit = prjs[[tstsetup]]$refmodel$fit,
+                              newdata = dat_crr)
     ))
   }
   return(dat_crr)

--- a/tests/testthat/helpers/getters.R
+++ b/tests/testthat/helpers/getters.R
@@ -77,15 +77,9 @@ get_dat <- function(tstsetup, dat_crr = dat, offs_ylat = 0, ...) {
       dat_crr$projpred_internal_offs_stanreg <- offs_ylat
     }
     y_nm <- stdize_lhs(prjs[[tstsetup]]$refmodel$formula)$y_nm
-    # Use `ref_predfun_usr` here (instead of `ref_predfun`) to include
-    # offsets and group-level effects for existing group levels:
-    refprd_with_offs_grplvl <- get(
-      "ref_predfun_usr",
-      envir = environment(prjs[[tstsetup]]$refmodel$ref_predfun)
-    )
-    dat_crr[[y_nm]] <- rowMeans(unname(
-      refprd_with_offs_grplvl(fit = prjs[[tstsetup]]$refmodel$fit,
-                              newdata = dat_crr)
+    dat_crr[[y_nm]] <- rowMeans(prjs[[tstsetup]]$refmodel$ref_predfun(
+      fit = prjs[[tstsetup]]$refmodel$fit, newdata = dat_crr, excl_offs = FALSE,
+      mlvl_allrandom = FALSE
     ))
   }
   return(dat_crr)

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -546,8 +546,10 @@ refmodel_tester <- function(
   if (!is_datafit) {
     expect_equal(
       refmod$mu_offs,
-      refmod$family$linkinv(refmod$ref_predfun(refmod$fit, excl_offs = FALSE,
-                                               mlvl_allrandom = FALSE)),
+      refmod$family$linkinv(refmod$ref_predfun(
+        refmod$fit, excl_offs = FALSE,
+        mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
+      )),
       info = info_str
     )
   }
@@ -2070,9 +2072,10 @@ vsel_tester <- function(
           loo::psis(-ll_forPSIS, cores = 1, r_eff = NA)
         ))
         y_lat_loo <- colSums(
-          t(vs$refmodel$ref_predfun(vs$refmodel$fit, excl_offs = FALSE,
-                                    mlvl_allrandom = FALSE)) *
-            exp(lwdraws_ref)
+          t(vs$refmodel$ref_predfun(
+            vs$refmodel$fit, excl_offs = FALSE,
+            mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
+          )) * exp(lwdraws_ref)
         )
         expect_equal(vs$d_test$y, y_lat_loo, info = info_str)
       }

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -543,6 +543,14 @@ refmodel_tester <- function(
     ),
     info = info_str
   )
+  if (!is_datafit) {
+    expect_equal(
+      refmod$mu_offs,
+      refmod$family$linkinv(refmod$ref_predfun(refmod$fit, excl_offs = FALSE,
+                                               mlvl_allrandom = FALSE)),
+      info = info_str
+    )
+  }
 
   # dis
   if (refmod$family$family == "gaussian") {

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -2069,12 +2069,10 @@ vsel_tester <- function(
         lwdraws_ref <- weights(suppressWarnings(
           loo::psis(-ll_forPSIS, cores = 1, r_eff = NA)
         ))
-        refprd_with_offs_grplvl <- get(
-          "ref_predfun_usr",
-          envir = environment(vs$refmodel$ref_predfun)
-        )
         y_lat_loo <- colSums(
-          t(unname(refprd_with_offs_grplvl(vs$refmodel$fit))) * exp(lwdraws_ref)
+          t(vs$refmodel$ref_predfun(vs$refmodel$fit, excl_offs = FALSE,
+                                    mlvl_allrandom = FALSE)) *
+            exp(lwdraws_ref)
         )
         expect_equal(vs$d_test$y, y_lat_loo, info = info_str)
       }

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -548,7 +548,7 @@ refmodel_tester <- function(
       refmod$mu_offs,
       refmod$family$linkinv(refmod$ref_predfun(
         refmod$fit, excl_offs = FALSE,
-        mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
+        mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)
       )),
       info = info_str
     )
@@ -2074,7 +2074,7 @@ vsel_tester <- function(
         y_lat_loo <- colSums(
           t(vs$refmodel$ref_predfun(
             vs$refmodel$fit, excl_offs = FALSE,
-            mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
+            mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)
           )) * exp(lwdraws_ref)
         )
         expect_equal(vs$d_test$y, y_lat_loo, info = info_str)

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -2061,10 +2061,12 @@ vsel_tester <- function(
         lwdraws_ref <- weights(suppressWarnings(
           loo::psis(-ll_forPSIS, cores = 1, r_eff = NA)
         ))
-        refprd_with_offs <- get("ref_predfun_usr",
-                                envir = environment(vs$refmodel$ref_predfun))
+        refprd_with_offs_grplvl <- get(
+          "ref_predfun_usr",
+          envir = environment(vs$refmodel$ref_predfun)
+        )
         y_lat_loo <- colSums(
-          t(unname(refprd_with_offs(vs$refmodel$fit))) * exp(lwdraws_ref)
+          t(unname(refprd_with_offs_grplvl(vs$refmodel$fit))) * exp(lwdraws_ref)
         )
         expect_equal(vs$d_test$y, y_lat_loo, info = info_str)
       }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -192,6 +192,8 @@ warn_mclogit <- if (packageVersion("mclogit") >= "0.9.6") {
          "^Algorithm stopped due to false convergence$")
 }
 
+options(projpred.mlvl_prd_new = TRUE)
+
 # Data --------------------------------------------------------------------
 
 ## Setup ------------------------------------------------------------------

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -192,8 +192,6 @@ warn_mclogit <- if (packageVersion("mclogit") >= "0.9.6") {
          "^Algorithm stopped due to false convergence$")
 }
 
-options(projpred.mlvl_prd_new = TRUE)
-
 # Data --------------------------------------------------------------------
 
 ## Setup ------------------------------------------------------------------

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1402,7 +1402,7 @@ if (run_cvvs) {
 ### From "projection" -----------------------------------------------------
 
 if (run_prj) {
-  pls <- lapply(prjs, proj_linpred)
+  pls <- lapply(prjs, proj_linpred, .seed = seed2_tst)
   pps <- lapply(prjs, proj_predict, .seed = seed2_tst)
 }
 
@@ -1411,14 +1411,14 @@ if (run_prj) {
 #### varsel() -------------------------------------------------------------
 
 if (run_vs) {
-  pls_vs <- lapply(prjs_vs, proj_linpred)
+  pls_vs <- lapply(prjs_vs, proj_linpred, .seed = seed2_tst)
   pps_vs <- lapply(prjs_vs, proj_predict, .seed = seed2_tst)
 }
 
 #### cv_varsel() ----------------------------------------------------------
 
 if (run_cvvs) {
-  pls_cvvs <- lapply(prjs_cvvs, proj_linpred)
+  pls_cvvs <- lapply(prjs_cvvs, proj_linpred, .seed = seed2_tst)
   pps_cvvs <- lapply(prjs_cvvs, proj_predict, .seed = seed2_tst)
 }
 

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -115,7 +115,7 @@ test_that("as.matrix.projection() works", {
         }
         colnms_prjmat_expect <- c(colnms_prjmat_expect,
                                   paste0("sd_z.1__", mlvl_icpt_str))
-        if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+        if (!getOption("projpred.mlvl_pred_new", FALSE)) {
           if (fam_crr == "categ") {
             mlvl_r_str <- paste0("__mu", yunq_norefcat)
           } else {
@@ -132,7 +132,7 @@ test_that("as.matrix.projection() works", {
       } else if (pkg_crr == "rstanarm") {
         colnms_prjmat_expect <- c(colnms_prjmat_expect,
                                   "Sigma[z.1:(Intercept),(Intercept)]")
-        if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+        if (!getOption("projpred.mlvl_pred_new", FALSE)) {
           colnms_prjmat_expect <- c(
             colnms_prjmat_expect,
             paste0("b[(Intercept) z.1:lvl", seq_len(nlvl_ran[1]), "]")
@@ -148,7 +148,7 @@ test_that("as.matrix.projection() works", {
         }
         colnms_prjmat_expect <- c(colnms_prjmat_expect,
                                   paste0("sd_z.1__", mlvl_xco_str))
-        if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+        if (!getOption("projpred.mlvl_pred_new", FALSE)) {
           colnms_prjmat_expect <- c(
             colnms_prjmat_expect,
             unlist(lapply(mlvl_r_str, function(mlvl_r_str_i) {
@@ -160,7 +160,7 @@ test_that("as.matrix.projection() works", {
       } else if (pkg_crr == "rstanarm") {
         colnms_prjmat_expect <- c(colnms_prjmat_expect,
                                   "Sigma[z.1:xco.1,xco.1]")
-        if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+        if (!getOption("projpred.mlvl_pred_new", FALSE)) {
           colnms_prjmat_expect <- c(
             colnms_prjmat_expect,
             paste0("b[xco.1 z.1:lvl", seq_len(nlvl_ran[1]), "]")

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -115,25 +115,9 @@ test_that("as.matrix.projection() works", {
         }
         colnms_prjmat_expect <- c(colnms_prjmat_expect,
                                   paste0("sd_z.1__", mlvl_icpt_str))
-        if (fam_crr == "categ") {
-          mlvl_r_str <- paste0("__mu", yunq_norefcat)
-        } else {
-          mlvl_r_str <- ""
-        }
-        colnms_prjmat_expect <- c(
-          colnms_prjmat_expect,
-          unlist(lapply(mlvl_r_str, function(mlvl_r_str_i) {
-            paste0("r_z.1", mlvl_r_str_i,
-                   "[lvl", seq_len(nlvl_ran[1]), ",Intercept]")
-          }))
-        )
       } else if (pkg_crr == "rstanarm") {
         colnms_prjmat_expect <- c(colnms_prjmat_expect,
                                   "Sigma[z.1:(Intercept),(Intercept)]")
-        colnms_prjmat_expect <- c(
-          colnms_prjmat_expect,
-          paste0("b[(Intercept) z.1:lvl", seq_len(nlvl_ran[1]), "]")
-        )
       }
     }
     if ("(xco.1 | z.1)" %in% solterms) {
@@ -144,20 +128,9 @@ test_that("as.matrix.projection() works", {
         }
         colnms_prjmat_expect <- c(colnms_prjmat_expect,
                                   paste0("sd_z.1__", mlvl_xco_str))
-        colnms_prjmat_expect <- c(
-          colnms_prjmat_expect,
-          unlist(lapply(mlvl_r_str, function(mlvl_r_str_i) {
-            paste0("r_z.1", mlvl_r_str_i,
-                   "[lvl", seq_len(nlvl_ran[1]), ",xco.1]")
-          }))
-        )
       } else if (pkg_crr == "rstanarm") {
         colnms_prjmat_expect <- c(colnms_prjmat_expect,
                                   "Sigma[z.1:xco.1,xco.1]")
-        colnms_prjmat_expect <- c(
-          colnms_prjmat_expect,
-          paste0("b[xco.1 z.1:lvl", seq_len(nlvl_ran[1]), "]")
-        )
       }
     }
     if (all(c("(1 | z.1)", "(xco.1 | z.1)") %in% solterms)) {

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -115,9 +115,29 @@ test_that("as.matrix.projection() works", {
         }
         colnms_prjmat_expect <- c(colnms_prjmat_expect,
                                   paste0("sd_z.1__", mlvl_icpt_str))
+        if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+          if (fam_crr == "categ") {
+            mlvl_r_str <- paste0("__mu", yunq_norefcat)
+          } else {
+            mlvl_r_str <- ""
+          }
+          colnms_prjmat_expect <- c(
+            colnms_prjmat_expect,
+            unlist(lapply(mlvl_r_str, function(mlvl_r_str_i) {
+              paste0("r_z.1", mlvl_r_str_i,
+                     "[lvl", seq_len(nlvl_ran[1]), ",Intercept]")
+            }))
+          )
+        }
       } else if (pkg_crr == "rstanarm") {
         colnms_prjmat_expect <- c(colnms_prjmat_expect,
                                   "Sigma[z.1:(Intercept),(Intercept)]")
+        if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+          colnms_prjmat_expect <- c(
+            colnms_prjmat_expect,
+            paste0("b[(Intercept) z.1:lvl", seq_len(nlvl_ran[1]), "]")
+          )
+        }
       }
     }
     if ("(xco.1 | z.1)" %in% solterms) {
@@ -128,9 +148,24 @@ test_that("as.matrix.projection() works", {
         }
         colnms_prjmat_expect <- c(colnms_prjmat_expect,
                                   paste0("sd_z.1__", mlvl_xco_str))
+        if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+          colnms_prjmat_expect <- c(
+            colnms_prjmat_expect,
+            unlist(lapply(mlvl_r_str, function(mlvl_r_str_i) {
+              paste0("r_z.1", mlvl_r_str_i,
+                     "[lvl", seq_len(nlvl_ran[1]), ",xco.1]")
+            }))
+          )
+        }
       } else if (pkg_crr == "rstanarm") {
         colnms_prjmat_expect <- c(colnms_prjmat_expect,
                                   "Sigma[z.1:xco.1,xco.1]")
+        if (!getOption("projpred.mlvl_prd_new", FALSE)) {
+          colnms_prjmat_expect <- c(
+            colnms_prjmat_expect,
+            paste0("b[xco.1 z.1:lvl", seq_len(nlvl_ran[1]), "]")
+          )
+        }
       }
     }
     if (all(c("(1 | z.1)", "(xco.1 | z.1)") %in% solterms)) {

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -184,7 +184,7 @@ if (run_vs) {
 ### From "proj_list" ------------------------------------------------------
 
 if (run_vs) {
-  pls_vs_datafit <- lapply(prjs_vs_datafit, proj_linpred)
+  pls_vs_datafit <- lapply(prjs_vs_datafit, proj_linpred, .seed = seed2_tst)
   pps_vs_datafit <- lapply(prjs_vs_datafit, proj_predict, .seed = seed2_tst)
 }
 
@@ -418,7 +418,8 @@ test_that(paste(
         tail(nobsv_tst, 1)
       ),
       weightsnew = ~ wobs_col,
-      filter_nterms = nterms_crr[1]
+      filter_nterms = nterms_crr[1],
+      .seed = seed2_tst
     )
     pl_tester(pl_with_args,
               len_expected = 1L,
@@ -693,8 +694,8 @@ test_that(paste(
     expect_warning(
       pred1 <- proj_linpred(vs,
                             newdata = data.frame(x = x, weights = weights),
-                            nterms = 0:nterms, transform = FALSE,
-                            refit_prj = FALSE),
+                            transform = FALSE, .seed = seed2_tst,
+                            nterms = 0:nterms, refit_prj = FALSE),
       paste("^Currently, `refit_prj = FALSE` requires some caution, see GitHub",
             "issues #168 and #211\\.$"),
       info = fam$family

--- a/tests/testthat/test_latent.R
+++ b/tests/testthat/test_latent.R
@@ -127,6 +127,7 @@ test_that(paste(
       pref_trad[setdiff(names(pref_trad), c("mu", "mu_offs", "var", "dis"))],
       info = tstsetup
     )
+
     mu_lat_oscale <- refmod_crr$family$latent_ilink(t(refmod_crr$mu))
     mu_lat_oscale_cl <- sapply(
       seq_len(max(pref_lat$cl, na.rm = TRUE)),
@@ -137,6 +138,20 @@ test_that(paste(
       }
     )
     expect_equal(mu_lat_oscale_cl, pref_trad$mu, tolerance = 1e-10,
+                 info = tstsetup)
+
+    mu_offs_lat_oscale <- refmod_crr$family$latent_ilink(t(refmod_crr$mu_offs))
+    mu_offs_lat_oscale_cl <- sapply(
+      seq_len(max(pref_lat$cl, na.rm = TRUE)),
+      function(cl_idx) {
+        # We don't use `eps` here, so there are minor differences compared to
+        # .get_pclust():
+        colMeans(
+          mu_offs_lat_oscale[which(pref_lat$cl == cl_idx), , drop = FALSE]
+        )
+      }
+    )
+    expect_equal(mu_offs_lat_oscale_cl, pref_trad$mu_offs, tolerance = 1e-10,
                  info = tstsetup)
   }
   if (exists("rng_old")) assign(".Random.seed", rng_old, envir = .GlobalEnv)

--- a/tests/testthat/test_proj_pred.R
+++ b/tests/testthat/test_proj_pred.R
@@ -113,7 +113,7 @@ test_that(paste(
   skip_if_not(run_prj)
   tstsetups <- grep("\\.trad\\..*\\.clust$", names(prjs), value = TRUE)
   stopifnot(length(tstsetups) > 1)
-  pl <- proj_linpred(prjs[tstsetups])
+  pl <- proj_linpred(prjs[tstsetups], .seed = seed2_tst)
   pl_tester(pl,
             len_expected = length(tstsetups),
             ncats_nlats_expected = lapply(tstsetups, function(tstsetup) {
@@ -136,7 +136,7 @@ test_that(paste(
   for (tstsetup in tstsetups) {
     args_prj_i <- args_prj[[tstsetup]]
     pl_from_refmod <- do.call(proj_linpred, c(
-      list(object = refmods[[args_prj_i$tstsetup_ref]]),
+      list(object = refmods[[args_prj_i$tstsetup_ref]], .seed = seed2_tst),
       excl_nonargs(args_prj_i)
     ))
     pl_from_prj <- pls[[tstsetup]]
@@ -154,7 +154,7 @@ test_that(paste(
   for (tstsetup in tstsetups) {
     args_prj_i <- args_prj[[tstsetup]]
     pl_from_fit <- do.call(proj_linpred, c(
-      list(object = fits[[args_prj_i$tstsetup_fit]]),
+      list(object = fits[[args_prj_i$tstsetup_fit]], .seed = seed2_tst),
       excl_nonargs(args_prj_i),
       excl_nonargs(args_ref[[args_prj_i$tstsetup_ref]])
     ))
@@ -174,7 +174,7 @@ test_that(paste(
   for (tstsetup in tstsetups) {
     args_prj_vs_i <- args_prj_vs[[tstsetup]]
     pl_from_vsel <- do.call(proj_linpred, c(
-      list(object = vss[[args_prj_vs_i$tstsetup_vsel]]),
+      list(object = vss[[args_prj_vs_i$tstsetup_vsel]], .seed = seed2_tst),
       excl_nonargs(args_prj_vs_i)
     ))
     pl_from_prj <- pls_vs[[tstsetup]]
@@ -202,7 +202,7 @@ test_that(paste(
   for (tstsetup in tstsetups) {
     args_prj_cvvs_i <- args_prj_cvvs[[tstsetup]]
     pl_from_vsel <- do.call(proj_linpred, c(
-      list(object = cvvss[[args_prj_cvvs_i$tstsetup_vsel]]),
+      list(object = cvvss[[args_prj_cvvs_i$tstsetup_vsel]], .seed = seed2_tst),
       excl_nonargs(args_prj_cvvs_i)
     ))
     pl_from_prj <- pls_cvvs[[tstsetup]]
@@ -212,23 +212,23 @@ test_that(paste(
 
 test_that("`object` not of class \"vsel\" and missing `solution_terms` fails", {
   expect_error(
-    proj_linpred(1),
+    proj_linpred(1, .seed = seed2_tst),
     paste("^Please provide an `object` of class \"vsel\" or use argument",
           "`solution_terms`\\.$")
   )
   expect_error(
-    proj_linpred(fits[[1]]),
+    proj_linpred(fits[[1]], .seed = seed2_tst),
     paste("^Please provide an `object` of class \"vsel\" or use argument",
           "`solution_terms`\\.$")
   )
   expect_error(
-    proj_linpred(refmods[[1]]),
+    proj_linpred(refmods[[1]], .seed = seed2_tst),
     paste("^Please provide an `object` of class \"vsel\" or use argument",
           "`solution_terms`\\.$")
   )
   if (run_prj) {
     expect_error(
-      proj_linpred(c(prjs, list(dat))),
+      proj_linpred(c(prjs, list(dat)), .seed = seed2_tst),
       paste("Please provide an `object` of class \"vsel\" or use argument",
             "`solution_terms`\\.")
     )
@@ -240,14 +240,15 @@ test_that("`object` not of class \"vsel\" and missing `solution_terms` fails", {
 test_that("invalid `newdata` fails", {
   skip_if_not(run_prj)
   expect_error(
-    proj_linpred(prjs, newdata = dat[, 1]),
+    proj_linpred(prjs, newdata = dat[, 1], .seed = seed2_tst),
     "must be a data\\.frame or a matrix"
   )
   stopifnot(length(solterms_x) > 1)
   expect_error(
     proj_linpred(prjs[[head(grep("\\.glm\\.gauss.*\\.solterms_x", names(prjs)),
                             1)]],
-                 newdata = dat[, head(solterms_x, -1), drop = FALSE]),
+                 newdata = dat[, head(solterms_x, -1), drop = FALSE],
+                 .seed = seed2_tst),
     "^object '.*' not found$"
   )
 })
@@ -270,7 +271,8 @@ test_that("`newdata` and `integrated` work (even in edge cases)", {
         ncats_nlats_expected_crr <- integer()
       }
       pl_false <- proj_linpred(prjs[[tstsetup]],
-                               newdata = head(dat_crr, nobsv_crr))
+                               newdata = head(dat_crr, nobsv_crr),
+                               .seed = seed2_tst)
       pl_tester(pl_false,
                 nprjdraws_expected = ndr_ncl$nprjdraws,
                 nobsv_expected = nobsv_crr,
@@ -278,7 +280,8 @@ test_that("`newdata` and `integrated` work (even in edge cases)", {
                 info_str = paste(tstsetup, nobsv_crr, sep = "__"))
       pl_true <- proj_linpred(prjs[[tstsetup]],
                               newdata = head(dat_crr, nobsv_crr),
-                              integrated = TRUE)
+                              integrated = TRUE,
+                              .seed = seed2_tst)
       pl_tester(pl_true,
                 nprjdraws_expected = 1L,
                 nobsv_expected = nobsv_crr,
@@ -303,13 +306,15 @@ test_that("`newdata` set to the original dataset doesn't change results", {
   for (tstsetup in names(prjs)) {
     dat_crr <- get_dat(tstsetup)
     # With `transform = FALSE`:
-    pl_newdata <- proj_linpred(prjs[[tstsetup]], newdata = dat_crr)
+    pl_newdata <- proj_linpred(prjs[[tstsetup]], newdata = dat_crr,
+                               .seed = seed2_tst)
     pl_orig <- pls[[tstsetup]]
     expect_equal(pl_newdata, pl_orig, info = tstsetup)
     # With `transform = TRUE`:
     pl_newdata_t <- proj_linpred(prjs[[tstsetup]], newdata = dat_crr,
-                                 transform = TRUE)
-    pl_orig_t <- proj_linpred(prjs[[tstsetup]], transform = TRUE)
+                                 transform = TRUE, .seed = seed2_tst)
+    pl_orig_t <- proj_linpred(prjs[[tstsetup]], transform = TRUE,
+                              .seed = seed2_tst)
     expect_equal(pl_newdata_t, pl_orig_t, info = tstsetup)
   }
 })
@@ -335,7 +340,8 @@ test_that(paste(
     dat_crr <- get_dat(tstsetup)
     pl_noresp <- proj_linpred(
       prjs[[tstsetup]],
-      newdata = dat_crr[, setdiff(names(dat_crr), resp_nm)]
+      newdata = dat_crr[, setdiff(names(dat_crr), resp_nm)],
+      .seed = seed2_tst
     )
     if (args_prj[[tstsetup]]$prj_nm == "augdat") {
       ncats_nlats_expected_crr <- length(
@@ -373,7 +379,8 @@ test_that("`weightsnew` works", {
       # TODO (brms): Fix or document why this doesn't work for "brmsfit"s.
       pl_ones <- proj_linpred(prjs[[tstsetup]],
                               newdata = get_dat(tstsetup, dat_wobs_ones),
-                              weightsnew = ~ wobs_col_ones)
+                              weightsnew = ~ wobs_col_ones,
+                              .seed = seed2_tst)
       pl_tester(pl_ones,
                 nprjdraws_expected = ndr_ncl$nprjdraws,
                 ncats_nlats_expected = list(ncats_nlats_expected_crr),
@@ -382,7 +389,8 @@ test_that("`weightsnew` works", {
     if (!args_prj[[tstsetup]]$prj_nm %in% c("latent", "augdat")) {
       pl <- proj_linpred(prjs[[tstsetup]],
                          newdata = get_dat(tstsetup, dat),
-                         weightsnew = ~ wobs_col)
+                         weightsnew = ~ wobs_col,
+                         .seed = seed2_tst)
       pl_tester(pl,
                 nprjdraws_expected = ndr_ncl$nprjdraws,
                 ncats_nlats_expected = list(ncats_nlats_expected_crr),
@@ -394,7 +402,8 @@ test_that("`weightsnew` works", {
       # TODO (brms): Fix or document why this doesn't work for "brmsfit"s.
       plw <- proj_linpred(prjs[[tstsetup]],
                           newdata = get_dat(tstsetup, dat_wobs_new),
-                          weightsnew = ~ wobs_col_new)
+                          weightsnew = ~ wobs_col_new,
+                          .seed = seed2_tst)
       pl_tester(plw,
                 nprjdraws_expected = ndr_ncl$nprjdraws,
                 ncats_nlats_expected = list(ncats_nlats_expected_crr),
@@ -479,7 +488,8 @@ test_that("`offsetnew` works", {
       pl_zeros <- proj_linpred(prjs[[tstsetup]],
                                newdata = get_dat(tstsetup, dat_offs_zeros,
                                                  add_offs_dummy = add_offs_crr),
-                               offsetnew = ~ offs_col_zeros)
+                               offsetnew = ~ offs_col_zeros,
+                               .seed = seed2_tst)
       pl_tester(pl_zeros,
                 nprjdraws_expected = ndr_ncl$nprjdraws,
                 ncats_nlats_expected = list(ncats_nlats_expected_crr),
@@ -487,7 +497,8 @@ test_that("`offsetnew` works", {
     }
     pl <- proj_linpred(prjs[[tstsetup]],
                        newdata = get_dat(tstsetup, dat, offs_ylat = offs_tst),
-                       offsetnew = ~ offs_col)
+                       offsetnew = ~ offs_col,
+                       .seed = seed2_tst)
     pl_tester(pl,
               nprjdraws_expected = ndr_ncl$nprjdraws,
               ncats_nlats_expected = list(ncats_nlats_expected_crr),
@@ -500,7 +511,8 @@ test_that("`offsetnew` works", {
                             offs_ylat = dat_offs_new$offs_col_new,
                             add_offs_dummy = add_offs_crr
                           ),
-                          offsetnew = ~ offs_col_new)
+                          offsetnew = ~ offs_col_new,
+                          .seed = seed2_tst)
       pl_tester(plo,
                 nprjdraws_expected = ndr_ncl$nprjdraws,
                 ncats_nlats_expected = list(ncats_nlats_expected_crr),
@@ -614,7 +626,8 @@ test_that("`transform` works", {
       ncats_nlats_expected_crr <- integer()
     }
     pl_false <- pls[[tstsetup]]
-    pl_true <- proj_linpred(prjs[[tstsetup]], transform = TRUE)
+    pl_true <- proj_linpred(prjs[[tstsetup]], transform = TRUE,
+                            .seed = seed2_tst)
     pl_tester(pl_true,
               nprjdraws_expected = ndr_ncl$nprjdraws,
               ncats_nlats_expected = list(ncats_nlats_expected_crr),
@@ -672,6 +685,7 @@ test_that("`regul` works", {
       pl <- do.call(proj_linpred, c(
         list(object = refmods[[args_prj_i$tstsetup_ref]],
              integrated = TRUE,
+             .seed = seed2_tst,
              regul = regul_crr),
         excl_nonargs(args_prj_i)
       ))
@@ -699,12 +713,14 @@ test_that("`filter_nterms` works (for an `object` of class \"projection\")", {
     stopifnot(!nterms_avail_crr %in% nterms_unavail_crr)
     for (filter_nterms_crr in nterms_unavail_crr) {
       expect_error(proj_linpred(prjs[[tstsetup]],
-                                filter_nterms = filter_nterms_crr),
+                                filter_nterms = filter_nterms_crr,
+                                .seed = seed2_tst),
                    "Invalid `filter_nterms`\\.",
                    info = paste(tstsetup, filter_nterms_crr, sep = "__"))
     }
     pl <- proj_linpred(prjs[[tstsetup]],
-                       filter_nterms = nterms_avail_crr)
+                       filter_nterms = nterms_avail_crr,
+                       .seed = seed2_tst)
     pl_orig <- pls[[tstsetup]]
     expect_equal(pl, pl_orig, info = tstsetup)
   }
@@ -727,7 +743,8 @@ test_that(paste(
     # Unavailable number(s) of terms:
     for (filter_nterms_crr in nterms_unavail) {
       expect_error(proj_linpred(prjs_vs[[tstsetup]],
-                                filter_nterms = filter_nterms_crr),
+                                filter_nterms = filter_nterms_crr,
+                                .seed = seed2_tst),
                    "Invalid `filter_nterms`\\.",
                    info = paste(tstsetup,
                                 paste(filter_nterms_crr, collapse = ","),
@@ -740,7 +757,8 @@ test_that(paste(
     )
     for (filter_nterms_crr in nterms_avail_filter) {
       pl_crr <- proj_linpred(prjs_vs[[tstsetup]],
-                             filter_nterms = filter_nterms_crr)
+                             filter_nterms = filter_nterms_crr,
+                             .seed = seed2_tst)
       if (is.null(filter_nterms_crr)) filter_nterms_crr <- 0:nterms_max_tst
       nhits_nterms <- sum(filter_nterms_crr <= nterms_max_tst)
       pl_tester(pl_crr,
@@ -788,6 +806,7 @@ test_that(paste(
     }
     pl_args <- list(refmods[[args_prj[[tstsetup]]$tstsetup_ref]],
                     newdata = head(get_dat(tstsetup), 1),
+                    .seed = seed2_tst,
                     solution_terms = args_prj[[tstsetup]]$solution_terms,
                     nclusters = 1L,
                     seed = seed_tst)

--- a/tests/testthat/test_proj_predfun.R
+++ b/tests/testthat/test_proj_predfun.R
@@ -112,24 +112,49 @@ test_that("repair_re() works for GLMMs", {
   expect_identical(dim(lpreds), c(nrow(dat_new), 1L))
   lpreds <- lpreds[, 1]
 
+  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+    n_sbj <- length(unique(dat_new$sbj))
+    n_grp <- length(unique(dat_new$grp))
+  } else {
+    n_sbj <- 1
+    n_grp <- 1
+  }
+
   set.seed(seed3_tst)
   ranmulti_sbj <- mvtnorm::rmvnorm(
-    n = length(unique(dat_new$sbj)), sigma = lmm_VarCorr$sbj[, , drop = FALSE],
+    n = n_sbj, sigma = lmm_VarCorr$sbj[, , drop = FALSE],
     checkSymmetry = FALSE
   )
   ranmulti_grp <- mvtnorm::rmvnorm(
-    n = length(unique(dat_new$grp)), sigma = lmm_VarCorr$grp[, , drop = FALSE],
+    n = n_grp, sigma = lmm_VarCorr$grp[, , drop = FALSE],
     checkSymmetry = FALSE
   )
-  ranslopes <- list(
-    X1 = c(ranmulti_grp[1, 2], rep(ranmulti_grp[2, 2], 2)),
-    X2 = rep(0, 3),
-    Xfl2 = c(ranmulti_grp[1, 3], rep(ranmulti_grp[2, 3], 2)),
-    Xfl3 = c(ranmulti_grp[1, 4], rep(ranmulti_grp[2, 4], 2))
-  )
+  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+    ranicpts <- c(ranmulti_sbj[1, 1], rep(ranmulti_sbj[2, 1], 2)) +
+      c(ranmulti_grp[1, 1], rep(ranmulti_grp[2, 1], 2))
+    ranslopes <- list(
+      X1 = c(ranmulti_grp[1, 2], rep(ranmulti_grp[2, 2], 2)),
+      X2 = rep(0, 3),
+      Xfl2 = c(ranmulti_grp[1, 3], rep(ranmulti_grp[2, 3], 2)),
+      Xfl3 = c(ranmulti_grp[1, 4], rep(ranmulti_grp[2, 4], 2))
+    )
+  } else {
+    ranicpts <- c(lmm_ranef$sbj[as.character(dat_new_ch$sbj[1]), "(Intercept)"],
+                  rep(ranmulti_sbj[1, 1], 2)) +
+      c(lmm_ranef$grp[as.character(dat_new_ch$grp[1]), "(Intercept)"],
+        rep(ranmulti_grp[1, 1], 2))
+    ranslopes <- list(
+      X1 = c(lmm_ranef$grp[as.character(dat_new_ch$grp[1]), "X1"],
+             rep(ranmulti_grp[1, 2], 2)),
+      X2 = rep(0, 3),
+      Xfl2 = c(lmm_ranef$grp[as.character(dat_new_ch$grp[1]), "Xfl2"],
+               rep(ranmulti_grp[1, 3], 2)),
+      Xfl3 = c(lmm_ranef$grp[as.character(dat_new_ch$grp[1]), "Xfl3"],
+               rep(ranmulti_grp[1, 4], 2))
+    )
+  }
   lpreds_man <- lmm_fixef["(Intercept)"] +
-    c(ranmulti_sbj[1, 1], rep(ranmulti_sbj[2, 1], 2)) +
-    c(ranmulti_grp[1, 1], rep(ranmulti_grp[2, 1], 2)) +
+    ranicpts +
     sapply(seq_len(nrow(dat_new_ch)), function(i) {
       drop(as.matrix(dat_new_ch[i, fixnms_b, drop = FALSE]) %*%
              (lmm_fixef[fixnms_b] + sapply(ranslopes[fixnms_b], "[", i)))
@@ -247,30 +272,55 @@ test_that("repair_re() works for multilevel cumulative() models", {
                    c(nrow(inhaler_new), nlevels(inhaler$rating) - 1L, 1L))
   lpreds <- lpreds[, , 1]
 
+  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+    n_sbj <- length(unique(inhaler_new$sbj))
+    n_grp <- length(unique(inhaler_new$grp))
+  } else {
+    n_sbj <- 1
+    n_grp <- 1
+  }
+
   set.seed(seed3_tst)
   ranmulti_sbj <- mvtnorm::rmvnorm(
-    n = length(unique(inhaler_new$sbj)), sigma = oVarCorr$sbj[, , drop = FALSE],
+    n = n_sbj, sigma = oVarCorr$sbj[, , drop = FALSE],
     checkSymmetry = FALSE
   )
   ranmulti_grp <- mvtnorm::rmvnorm(
-    n = length(unique(inhaler_new$grp)), sigma = oVarCorr$grp[, , drop = FALSE],
+    n = n_grp, sigma = oVarCorr$grp[, , drop = FALSE],
     checkSymmetry = FALSE
   )
-  ranslopes <- list(
-    periodpd1 = c(ranmulti_grp[1, 2], rep(ranmulti_grp[2, 2], 2)),
-    carry = c(ranmulti_grp[1, 3], rep(ranmulti_grp[2, 3], 2)),
-    treat = rep(0, 3)
-  )
+  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+    ranicpts <- c(ranmulti_sbj[1, 1], rep(ranmulti_sbj[2, 1], 2)) +
+      c(ranmulti_grp[1, 1], rep(ranmulti_grp[2, 1], 2))
+    ranslopes <- list(
+      periodpd1 = c(ranmulti_grp[1, 2], rep(ranmulti_grp[2, 2], 2)),
+      carry = c(ranmulti_grp[1, 3], rep(ranmulti_grp[2, 3], 2)),
+      treat = rep(0, 3)
+    )
+  } else {
+    ranicpts <- c(
+      oranef$sbj[as.character(inhaler_new_ch$sbj[1]), "(Intercept)"],
+      rep(ranmulti_sbj[1, 1], 2)
+    ) +
+      c(oranef$grp[as.character(inhaler_new_ch$grp[1]), "(Intercept)"],
+        rep(ranmulti_grp[1, 1], 2))
+    ranslopes <- list(
+      periodpd1 = c(
+        oranef$grp[as.character(inhaler_new_ch$grp[1]), "periodpd1"],
+        rep(ranmulti_grp[1, 2], 2)
+      ),
+      carry = c(oranef$grp[as.character(inhaler_new_ch$grp[1]), "carry"],
+                rep(ranmulti_grp[1, 3], 2)),
+      treat = rep(0, 3)
+    )
+  }
   lpreds_man <- matrix(othres, nrow = nrow(inhaler_new_ch),
                        ncol = length(othres), byrow = TRUE) -
-    (
-      c(ranmulti_sbj[1, 1], rep(ranmulti_sbj[2, 1], 2)) +
-        c(ranmulti_grp[1, 1], rep(ranmulti_grp[2, 1], 2)) +
-        sapply(seq_len(nrow(inhaler_new_ch)), function(i) {
-          drop(as.matrix(inhaler_new_ch[i, fixnms_b, drop = FALSE]) %*%
-                 (ofixef[fixnms_b] + sapply(ranslopes[fixnms_b], "[", i)))
-        })
-    )
+    (ranicpts +
+       sapply(seq_len(nrow(inhaler_new_ch)), function(i) {
+         drop(as.matrix(inhaler_new_ch[i, fixnms_b, drop = FALSE]) %*%
+                (ofixef[fixnms_b] + sapply(ranslopes[fixnms_b], "[", i)))
+       }))
   expect_equal(unname(lpreds), lpreds_man, tolerance = 1e-14)
 
   # Teardown ----------------------------------------------------------------
@@ -527,17 +577,43 @@ test_that(paste(
   expect_identical(dim(lpreds), c(nrow(VA_new), nlats, 1L))
   lpreds <- lpreds[, , 1]
 
+  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+    n_grp <- length(unique(VA_new$grp))
+  } else {
+    n_grp <- 1
+  }
+
   set.seed(seed3_tst)
   ranmulti_grp <- mvtnorm::rmvnorm(
-    n = length(unique(VA_new$grp)), sigma = mVarCorr$grp, checkSymmetry = FALSE
+    n = n_grp, sigma = mVarCorr$grp, checkSymmetry = FALSE
   )
-  ranslopes <- list(
-    treat2 = rbind(
+  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+    ranicpts <- rbind(
+      matrix(ranmulti_grp[1, grep("~1$", colnames(mVarCorr$grp))],
+             nrow = 1L, ncol = nlats, byrow = TRUE),
+      matrix(ranmulti_grp[2, grep("~1$", colnames(mVarCorr$grp))],
+             nrow = nrow(VA_new) - 1L, ncol = nlats, byrow = TRUE)
+    )
+    ranslopes_treat2 <- rbind(
       matrix(ranmulti_grp[1, grep("~treat2$", colnames(mVarCorr$grp))],
              nrow = 1L, ncol = nlats, byrow = TRUE),
       matrix(ranmulti_grp[2, grep("~treat2$", colnames(mVarCorr$grp))],
              nrow = nrow(VA_new) - 1L, ncol = nlats, byrow = TRUE)
-    ),
+    )
+  } else {
+    ranicpts <- rbind(
+      mranef$grp[seq_len(nlats) + (lvl_idx_new1 - 1L) * 2L * nlats, 1],
+      matrix(ranmulti_grp[1, grep("~1$", colnames(mVarCorr$grp))],
+             nrow = nrow(VA_new) - 1L, ncol = nlats, byrow = TRUE)
+    )
+    ranslopes_treat2 <- rbind(
+      mranef$grp[seq_len(nlats) + nlats + (lvl_idx_new1 - 1L) * 2L * nlats, 1],
+      matrix(ranmulti_grp[1, grep("~treat2$", colnames(mVarCorr$grp))],
+             nrow = nrow(VA_new) - 1L, ncol = nlats, byrow = TRUE)
+    )
+  }
+  ranslopes <- list(
+    treat2 = ranslopes_treat2,
     age = matrix(0, nrow = nrow(VA_new), ncol = nlats),
     Karn = matrix(0, nrow = nrow(VA_new), ncol = nlats),
     prior10 = matrix(0, nrow = nrow(VA_new), ncol = nlats)
@@ -545,12 +621,7 @@ test_that(paste(
   lpreds_man <- matrix(mfixef[, "(Intercept)"],
                        nrow = nrow(VA_new_ch),
                        ncol = nlats, byrow = TRUE) +
-    rbind(
-      matrix(ranmulti_grp[1, grep("~1$", colnames(mVarCorr$grp))],
-             nrow = 1L, ncol = nlats, byrow = TRUE),
-      matrix(ranmulti_grp[2, grep("~1$", colnames(mVarCorr$grp))],
-             nrow = nrow(VA_new) - 1L, ncol = nlats, byrow = TRUE)
-    ) +
+    ranicpts +
     do.call(rbind, lapply(seq_len(nrow(VA_new_ch)), function(i) {
       as.matrix(VA_new_ch[i, fixnms_b, drop = FALSE]) %*%
         (t(mfixef[, fixnms_b]) +
@@ -780,20 +851,55 @@ test_that(paste(
   expect_identical(dim(lpreds), c(nrow(VA_new), nlats, 1L))
   lpreds <- lpreds[, , 1]
 
+  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+    n_sbj <- length(unique(VA_new$sbj))
+    n_grp <- length(unique(VA_new$grp))
+  } else {
+    n_sbj <- 1
+    n_grp <- 1
+  }
+
   set.seed(seed3_tst)
   ranmulti_sbj <- mvtnorm::rmvnorm(
-    n = length(unique(VA_new$sbj)), sigma = mVarCorr$sbj, checkSymmetry = FALSE
+    n = n_sbj, sigma = mVarCorr$sbj, checkSymmetry = FALSE
   )
   ranmulti_grp <- mvtnorm::rmvnorm(
-    n = length(unique(VA_new$grp)), sigma = mVarCorr$grp, checkSymmetry = FALSE
+    n = n_grp, sigma = mVarCorr$grp, checkSymmetry = FALSE
   )
-  ranslopes <- list(
-    treat2 = rbind(
+  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+    ranicpts <- rbind(
+      matrix(ranmulti_sbj[1, grep("~1$", colnames(mVarCorr$sbj))],
+             nrow = 1L, ncol = nlats, byrow = TRUE),
+      matrix(ranmulti_sbj[2, grep("~1$", colnames(mVarCorr$sbj))],
+             nrow = nrow(VA_new) - 1L, ncol = nlats, byrow = TRUE)
+    ) +
+      rbind(matrix(ranmulti_grp[1, grep("~1$", colnames(mVarCorr$grp))],
+                   nrow = 1L, ncol = nlats, byrow = TRUE),
+            matrix(ranmulti_grp[2, grep("~1$", colnames(mVarCorr$grp))],
+                   nrow = nrow(VA_new) - 1L, ncol = nlats, byrow = TRUE))
+    ranslopes_treat2 <- rbind(
       matrix(ranmulti_grp[1, grep("~treat2$", colnames(mVarCorr$grp))],
              nrow = 1L, ncol = nlats, byrow = TRUE),
       matrix(ranmulti_grp[2, grep("~treat2$", colnames(mVarCorr$grp))],
              nrow = nrow(VA_new) - 1L, ncol = nlats, byrow = TRUE)
-    ),
+    )
+  } else {
+    ranicpts <- rbind(
+      mranef$sbj[seq_len(nlats) + (lvl_idx_new1_sbj - 1L) * nlats, 1],
+      matrix(ranmulti_sbj[1, grep("~1$", colnames(mVarCorr$sbj))],
+             nrow = nrow(VA_new) - 1L, ncol = nlats, byrow = TRUE)
+    ) +
+      rbind(mranef$grp[seq_len(nlats) + (lvl_idx_new1 - 1L) * 2L * nlats, 1],
+            matrix(ranmulti_grp[1, grep("~1$", colnames(mVarCorr$grp))],
+                   nrow = nrow(VA_new) - 1L, ncol = nlats, byrow = TRUE))
+    ranslopes_treat2 <- rbind(
+      mranef$grp[seq_len(nlats) + nlats + (lvl_idx_new1 - 1L) * 2L * nlats, 1],
+      matrix(ranmulti_grp[1, grep("~treat2$", colnames(mVarCorr$grp))],
+             nrow = nrow(VA_new) - 1L, ncol = nlats, byrow = TRUE)
+    )
+  }
+  ranslopes <- list(
+    treat2 = ranslopes_treat2,
     age = matrix(0, nrow = nrow(VA_new), ncol = nlats),
     Karn = matrix(0, nrow = nrow(VA_new), ncol = nlats),
     prior10 = matrix(0, nrow = nrow(VA_new), ncol = nlats)
@@ -801,18 +907,7 @@ test_that(paste(
   lpreds_man <- matrix(mfixef[, "(Intercept)"],
                        nrow = nrow(VA_new_ch),
                        ncol = nlats, byrow = TRUE) +
-    rbind(
-      matrix(ranmulti_sbj[1, grep("~1$", colnames(mVarCorr$sbj))],
-             nrow = 1L, ncol = nlats, byrow = TRUE),
-      matrix(ranmulti_sbj[2, grep("~1$", colnames(mVarCorr$sbj))],
-             nrow = nrow(VA_new) - 1L, ncol = nlats, byrow = TRUE)
-    ) +
-    rbind(
-      matrix(ranmulti_grp[1, grep("~1$", colnames(mVarCorr$grp))],
-             nrow = 1L, ncol = nlats, byrow = TRUE),
-      matrix(ranmulti_grp[2, grep("~1$", colnames(mVarCorr$grp))],
-             nrow = nrow(VA_new) - 1L, ncol = nlats, byrow = TRUE)
-    ) +
+    ranicpts +
     do.call(rbind, lapply(seq_len(nrow(VA_new_ch)), function(i) {
       as.matrix(VA_new_ch[i, fixnms_b, drop = FALSE]) %*%
         (t(mfixef[, fixnms_b]) +

--- a/tests/testthat/test_proj_predfun.R
+++ b/tests/testthat/test_proj_predfun.R
@@ -112,7 +112,7 @@ test_that("repair_re() works for GLMMs", {
   expect_identical(dim(lpreds), c(nrow(dat_new), 1L))
   lpreds <- lpreds[, 1]
 
-  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+  if (getOption("projpred.mlvl_pred_new", FALSE)) {
     n_sbj <- length(unique(dat_new$sbj))
     n_grp <- length(unique(dat_new$grp))
   } else {
@@ -129,7 +129,7 @@ test_that("repair_re() works for GLMMs", {
     n = n_grp, sigma = lmm_VarCorr$grp[, , drop = FALSE],
     checkSymmetry = FALSE
   )
-  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+  if (getOption("projpred.mlvl_pred_new", FALSE)) {
     ranicpts <- c(ranmulti_sbj[1, 1], rep(ranmulti_sbj[2, 1], 2)) +
       c(ranmulti_grp[1, 1], rep(ranmulti_grp[2, 1], 2))
     ranslopes <- list(
@@ -272,7 +272,7 @@ test_that("repair_re() works for multilevel cumulative() models", {
                    c(nrow(inhaler_new), nlevels(inhaler$rating) - 1L, 1L))
   lpreds <- lpreds[, , 1]
 
-  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+  if (getOption("projpred.mlvl_pred_new", FALSE)) {
     n_sbj <- length(unique(inhaler_new$sbj))
     n_grp <- length(unique(inhaler_new$grp))
   } else {
@@ -289,7 +289,7 @@ test_that("repair_re() works for multilevel cumulative() models", {
     n = n_grp, sigma = oVarCorr$grp[, , drop = FALSE],
     checkSymmetry = FALSE
   )
-  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+  if (getOption("projpred.mlvl_pred_new", FALSE)) {
     ranicpts <- c(ranmulti_sbj[1, 1], rep(ranmulti_sbj[2, 1], 2)) +
       c(ranmulti_grp[1, 1], rep(ranmulti_grp[2, 1], 2))
     ranslopes <- list(
@@ -577,7 +577,7 @@ test_that(paste(
   expect_identical(dim(lpreds), c(nrow(VA_new), nlats, 1L))
   lpreds <- lpreds[, , 1]
 
-  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+  if (getOption("projpred.mlvl_pred_new", FALSE)) {
     n_grp <- length(unique(VA_new$grp))
   } else {
     n_grp <- 1
@@ -587,7 +587,7 @@ test_that(paste(
   ranmulti_grp <- mvtnorm::rmvnorm(
     n = n_grp, sigma = mVarCorr$grp, checkSymmetry = FALSE
   )
-  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+  if (getOption("projpred.mlvl_pred_new", FALSE)) {
     ranicpts <- rbind(
       matrix(ranmulti_grp[1, grep("~1$", colnames(mVarCorr$grp))],
              nrow = 1L, ncol = nlats, byrow = TRUE),
@@ -851,7 +851,7 @@ test_that(paste(
   expect_identical(dim(lpreds), c(nrow(VA_new), nlats, 1L))
   lpreds <- lpreds[, , 1]
 
-  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+  if (getOption("projpred.mlvl_pred_new", FALSE)) {
     n_sbj <- length(unique(VA_new$sbj))
     n_grp <- length(unique(VA_new$grp))
   } else {
@@ -866,7 +866,7 @@ test_that(paste(
   ranmulti_grp <- mvtnorm::rmvnorm(
     n = n_grp, sigma = mVarCorr$grp, checkSymmetry = FALSE
   )
-  if (getOption("projpred.mlvl_prd_new", FALSE)) {
+  if (getOption("projpred.mlvl_pred_new", FALSE)) {
     ranicpts <- rbind(
       matrix(ranmulti_sbj[1, grep("~1$", colnames(mVarCorr$sbj))],
              nrow = 1L, ncol = nlats, byrow = TRUE),

--- a/tests/testthat/test_project.R
+++ b/tests/testthat/test_project.R
@@ -278,6 +278,17 @@ test_that("non-clustered projection does not require a seed", {
                     value = TRUE)
   for (tstsetup in tstsetups) {
     args_prj_i <- args_prj[[tstsetup]]
+    if (args_prj_i$mod_nm %in% c("glmm", "gamm")) {
+      # In this case, the multilevel submodel fitters (fit_glmer_callback(),
+      # fit_gamm_callback(), fit_cumul_mlvl(), fit_categ_mlvl()) should still be
+      # deterministic, but the prediction from the fitted submodels is not
+      # (because of the randomly drawn new group-level effects for existing
+      # group levels).
+      # TODO: Test the multilevel submodel fitters separately (outside of
+      # project()) or compare only the as.matrix.projection() output (but for
+      # Gaussian models, we then need to exclude `sigma` from that matrix).
+      next
+    }
     p_orig <- prjs[[tstsetup]]
     rand_new1 <- runif(1) # Just to advance `.Random.seed[2]`.
     if (args_prj_i$prj_nm == "augdat" && args_prj_i$fam_nm == "cumul" &&

--- a/tests/testthat/test_project.R
+++ b/tests/testthat/test_project.R
@@ -298,30 +298,44 @@ test_that("non-clustered projection does not require a seed", {
     )
     if (args_prj_i$mod_nm %in% c("glmm", "gamm") &&
         any(grepl("\\|", args_prj_i$solution_terms))) {
-      # In this case, the multilevel submodel fitters (fit_glmer_callback(),
-      # fit_gamm_callback(), fit_cumul_mlvl(), fit_categ_mlvl()) should still be
-      # deterministic, but the prediction from the fitted submodels is not
-      # (because of the group-level effects drawn randomly by repair_re() (for
-      # all group levels; here, only the existing ones are relevant)). Thus, we
-      # cannot test the whole project() output, but need to restrict ourselves
-      # to the output of as.matrix.projection().
-      if (args_prj_i$mod_nm == "gamm") {
-        # Skipping GAMMs because of issue #131.
-        # TODO (GAMMs): Fix this.
-        next
+      if (getOption("projpred.mlvl_prd_new", FALSE)) {
+        # In this case, the multilevel submodel fitters (fit_glmer_callback(),
+        # fit_gamm_callback(), fit_cumul_mlvl(), fit_categ_mlvl()) should still
+        # be deterministic, but the prediction from the fitted submodels is not
+        # (because of the group-level effects drawn randomly by repair_re() (for
+        # all group levels; here, only the existing ones are relevant)). Thus,
+        # we cannot test the whole project() output, but need to restrict
+        # ourselves to the output of as.matrix.projection().
+        if (args_prj_i$mod_nm == "gamm") {
+          # Skipping GAMMs because of issue #131.
+          # TODO (GAMMs): Fix this.
+          next
+        }
+        prjmat_orig <- as.matrix(p_orig)
+        prjmat_new <- as.matrix(p_new)
+        if (args_prj_i$fam_nm == "gauss" || args_prj_i$prj_nm == "latent") {
+          # The projected dispersion parameter is affected by the group-level
+          # effects drawn randomly by repair_re() (for all group levels):
+          prjmat_new[, "sigma"] <- prjmat_orig[, "sigma"]
+        }
+        expect_equal(prjmat_new, prjmat_orig, info = tstsetup,
+                     tolerance = .Machine$double.eps)
+        # To facilitate the `if` conditions here:
+        p_new <- p_orig
+      } else if (args_prj_i$prj_nm == "augdat" &&
+                 args_prj_i$fam_nm == "cumul" && args_prj_i$mod_nm == "glmm") {
+        for (idx_s in seq_along(p_new$submodl)) {
+          if (!is.null(p_new$submodl[[idx_s]][["L"]])) {
+            # We could also use `"sparseMatrix"` instead of `"Matrix"`:
+            expect_equal(as(p_new$submodl[[idx_s]][["L"]], "Matrix"),
+                         as(p_orig$submodl[[idx_s]][["L"]], "Matrix"),
+                         info = tstsetup)
+            p_new$submodl[[idx_s]][["L"]] <- p_orig$submodl[[idx_s]][["L"]]
+          }
+        }
       }
-      prjmat_orig <- as.matrix(p_orig)
-      prjmat_new <- as.matrix(p_new)
-      if (args_prj_i$fam_nm == "gauss" || args_prj_i$prj_nm == "latent") {
-        # The projected dispersion parameter is affected by the group-level
-        # effects drawn randomly by repair_re() (for all group levels):
-        prjmat_new[, "sigma"] <- prjmat_orig[, "sigma"]
-      }
-      expect_equal(prjmat_new, prjmat_orig, info = tstsetup,
-                   tolerance = .Machine$double.eps)
-    } else {
-      expect_equal(p_new, p_orig, info = tstsetup)
     }
+    expect_equal(p_new, p_orig, info = tstsetup)
   }
 })
 

--- a/tests/testthat/test_project.R
+++ b/tests/testthat/test_project.R
@@ -298,7 +298,7 @@ test_that("non-clustered projection does not require a seed", {
     )
     if (args_prj_i$mod_nm %in% c("glmm", "gamm") &&
         any(grepl("\\|", args_prj_i$solution_terms))) {
-      if (getOption("projpred.mlvl_prd_new", FALSE)) {
+      if (getOption("projpred.mlvl_pred_new", FALSE)) {
         # In this case, the multilevel submodel fitters (fit_glmer_callback(),
         # fit_gamm_callback(), fit_cumul_mlvl(), fit_categ_mlvl()) should still
         # be deterministic, but the prediction from the fitted submodels is not

--- a/tests/testthat/test_project.R
+++ b/tests/testthat/test_project.R
@@ -305,6 +305,11 @@ test_that("non-clustered projection does not require a seed", {
       # all group levels; here, only the existing ones are relevant)). Thus, we
       # cannot test the whole project() output, but need to restrict ourselves
       # to the output of as.matrix.projection().
+      if (args_prj_i$mod_nm == "gamm") {
+        # Skipping GAMMs because of issue #131.
+        # TODO (GAMMs): Fix this.
+        next
+      }
       prjmat_orig <- as.matrix(p_orig)
       prjmat_new <- as.matrix(p_new)
       if (args_prj_i$fam_nm == "gauss" || args_prj_i$prj_nm == "latent") {

--- a/tests/testthat/test_refmodel.R
+++ b/tests/testthat/test_refmodel.R
@@ -172,15 +172,9 @@ test_that(paste(
         dat_crr$projpred_internal_offs_stanreg <- 0
       }
       y_nm <- stdize_lhs(refmods[[tstsetup]]$formula)$y_nm
-      # Use `ref_predfun_usr` here (instead of `ref_predfun`) to include
-      # offsets and group-level effects for existing group levels:
-      refprd_with_offs_grplvl <- get(
-        "ref_predfun_usr",
-        envir = environment(refmods[[tstsetup]]$ref_predfun)
-      )
-      y_crr_link <- rowMeans(unname(
-        refprd_with_offs_grplvl(fit = refmods[[tstsetup]]$fit,
-                                newdata = dat_crr)
+      y_crr_link <- rowMeans(refmods[[tstsetup]]$ref_predfun(
+        fit = refmods[[tstsetup]]$fit, newdata = dat_crr, excl_offs = FALSE,
+        mlvl_allrandom = FALSE
       ))
     } else {
       y_crr_link <- y_crr

--- a/tests/testthat/test_refmodel.R
+++ b/tests/testthat/test_refmodel.R
@@ -174,7 +174,7 @@ test_that(paste(
       y_nm <- stdize_lhs(refmods[[tstsetup]]$formula)$y_nm
       y_crr_link <- rowMeans(refmods[[tstsetup]]$ref_predfun(
         fit = refmods[[tstsetup]]$fit, newdata = dat_crr, excl_offs = FALSE,
-        mlvl_allrandom = FALSE
+        mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
       ))
     } else {
       y_crr_link <- y_crr

--- a/tests/testthat/test_refmodel.R
+++ b/tests/testthat/test_refmodel.R
@@ -173,13 +173,14 @@ test_that(paste(
       }
       y_nm <- stdize_lhs(refmods[[tstsetup]]$formula)$y_nm
       # Use `ref_predfun_usr` here (instead of `ref_predfun`) to include
-      # offsets:
-      refprd_with_offs <- get(
+      # offsets and group-level effects for existing group levels:
+      refprd_with_offs_grplvl <- get(
         "ref_predfun_usr",
         envir = environment(refmods[[tstsetup]]$ref_predfun)
       )
       y_crr_link <- rowMeans(unname(
-        refprd_with_offs(fit = refmods[[tstsetup]]$fit, newdata = dat_crr)
+        refprd_with_offs_grplvl(fit = refmods[[tstsetup]]$fit,
+                                newdata = dat_crr)
       ))
     } else {
       y_crr_link <- y_crr

--- a/tests/testthat/test_refmodel.R
+++ b/tests/testthat/test_refmodel.R
@@ -174,7 +174,7 @@ test_that(paste(
       y_nm <- stdize_lhs(refmods[[tstsetup]]$formula)$y_nm
       y_crr_link <- rowMeans(refmods[[tstsetup]]$ref_predfun(
         fit = refmods[[tstsetup]]$fit, newdata = dat_crr, excl_offs = FALSE,
-        mlvl_allrandom = getOption("projpred.mlvl_prj_ref_new", FALSE)
+        mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)
       ))
     } else {
       y_crr_link <- y_crr

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -128,7 +128,7 @@ test_that(paste(
           args_ref[[args_vs_i$tstsetup_ref]]$latent_y_unqs
         lvls_crr <- lvls_crr %||% yunqs
         y_oscale_crr <- factor(as.character(y_oscale_crr), levels = lvls_crr,
-                            ordered = is.ordered(y_oscale_crr))
+                               ordered = is.ordered(y_oscale_crr))
       }
       if (prj_crr == "augdat") {
         d_test_crr$y <- y_oscale_crr
@@ -252,7 +252,7 @@ test_that(paste(
           args_ref[[args_vs_i$tstsetup_ref]]$latent_y_unqs
         lvls_crr <- lvls_crr %||% yunqs
         y_oscale_crr <- factor(as.character(y_oscale_crr), levels = lvls_crr,
-                            ordered = is.ordered(y_oscale_crr))
+                               ordered = is.ordered(y_oscale_crr))
       }
       if (prj_crr == "augdat") {
         d_test_crr$y <- y_oscale_crr
@@ -304,79 +304,90 @@ test_that(paste(
 
     ### Summaries for the submodels -------------------------------------------
 
-    if (!is.null(args_vs_i$avoid.increase)) {
-      warn_expected <- NA
-    }
-    # For getting the correct seed in proj_linpred():
-    set.seed(args_vs_i$seed)
-    p_sel_dummy <- .get_refdist(refmods[[tstsetup_ref]],
-                                nclusters = vs_indep$nprjdraws_search)
-    # As soon as GitHub issues #168 and #211 are fixed, we can use `refit_prj =
-    # FALSE` here:
-    expect_warning(
-      pl_indep <- proj_linpred(
-        vs_indep,
-        newdata = dat_indep_crr,
-        offsetnew = d_test_crr$offset,
-        weightsnew = d_test_crr$weights,
-        transform = TRUE,
-        integrated = TRUE,
-        .seed = NA,
-        nterms = c(0L, seq_along(vs_indep$solution_terms)),
-        nclusters = args_vs_i$nclusters_pred,
-        seed = NA
-      ),
-      warn_expected
-    )
-    summ_sub_ch <- lapply(pl_indep, function(pl_indep_k) {
-      names(pl_indep_k)[names(pl_indep_k) == "pred"] <- "mu"
-      names(pl_indep_k)[names(pl_indep_k) == "lpd"] <- "lppd"
-      pl_indep_k$mu <- unname(drop(pl_indep_k$mu))
-      pl_indep_k$lppd <- drop(pl_indep_k$lppd)
-      if (!is.null(refmods[[tstsetup_ref]]$family$cats)) {
-        pl_indep_k$mu <- structure(as.vector(pl_indep_k$mu),
-                                   class = "augvec",
-                                   nobs_orig = nrow(pl_indep_k$mu))
+    if (!(mod_crr %in% c("glmm", "gamm") &&
+          any(grepl("\\|", solution_terms(vs_indep))))) {
+      # In the negation of this case (i.e., multilevel models), proj_linpred()
+      # can't be used to calculate the reference model's performance statistics
+      # because proj_linpred()'s argument `.seed` cannot be set such that the
+      # .Random.seed from inside proj_linpred() at the place where the new
+      # group-level effects are drawn coincides with .Random.seed from inside
+      # varsel() at the place where the new group-level effects are drawn (not
+      # even `.seed = NA` with an appropriate preparation is possible).
+
+      if (!is.null(args_vs_i$avoid.increase)) {
+        warn_expected <- NA
       }
-      return(pl_indep_k)
-    })
-    if (prj_crr == "latent") {
       # For getting the correct seed in proj_linpred():
       set.seed(args_vs_i$seed)
       p_sel_dummy <- .get_refdist(refmods[[tstsetup_ref]],
                                   nclusters = vs_indep$nprjdraws_search)
-      # As soon as GitHub issues #168 and #211 are fixed, we can use `refit_prj
-      # = FALSE` here:
-      dat_indep_crr[[paste0(".", y_nm_crr)]] <- d_test_crr$y
-      pl_indep_lat <- proj_linpred(
-        vs_indep,
-        newdata = dat_indep_crr,
-        offsetnew = d_test_crr$offset,
-        weightsnew = d_test_crr$weights,
-        transform = FALSE,
-        integrated = TRUE,
-        .seed = NA,
-        nterms = c(0L, seq_along(vs_indep$solution_terms)),
-        nclusters = args_vs_i$nclusters_pred,
-        seed = NA
+      # As soon as GitHub issues #168 and #211 are fixed, we can use
+      # `refit_prj = FALSE` here:
+      expect_warning(
+        pl_indep <- proj_linpred(
+          vs_indep,
+          newdata = dat_indep_crr,
+          offsetnew = d_test_crr$offset,
+          weightsnew = d_test_crr$weights,
+          transform = TRUE,
+          integrated = TRUE,
+          .seed = NA,
+          nterms = c(0L, seq_along(vs_indep$solution_terms)),
+          nclusters = args_vs_i$nclusters_pred,
+          seed = NA
+        ),
+        warn_expected
       )
-      y_lat_mat <- matrix(d_test_crr$y, nrow = args_vs_i$nclusters_pred,
-                          ncol = nobsv_indep, byrow = TRUE)
-      summ_sub_ch_lat <- lapply(seq_along(pl_indep_lat), function(k_idx) {
-        pl_indep_k <- pl_indep_lat[[k_idx]]
+      summ_sub_ch <- lapply(pl_indep, function(pl_indep_k) {
         names(pl_indep_k)[names(pl_indep_k) == "pred"] <- "mu"
         names(pl_indep_k)[names(pl_indep_k) == "lpd"] <- "lppd"
         pl_indep_k$mu <- unname(drop(pl_indep_k$mu))
         pl_indep_k$lppd <- drop(pl_indep_k$lppd)
+        if (!is.null(refmods[[tstsetup_ref]]$family$cats)) {
+          pl_indep_k$mu <- structure(as.vector(pl_indep_k$mu),
+                                     class = "augvec",
+                                     nobs_orig = nrow(pl_indep_k$mu))
+        }
         return(pl_indep_k)
       })
-      summ_sub_ch <- lapply(seq_along(summ_sub_ch), function(k_idx) {
-        c(summ_sub_ch_lat[[k_idx]], list("oscale" = summ_sub_ch[[k_idx]]))
-      })
+      if (prj_crr == "latent") {
+        # For getting the correct seed in proj_linpred():
+        set.seed(args_vs_i$seed)
+        p_sel_dummy <- .get_refdist(refmods[[tstsetup_ref]],
+                                    nclusters = vs_indep$nprjdraws_search)
+        # As soon as GitHub issues #168 and #211 are fixed, we can use
+        # `refit_prj = FALSE` here:
+        dat_indep_crr[[paste0(".", y_nm_crr)]] <- d_test_crr$y
+        pl_indep_lat <- proj_linpred(
+          vs_indep,
+          newdata = dat_indep_crr,
+          offsetnew = d_test_crr$offset,
+          weightsnew = d_test_crr$weights,
+          transform = FALSE,
+          integrated = TRUE,
+          .seed = NA,
+          nterms = c(0L, seq_along(vs_indep$solution_terms)),
+          nclusters = args_vs_i$nclusters_pred,
+          seed = NA
+        )
+        y_lat_mat <- matrix(d_test_crr$y, nrow = args_vs_i$nclusters_pred,
+                            ncol = nobsv_indep, byrow = TRUE)
+        summ_sub_ch_lat <- lapply(seq_along(pl_indep_lat), function(k_idx) {
+          pl_indep_k <- pl_indep_lat[[k_idx]]
+          names(pl_indep_k)[names(pl_indep_k) == "pred"] <- "mu"
+          names(pl_indep_k)[names(pl_indep_k) == "lpd"] <- "lppd"
+          pl_indep_k$mu <- unname(drop(pl_indep_k$mu))
+          pl_indep_k$lppd <- drop(pl_indep_k$lppd)
+          return(pl_indep_k)
+        })
+        summ_sub_ch <- lapply(seq_along(summ_sub_ch), function(k_idx) {
+          c(summ_sub_ch_lat[[k_idx]], list("oscale" = summ_sub_ch[[k_idx]]))
+        })
+      }
+      names(summ_sub_ch) <- NULL
+      expect_equal(vs_indep$summaries$sub, summ_sub_ch,
+                   tolerance = .Machine$double.eps, info = tstsetup)
     }
-    names(summ_sub_ch) <- NULL
-    expect_equal(vs_indep$summaries$sub, summ_sub_ch,
-                 tolerance = .Machine$double.eps, info = tstsetup)
 
     ### Summaries for the reference model -------------------------------------
 

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -304,11 +304,13 @@ test_that(paste(
 
     ### Summaries for the submodels -------------------------------------------
 
-    if (!(mod_crr %in% c("glmm", "gamm") &&
+    if (!(getOption("projpred.mlvl_prd_new", FALSE) &&
+          mod_crr %in% c("glmm", "gamm") &&
           any(grepl("\\|", solution_terms(vs_indep))))) {
-      # In the negation of this case (i.e., multilevel models), proj_linpred()
-      # can't be used to calculate the reference model's performance statistics
-      # because proj_linpred()'s argument `.seed` cannot be set such that the
+      # In the negation of this case (i.e., multilevel models with option
+      # `projpred.mlvl_prd_new` being set to `TRUE`), proj_linpred() can't be
+      # used to calculate the reference model's performance statistics because
+      # proj_linpred()'s argument `.seed` cannot be set such that the
       # .Random.seed from inside proj_linpred() at the place where the new
       # group-level effects are drawn coincides with .Random.seed from inside
       # varsel() at the place where the new group-level effects are drawn (not
@@ -391,7 +393,9 @@ test_that(paste(
 
     ### Summaries for the reference model -------------------------------------
 
-    dat_indep_crr$z.1 <- as.factor(paste0("NEW_", dat_indep_crr$z.1))
+    if (getOption("projpred.mlvl_prd_new", FALSE)) {
+      dat_indep_crr$z.1 <- as.factor(paste0("NEW_", dat_indep_crr$z.1))
+    }
     if (pkg_crr == "rstanarm") {
       mu_new <- rstantools::posterior_epred(refmods[[tstsetup_ref]]$fit,
                                             newdata = dat_indep_crr,

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -304,11 +304,11 @@ test_that(paste(
 
     ### Summaries for the submodels -------------------------------------------
 
-    if (!(getOption("projpred.mlvl_prd_new", FALSE) &&
+    if (!(getOption("projpred.mlvl_pred_new", FALSE) &&
           mod_crr %in% c("glmm", "gamm") &&
           any(grepl("\\|", solution_terms(vs_indep))))) {
       # In the negation of this case (i.e., multilevel models with option
-      # `projpred.mlvl_prd_new` being set to `TRUE`), proj_linpred() can't be
+      # `projpred.mlvl_pred_new` being set to `TRUE`), proj_linpred() can't be
       # used to calculate the reference model's performance statistics because
       # proj_linpred()'s argument `.seed` cannot be set such that the
       # .Random.seed from inside proj_linpred() at the place where the new
@@ -393,7 +393,7 @@ test_that(paste(
 
     ### Summaries for the reference model -------------------------------------
 
-    if (getOption("projpred.mlvl_prd_new", FALSE)) {
+    if (getOption("projpred.mlvl_pred_new", FALSE)) {
       dat_indep_crr$z.1 <- as.factor(paste0("NEW_", dat_indep_crr$z.1))
     }
     if (pkg_crr == "rstanarm") {

--- a/vignettes/projpred.Rmd
+++ b/vignettes/projpred.Rmd
@@ -301,7 +301,7 @@ refm_fit <- stan_gamm4(
 )
 ```
 
-In case of multilevel models, **projpred** has two global options that may be relevant for users: `projpred.mlvl_prd_new` and `projpred.mlvl_prj_ref_new`.
+In case of multilevel models, **projpred** has two global options that may be relevant for users: `projpred.mlvl_pred_new` and `projpred.mlvl_proj_ref_new`.
 These are explained in detail in the general package documentation (available [online](https://mc-stan.org/projpred/reference/projpred-package.html) or by typing `` ?`projpred-package` ``).
 
 ## Troubleshooting

--- a/vignettes/projpred.Rmd
+++ b/vignettes/projpred.Rmd
@@ -301,6 +301,9 @@ refm_fit <- stan_gamm4(
 )
 ```
 
+In case of multilevel models, **projpred** has two global options that may be relevant for users: `projpred.mlvl_prd_new` and `projpred.mlvl_prj_ref_new`.
+These are explained in detail in the general package documentation (available [online](https://mc-stan.org/projpred/reference/projpred-package.html) or by typing `` ?`projpred-package` ``).
+
 ## Troubleshooting
 
 Sometimes, the ordering of the predictor terms in the solution path makes sense, but for increasing submodel size, the performance measures of the submodels do not approach that of the reference model. There are different reasons that can explain this behavior (the following list might not be exhaustive, though):


### PR DESCRIPTION
In case of multilevel models, this PR adds two global options for "integrating out" group-level effects: `projpred.mlvl_pred_new` and `projpred.mlvl_proj_ref_new`. These refer to prediction time and projection time, respectively (the latter only affecting the reference model, not the submodels) and are explained in detail in the updated general package documentation (`` ?`projpred-package` ``) from this PR. The defaults for these options are such that the former behavior is retained.

Note that "prediction time" also includes the submodel predictions from `.init_submodel()`, affecting KL divergence (or rather cross-entropy, i.e., output element `ce`) and the projected dispersion parameter values. Because of the latter, a warning is thrown when constructing a `refmodel` object with the final `dis` being not all-`NA`s (except for a few latent-projection cases where such a warning is not necessary).

The integration across the group-level effects is performed by considering existing group-levels from the training data as new group levels and drawing group-level effects randomly for these (for *actually new* group levels, drawing group-level effects randomly has already been done before).