### PR TITLE
Further verbose mode enhancements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 ## Minor changes
 
 * Setting the new global option `projpred.extra_verbose` to `TRUE` will print out which submodel **projpred** is currently projecting onto as well as (if `method = "forward"` and `verbose = TRUE` in `varsel()` or `cv_varsel()`) which submodel has been selected at those steps of the forward search for which a percentage (of the maximum submodel size that the search is run up to) is printed. In general, however, we cannot recommend setting this new global option to `TRUE` for `cv_varsel()` with `cv_method = "LOO"` and `validate_search = TRUE` or for `cv_varsel()` with `cv_method = "kfold"` (simply due to the amount of information that will be printed, but also due to the progress bar which will not work anymore as intended). (GitHub: #363; thanks to @jtimonen)
+* Enhanced `verbose` output. In particular, `varsel()` is now more verbose, similarly to how `cv_varsel()` has already been for a long time. The  `verbose` output for `cv_varsel()` has also been updated, with the aim to give users a better understanding of **projpred**'s internal procedures. (GitHub: #382)
 
 ## Bug fixes
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -189,9 +189,7 @@ cv_varsel.refmodel <- function(
 
   if (validate_search || cv_method == "kfold") {
     ## run the selection using the full dataset
-    if (verbose) {
-      print(paste("Performing the selection using all the data.."))
-    }
+    verb_out("Performing the selection using all the data..", verbose = verbose)
     sel <- varsel(refmodel,
                   method = method, ndraws = ndraws, nclusters = nclusters,
                   ndraws_pred = ndraws_pred, nclusters_pred = nclusters_pred,
@@ -236,9 +234,7 @@ cv_varsel.refmodel <- function(
               nprjdraws_search = sel$nprjdraws_search,
               nprjdraws_eval = sel$nprjdraws_eval)
   class(vs) <- "vsel"
-  if (verbose) {
-    print("Done.")
-  }
+  verb_out("Done.", verbose = verbose)
   return(vs)
 }
 
@@ -427,9 +423,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   if (!validate_search) {
     # Case `validate_search = FALSE` ------------------------------------------
 
-    if (verbose) {
-      print(paste("Performing the selection using all the data.."))
-    }
+    verb_out("Performing the selection using all the data..", verbose = verbose)
     ## perform selection only once using all the data (not separately for each
     ## fold), and perform the projection then for each submodel size
     search_path <- select(
@@ -448,7 +442,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     )
 
     if (verbose) {
-      print(paste("Computing LOO for", nterms_max, "models..."))
+      verb_out("Computing LOO for ", nterms_max, " models...")
       pb <- utils::txtProgressBar(min = 0, max = nterms_max, style = 3,
                                   initial = 0)
     }
@@ -581,8 +575,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     prv_len_soltrms <- NULL
 
     if (verbose) {
-      print(paste("Repeating", sub("^l1$", "L1", method), "search for", nloo,
-                  "LOO folds..."))
+      verb_out("Repeating ", sub("^l1$", "L1", method), " search for ", nloo,
+               " LOO folds...")
       pb <- utils::txtProgressBar(min = 0, max = nloo, style = 3, initial = 0)
     }
 
@@ -815,7 +809,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
 
   # Perform the search for each fold:
   if (verbose) {
-    print("Performing selection for each fold..")
+    verb_out("Performing selection for each fold..")
     pb <- utils::txtProgressBar(min = 0, max = K, style = 3, initial = 0)
   }
   search_path_cv <- lapply(seq_along(list_cv), function(fold_index) {
@@ -842,7 +836,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
   # Re-project along the solution path (or fetch the projections from the search
   # results) for each fold:
   if (verbose && refit_prj) {
-    print("Computing projections..")
+    verb_out("Computing projections..")
     pb <- utils::txtProgressBar(min = 0, max = K, style = 3, initial = 0)
   }
   get_submodels_cv <- function(search_path, fold_index) {
@@ -961,7 +955,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
       # to normal cross-validation for the submodels although we don't have an
       # actual reference model
       if (verbose && !inherits(refmodel, "datafit")) {
-        print("Performing cross-validation for the reference model..")
+        verb_out("Performing cross-validation for the reference model..")
       }
       nobs <- NROW(refmodel$y)
       folds <- cvfolds(nobs, K = K)

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -434,7 +434,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     ## fold), and perform the projection then for each submodel size
     search_path <- select(
       method = method, p_sel = p_sel, refmodel = refmodel,
-      nterms_max = nterms_max, penalty = penalty, verbose = FALSE, opt = opt,
+      nterms_max = nterms_max, penalty = penalty, verbose = verbose, opt = opt,
       search_terms = search_terms, ...
     )
 
@@ -603,8 +603,9 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       ## perform selection with the reweighted clusters/samples
       search_path <- select(
         method = method, p_sel = p_sel, refmodel = refmodel,
-        nterms_max = nterms_max, penalty = penalty, verbose = FALSE, opt = opt,
-        search_terms = search_terms, ...
+        nterms_max = nterms_max, penalty = penalty,
+        verbose = verbose && getOption("projpred.extra_verbose", FALSE),
+        opt = opt, search_terms = search_terms, ...
       )
 
       ## project onto the selected models and compute the prediction accuracy
@@ -822,8 +823,9 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
     p_sel <- .get_refdist(fold$refmodel, ndraws, nclusters)
     out <- select(
       method = method, p_sel = p_sel, refmodel = fold$refmodel,
-      nterms_max = nterms_max, penalty = penalty, verbose = FALSE, opt = opt,
-      search_terms = search_terms, ...
+      nterms_max = nterms_max, penalty = penalty,
+      verbose = verbose && getOption("projpred.extra_verbose", FALSE),
+      opt = opt, search_terms = search_terms, ...
     )
     if (verbose) {
       utils::setTxtProgressBar(pb, fold_index)

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -457,10 +457,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
 
     if (verbose) {
       print(msg)
-      pb <- utils::txtProgressBar(
-        min = 0, max = nterms_max, style = 3,
-        initial = 0
-      )
+      pb <- utils::txtProgressBar(min = 0, max = nterms_max, style = 3,
+                                  initial = 0)
     }
 
     ## compute approximate LOO with PSIS weights

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -424,15 +424,6 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     }
   }
 
-  if (verbose) {
-    if (validate_search) {
-      msg <- paste("Repeating", sub("^l1$", "L1", method), "search for", nloo,
-                   "LOO folds...")
-    } else {
-      msg <- paste("Computing LOO for", nterms_max, "models...")
-    }
-  }
-
   if (!validate_search) {
     # Case `validate_search = FALSE` ------------------------------------------
 
@@ -457,7 +448,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     )
 
     if (verbose) {
-      print(msg)
+      print(paste("Computing LOO for", nterms_max, "models..."))
       pb <- utils::txtProgressBar(min = 0, max = nterms_max, style = 3,
                                   initial = 0)
     }
@@ -590,7 +581,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     prv_len_soltrms <- NULL
 
     if (verbose) {
-      print(msg)
+      print(paste("Repeating", sub("^l1$", "L1", method), "search for", nloo,
+                  "LOO folds..."))
       pb <- utils::txtProgressBar(min = 0, max = nloo, style = 3, initial = 0)
     }
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -426,7 +426,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
 
   if (verbose) {
     if (validate_search) {
-      msg <- paste("Repeating", method, "search for", nloo, "LOO folds...")
+      msg <- paste("Repeating", sub("^l1$", "L1", method), "search for", nloo,
+                   "LOO folds...")
     } else {
       msg <- paste("Computing LOO for", nterms_max, "models...")
     }

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -195,7 +195,7 @@ cv_varsel.refmodel <- function(
                   penalty = penalty, verbose = verbose,
                   lambda_min_ratio = lambda_min_ratio, nlambda = nlambda,
                   regul = regul, search_terms = search_terms_usr, seed = seed,
-                  ...)
+                  called_after_cv = TRUE, ...)
     verb_out("-----", verbose = verbose)
   } else {
     sel <- sel_cv$sel

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1208,8 +1208,10 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
 
   if (is.null(cvfun)) {
     if (!proper_model) {
-      # This is a dummy definition for cvfun(), but it will lead to standard CV
-      # for `datafit`s; see cv_varsel() and .get_kfold():
+      # This is a dummy definition for cvfun(), but the cvrefbuilder() function
+      # defined below will lead to standard CV nonetheless (at least for the
+      # submodels; for the reference model, we don't have an actual reference
+      # model, only a `datafit`):
       cvfun <- function(folds) {
         lapply(seq_len(max(folds)), function(k) list())
       }

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -273,20 +273,26 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
 
   # Run the search:
   opt <- nlist(lambda_min_ratio, nlambda, thresh, regul)
+  verb_out("-----\nRunning the search ...", verbose = verbose)
   search_path <- select(
     method = method, p_sel = p_sel, refmodel = refmodel,
     nterms_max = nterms_max, penalty = penalty, verbose = verbose, opt = opt,
     search_terms = search_terms, ...
   )
+  verb_out("-----", verbose = verbose)
 
   # For the performance evaluation: Re-project along the solution path (or fetch
   # the projections from the search results):
+  verb_out("-----\nFor performance evaluation: Re-projecting onto the ",
+           "submodels along the solution path ...",
+           verbose = verbose && refit_prj)
   submodels <- .get_submodels(
     search_path = search_path,
     nterms = c(0, seq_along(search_path$solution_terms)),
     p_ref = p_pred, refmodel = refmodel, regul = regul, refit_prj = refit_prj,
     ...
   )
+  verb_out("-----", verbose = verbose && refit_prj)
   # The performance evaluation itself, i.e., the calculation of the predictive
   # performance statistic(s) for the submodels along the solution path:
   sub <- .get_sub_summaries(submodels = submodels,

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -273,26 +273,35 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
 
   # Run the search:
   opt <- nlist(lambda_min_ratio, nlambda, thresh, regul)
-  verb_out("-----\nRunning the search ...", verbose = verbose)
+  # A single-liner for the following would be
+  # `calld_aft_cv <- list(...)[["called_after_cv"]] %||% FALSE`
+  # but that would always cause `...` to get evaluated. With the ...names()
+  # check, the ellipsis does not always get evaluated:
+  if ("called_after_cv" %in% ...names()) {
+    calld_aft_cv <- isTRUE(list(...)[["called_after_cv"]])
+  } else {
+    calld_aft_cv <- FALSE
+  }
+  verb_out("-----\nRunning the search ...", verbose = verbose && !calld_aft_cv)
   search_path <- select(
     method = method, p_sel = p_sel, refmodel = refmodel,
     nterms_max = nterms_max, penalty = penalty, verbose = verbose, opt = opt,
     search_terms = search_terms, ...
   )
-  verb_out("-----", verbose = verbose)
+  verb_out("-----", verbose = verbose && !calld_aft_cv)
 
   # For the performance evaluation: Re-project along the solution path (or fetch
   # the projections from the search results):
   verb_out("-----\nFor performance evaluation: Re-projecting onto the ",
            "submodels along the solution path ...",
-           verbose = verbose && refit_prj)
+           verbose = verbose && refit_prj && !calld_aft_cv)
   submodels <- .get_submodels(
     search_path = search_path,
     nterms = c(0, seq_along(search_path$solution_terms)),
     p_ref = p_pred, refmodel = refmodel, regul = regul, refit_prj = refit_prj,
     ...
   )
-  verb_out("-----", verbose = verbose && refit_prj)
+  verb_out("-----", verbose = verbose && refit_prj && !calld_aft_cv)
   # The performance evaluation itself, i.e., the calculation of the predictive
   # performance statistic(s) for the submodels along the solution path:
   sub <- .get_sub_summaries(submodels = submodels,


### PR DESCRIPTION
Building on top of #363, this provides some further enhancements for verbose mode. See the newly added `NEWS.md` entry and the commit messages for details.

The PSIS weighting of the performance evaluation results in the `validate_search = FALSE` case is typically very fast (much faster than re-running the search or the projections along the solution path). Thus, I have now omitted the progress bar there (the previously existing progress bar at that place might have led to confusion).

For testing all possible verbose modes:
```r
options(mc.cores = parallel::detectCores(logical = FALSE))
data("df_gaussian", package = "projpred")
df_gaussian <- df_gaussian[1:41, ]
dat <- data.frame(y = df_gaussian$y, df_gaussian$x)
library(rstanarm)
rfit <- stan_glm(y ~ X1 + X2 + X3 + X4 + X5,
                 data = dat,
                 seed = 1140350788,
                 refresh = 0)

library(projpred)
# Activate or deactivate this, depending on which situation should
# be tested:
options("projpred.extra_verbose" = TRUE)

vs <- varsel(rfit,
             nclusters = 3,
             nclusters_pred = 5,
             nterms_max = 4,
             seed = 46782345)
vs <- varsel(rfit,
             method = "forward",
             nclusters = 3,
             nclusters_pred = 5,
             nterms_max = 4,
             seed = 46782345)
cvvs <- cv_varsel(rfit,
                  validate_search = FALSE,
                  nclusters = 3,
                  nclusters_pred = 5,
                  nterms_max = 12,
                  seed = 46782345)
cvvs <- cv_varsel(rfit,
                  method = "forward",
                  validate_search = FALSE,
                  nclusters = 3,
                  nclusters_pred = 5,
                  nterms_max = 12,
                  seed = 46782345)
cvvs <- cv_varsel(rfit,
                  nclusters = 3,
                  nclusters_pred = 5,
                  nterms_max = 12,
                  seed = 46782345)
cvvs <- cv_varsel(rfit,
                  method = "forward",
                  nclusters = 3,
                  nclusters_pred = 5,
                  nterms_max = 12,
                  seed = 46782345)
cvvs <- cv_varsel(rfit,
                  cv_method = "kfold",
                  K = 2,
                  nclusters = 3,
                  nclusters_pred = 5,
                  nterms_max = 12,
                  seed = 46782345)
cvvs <- cv_varsel(rfit,
                  method = "forward",
                  cv_method = "kfold",
                  K = 2,
                  nclusters = 3,
                  nclusters_pred = 5,
                  nterms_max = 12,
                  seed = 46782345)
prj <- project(rfit,
               solution_terms = paste0("X", 5:2),
               nclusters = 3,
               seed = 46782345)
```