### PR TITLE
Efficiency improvement: Avoid unnecessary re-projections in `cv_varsel()`'s final `varsel()` call

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 * Setting the new global option `projpred.extra_verbose` to `TRUE` will print out which submodel **projpred** is currently projecting onto as well as (if `method = "forward"` and `verbose = TRUE` in `varsel()` or `cv_varsel()`) which submodel has been selected at those steps of the forward search for which a percentage (of the maximum submodel size that the search is run up to) is printed. In general, however, we cannot recommend setting this new global option to `TRUE` for `cv_varsel()` with `cv_method = "LOO"` and `validate_search = TRUE` or for `cv_varsel()` with `cv_method = "kfold"` (simply due to the amount of information that will be printed, but also due to the progress bar which will not work anymore as intended). (GitHub: #363; thanks to @jtimonen)
 * Enhanced `verbose` output. In particular, `varsel()` is now more verbose, similarly to how `cv_varsel()` has already been for a long time. The  `verbose` output for `cv_varsel()` has also been updated, with the aim to give users a better understanding of **projpred**'s internal procedures. (GitHub: #382)
+* Avoided an unnecessary final full-data performance evaluation (including costly re-projections if `refit_prj = TRUE`, which is the default for non-`datafit` reference models) in `cv_varsel()` with `validate_search = TRUE` or `cv_method = "kfold"`. (GitHub: #385)
 
 ## Bug fixes
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -195,7 +195,7 @@ cv_varsel.refmodel <- function(
                   penalty = penalty, verbose = verbose,
                   lambda_min_ratio = lambda_min_ratio, nlambda = nlambda,
                   regul = regul, search_terms = search_terms_usr, seed = seed,
-                  called_after_cv = TRUE, ...)
+                  ...)
     verb_out("-----", verbose = verbose)
   } else {
     sel <- sel_cv$sel

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -166,6 +166,14 @@ cv_varsel.refmodel <- function(
   # Arguments specific to the search:
   opt <- nlist(lambda_min_ratio, nlambda, thresh, regul)
 
+  if (validate_search || cv_method == "kfold") {
+    # Clustering or thinning for the final full-data search (already clustering
+    # or thinning here for consistent PRNG states between the full-data search
+    # in the `validate_search == FALSE` case and the full-data search in the
+    # cases `validate_search || cv_method == "kfold"` we are in here):
+    p_sel <- .get_refdist(refmodel, ndraws, nclusters)
+  }
+
   if (cv_method == "LOO") {
     sel_cv <- loo_varsel(
       refmodel = refmodel, method = method, nterms_max = nterms_max,
@@ -184,8 +192,6 @@ cv_varsel.refmodel <- function(
   }
 
   if (validate_search || cv_method == "kfold") {
-    # Clustering or thinning for the final full-data search:
-    p_sel <- .get_refdist(refmodel, ndraws, nclusters)
     verb_out("-----\nRunning a final search using the full dataset ...",
              verbose = verbose)
     sel <- select(method = method, p_sel = p_sel, refmodel = refmodel,

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -273,35 +273,26 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
 
   # Run the search:
   opt <- nlist(lambda_min_ratio, nlambda, thresh, regul)
-  # A single-liner for the following would be
-  # `calld_aft_cv <- list(...)[["called_after_cv"]] %||% FALSE`
-  # but that would always cause `...` to get evaluated. With the ...names()
-  # check, the ellipsis does not always get evaluated:
-  if ("called_after_cv" %in% ...names()) {
-    calld_aft_cv <- isTRUE(list(...)[["called_after_cv"]])
-  } else {
-    calld_aft_cv <- FALSE
-  }
-  verb_out("-----\nRunning the search ...", verbose = verbose && !calld_aft_cv)
+  verb_out("-----\nRunning the search ...", verbose = verbose)
   search_path <- select(
     method = method, p_sel = p_sel, refmodel = refmodel,
     nterms_max = nterms_max, penalty = penalty, verbose = verbose, opt = opt,
     search_terms = search_terms, ...
   )
-  verb_out("-----", verbose = verbose && !calld_aft_cv)
+  verb_out("-----", verbose = verbose)
 
   # For the performance evaluation: Re-project along the solution path (or fetch
   # the projections from the search results):
   verb_out("-----\nFor performance evaluation: Re-projecting onto the ",
            "submodels along the solution path ...",
-           verbose = verbose && refit_prj && !calld_aft_cv)
+           verbose = verbose && refit_prj)
   submodels <- .get_submodels(
     search_path = search_path,
     nterms = c(0, seq_along(search_path$solution_terms)),
     p_ref = p_pred, refmodel = refmodel, regul = regul, refit_prj = refit_prj,
     ...
   )
-  verb_out("-----", verbose = verbose && refit_prj && !calld_aft_cv)
+  verb_out("-----", verbose = verbose && refit_prj)
   # The performance evaluation itself, i.e., the calculation of the predictive
   # performance statistic(s) for the submodels along the solution path:
   sub <- .get_sub_summaries(submodels = submodels,

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -2228,13 +2228,17 @@ vsel_tester <- function(
   )
 
   # ce
-  expect_type(vs$ce, "double")
-  expect_length(vs$ce, solterms_len_expected + 1)
-  # Expected to be non-increasing for increasing model size:
-  expect_true(all(ifelse(sign(head(vs$ce, -1)) == 1,
-                         tail(vs$ce, -1) <= extra_tol * head(vs$ce, -1),
-                         tail(vs$ce, -1) <= 1 / extra_tol * head(vs$ce, -1))),
-              info = info_str)
+  if (with_cv && (valsearch_expected || cv_method_expected == "kfold")) {
+    expect_identical(vs$ce, rep(NA_real_, solterms_len_expected + 1))
+  } else {
+    expect_type(vs$ce, "double")
+    expect_length(vs$ce, solterms_len_expected + 1)
+    # Expected to be non-increasing for increasing model size:
+    expect_true(all(ifelse(sign(head(vs$ce, -1)) == 1,
+                           tail(vs$ce, -1) <= extra_tol * head(vs$ce, -1),
+                           tail(vs$ce, -1) <= 1 / extra_tol * head(vs$ce, -1))),
+                info = info_str)
+  }
 
   # pct_solution_terms_cv
   if (with_cv) {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1578,7 +1578,7 @@ vsel_nms_pred_opt <- c("solution_terms")
 vsel_nms_cv_nloo <- c("summaries", "pct_solution_terms_cv")
 vsel_nms_cv_nloo_opt <- c("pct_solution_terms_cv")
 # Related to `validate_search`:
-vsel_nms_cv_valsearch <- c("validate_search", "summaries",
+vsel_nms_cv_valsearch <- c("validate_search", "summaries", "ce",
                            "pct_solution_terms_cv")
 vsel_nms_cv_valsearch_opt <- character()
 # Related to `cvfits`:

--- a/tests/testthat/test_augdat.R
+++ b/tests/testthat/test_augdat.R
@@ -524,7 +524,7 @@ test_that(paste(
 
       expect_equal(smmry_pd[, setdiff(names(smmry_pd), "se")],
                    smmry_pd_trad[, setdiff(names(smmry_pd_trad), "se")],
-                   info = tstsetup)
+                   tolerance = tol_smmry, info = tstsetup)
       expect_equal(smmry_pd$se, smmry_pd_trad$se, tolerance = 1e-1,
                    info = tstsetup)
     }


### PR DESCRIPTION
This PR avoids an unnecessary final full-data performance evaluation (including costly re-projections if `refit_prj = TRUE`) in `cv_varsel()` with `validate_search = TRUE` or `cv_method = "kfold"`.

Thereby, a missing argument `thresh` in `cv_varsel()`'s former `varsel()` call is also fixed.

The KL divergence (or rather the (simplified) cross-entropy) values along the full-data solution path are now set to `NA`. Calculating them would indeed require a final full-data performance evaluation (including costly re-projections if `refit_prj = TRUE`), but these `ce` values are not used by projpred anyway and they would not be validated for the search (so will in general be over-optimistic, although the bias should be about the same for all submodels, so model selection might still be possible with them). If these `ce` values are requested by users in the future, we could think about performing such a final full-data performance evaluation conditionally on a new argument by which these `ce` values can be requested. But calculating these by default harms more than it helps.