### PR TITLE
Amend #383

### DIFF
--- a/R/glmfun.R
+++ b/R/glmfun.R
@@ -64,13 +64,12 @@ pseudo_data <- function(f, y, family, offset = rep(0, NROW(f)),
   } else if (family$family %in% c("gaussian", "poisson", "binomial")) {
     # exponential family distributions
     wobs <- (weights * dmu_df^2) / family$variance(mu) # 2* because of deviance
-    if (family$family == "gaussian") {
-      # We can use `dis <- 1` here because in this case, `dis` simply scales and
-      # shifts the deviance (and thus `loss` here):
-      dis <- 1
-    } else {
-      dis <- NULL
-    }
+    # We can use always use `dis <- NULL` here because for the Poisson and the
+    # binomial family, there is no dispersion parameter and for the Gaussian
+    # family, `dis <- NULL` is internally replaced by `dis <- 1` which is ok
+    # here because `dis` simply scales and shifts the deviance (and thus `loss`
+    # here), see issue #200 and PR #383:
+    dis <- NULL
     loss <- 0.5 * sum(family$deviance(mu, y, weights, dis))
     grad <- -wobs * (z - f)
   } else {

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -125,7 +125,7 @@ test_that(paste(
   "`pseudo_data(f = 0, [...], family = extend_family(gaussian()), [...])` is",
   "essentially an identity function (apart from offsets)."
 ), {
-  mu_crr <- matrix(1:12, nrow = 3)
+  mu_crr <- matrix(1:3, ncol = 1)
   wobs_crr <- c(2.5, 6, 4)
   offs_crr <- c(-4.2, 3.5, 1.1)
   psdat <- pseudo_data(


### PR DESCRIPTION
This amends PR #383: It fixes a long-standing misconception in a unit test for `pseudo_data()` and (only for safety in the future) it switches back to relying on `dis <- NULL` in `pseudo_data()`.