### PR TITLE
Use `extract_y` consistently, fixing bug in `predict.refmodel()` for brms

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 # projpred 2.4.0.9000
 
+## Bug fixes
+
+* Fixed a bug causing `predict.refmodel()` to require `newdata` to contain the response variable in case of a **brms** reference model. This is similar to paul-buerkner/brms#1457, but concerns `predict.refmodel()` (paul-buerkner/brms#1457 referred to predictions from the *submodels*). In order to make this `predict.refmodel()` fix work, **brms** version 2.18.8 or later is needed. (GitHub: #381)
 
 # projpred 2.4.0
 

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -443,15 +443,17 @@ predict.refmodel <- function(object, newdata = NULL, ynew = NULL,
   if (!is.null(newdata)) {
     newdata <- na.fail(newdata)
   }
+  nobs_new <- nrow(newdata %||% object$fetch_data())
   w_o <- object$extract_model_data(object$fit, newdata = newdata,
-                                   wrhs = weightsnew, orhs = offsetnew)
+                                   wrhs = weightsnew, orhs = offsetnew,
+                                   extract_y = FALSE)
   weightsnew <- w_o$weights
   offsetnew <- w_o$offset
   if (length(weightsnew) == 0) {
-    weightsnew <- rep(1, length(w_o$y))
+    weightsnew <- rep(1, nobs_new)
   }
   if (length(offsetnew) == 0) {
-    offsetnew <- rep(0, length(w_o$y))
+    offsetnew <- rep(0, nobs_new)
   }
   if (object$family$for_augdat && !all(weightsnew == 1)) {
     stop("Currently, the augmented-data projection may not be combined with ",
@@ -511,9 +513,7 @@ predict.refmodel <- function(object, newdata = NULL, ynew = NULL,
       }
     }
     if (was_augmat) {
-      pred <- structure(pred,
-                        nobs_orig = nrow(newdata %||% object$fetch_data()),
-                        class = "augvec")
+      pred <- structure(pred, nobs_orig = nobs_new, class = "augvec")
       pred <- augmat2arr(augvec2augmat(pred))
       pred <- matrix(pred, nrow = dim(pred)[1], ncol = dim(pred)[2])
     }
@@ -815,7 +815,8 @@ get_refmodel.stanreg <- function(object, latent = FALSE, dis = NULL, ...) {
 
     # Observation weights are not needed here, so use `wrhs = NULL` to avoid
     # potential conflicts for a non-`NULL` default `wrhs`:
-    offs <- extract_model_data(fit, newdata = newdata, wrhs = NULL)$offset
+    offs <- extract_model_data(fit, newdata = newdata, wrhs = NULL,
+                               extract_y = FALSE)$offset
     n_obs <- nrow(newdata %||% data)
     if (length(offs) == 0) {
       offs <- rep(0, n_obs)
@@ -1147,7 +1148,8 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
       if (excl_offs) {
         # Observation weights are not needed here, so use `wrhs = NULL` to avoid
         # potential conflicts for a non-`NULL` default `wrhs`:
-        offs <- extract_model_data(fit, newdata = newdata, wrhs = NULL)$offset
+        offs <- extract_model_data(fit, newdata = newdata, wrhs = NULL,
+                                   extract_y = FALSE)$offset
         if (length(offs) > 0) {
           stopifnot(length(offs) %in% c(1L, n_obs))
           if (family$family %in% fams_neg_linpred()) {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1237,7 +1237,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
 
   # Data --------------------------------------------------------------------
 
-  model_data <- extract_model_data(object, newdata = data)
+  model_data <- extract_model_data(object, newdata = data, extract_y = TRUE)
   weights <- model_data$weights
   offset <- model_data$offset
   if (family$for_latent) {


### PR DESCRIPTION
This PR ensures that `extract_y = FALSE` in calls of `extract_model_data()` is set consistently, thereby fixing a bug similar to paul-buerkner/brms#1457, but for `predict.refmodel()` (paul-buerkner/brms#1457 referred to predictions from the *submodels*). In order to make this `predict.refmodel()` fix work, brms version 2.18.8 or later is needed.

### Illustration

Running
```r
library(brms)
options(mc.cores = parallel::detectCores())
ref_fit <- brm(
  formula = rate ~ conc*state,
  data = Puromycin,
  backend = "cmdstanr",
  seed = 2052109,
  refresh = 0
)

library(projpred)
ref <- get_refmodel(ref_fit)
Puromycin_new <- expand.grid(conc = quantile(Puromycin$conc, names = FALSE),
                             state = unique(Puromycin$state),
                             KEEP.OUT.ATTRS = FALSE)
prd <- predict(ref, newdata = Puromycin_new)

```
with a projpred version prior to this PR will result in
```
Error: Response variables must be specified in 'newdata'.
Missing variables: 'rate'
```
(no matter whether brms >= 2.18.8 or an earlier version is installed).

In contrast, running the same code with the projpred version from this PR will succeed.