### PR TITLE
Pass `digits` of `print.vselsummary()` to `print.data.frame()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Enhanced `verbose` output. In particular, `varsel()` is now more verbose, similarly to how `cv_varsel()` has already been for a long time. The  `verbose` output for `cv_varsel()` has also been updated, with the aim to give users a better understanding of **projpred**'s internal procedures. (GitHub: #382)
 * Avoided an unnecessary final full-data performance evaluation (including costly re-projections if `refit_prj = TRUE`, which is the default for non-`datafit` reference models) in `cv_varsel()` with `validate_search = TRUE` or `cv_method = "kfold"`. (GitHub: #385)
 * Reduced dependencies. (GitHub: #388)
+* Argument `digits` of `print.vselsummary()` is not used for an internal `round()` call anymore, but passed to argument `digits` of `print.data.frame()`, meaning that it now determines the minimum number of *significant digits* to be printed. (GitHub: #389)
 
 ## Bug fixes
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -929,7 +929,7 @@ summary.vsel <- function(
 #' selection.
 #'
 #' @param x An object of class `vselsummary`.
-#' @param digits Passed to argument `digits` of [round()].
+#' @param digits Passed to argument `digits` of [print.data.frame()].
 #' @param ... Currently ignored.
 #'
 #' @return The output of [summary.vsel()] (invisible).
@@ -982,12 +982,7 @@ print.vselsummary <- function(x, digits = 1, ...) {
     scale_string <- ""
   }
   cat("Selection Summary", scale_string, ":\n", sep = "")
-  sel_dfr <- x$selection
-  sel_dfr[sapply(sel_dfr, is.numeric)] <- round(
-    sel_dfr[sapply(sel_dfr, is.numeric)],
-    digits
-  )
-  print(sel_dfr, row.names = FALSE)
+  print(x$selection, digits = digits, row.names = FALSE)
   return(invisible(x))
 }
 

--- a/man/print.vselsummary.Rd
+++ b/man/print.vselsummary.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{x}{An object of class \code{vselsummary}.}
 
-\item{digits}{Passed to argument \code{digits} of \code{\link[=round]{round()}}.}
+\item{digits}{Passed to argument \code{digits} of \code{\link[=print.data.frame]{print.data.frame()}}.}
 
 \item{...}{Currently ignored.}
 }


### PR DESCRIPTION
Using argument `digits` of `print.vselsummary()` for determining the minimum number of significant digits is more natural than using it in `round()`. This is probably also the reason why `print.data.frame()` uses `digits` that way. Thus, this PR switches from using `digits` in `round()` to using it in `print.data.frame()`.

See the commit messages and the newly added `NEWS` entry for details.