### PR TITLE
Always project onto submodels including an intercept

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Avoided an unnecessary final full-data performance evaluation (including costly re-projections if `refit_prj = TRUE`, which is the default for non-`datafit` reference models) in `cv_varsel()` with `validate_search = TRUE` or `cv_method = "kfold"`. (GitHub: #385)
 * Reduced dependencies. (GitHub: #388)
 * Argument `digits` of `print.vselsummary()` is not used for an internal `round()` call anymore, but passed to argument `digits` of `print.data.frame()`, meaning that it now determines the minimum number of *significant digits* to be printed. (GitHub: #389)
+* Although bad practice (in general), a reference model lacking an intercept can now be used within **projpred**. However, it will always be projected onto submodels which *include* an intercept. The reason is that even if the true intercept in the reference model is zero, this does not need to hold for the submodels. An informational message mentioning the projection onto intercept-including submodels is thrown when **projpred** encounters a reference model lacking an intercept. (GitHub: #96, #391)
 
 ## Bug fixes
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -198,7 +198,7 @@ cv_varsel.refmodel <- function(
                   nterms_max = nterms_max, penalty = penalty, verbose = verbose,
                   opt = opt, search_terms = search_terms, ...)
     verb_out("-----", verbose = verbose)
-    ce_out <- rep(NA_real_, length(sel$solution_terms) + refmodel$intercept)
+    ce_out <- rep(NA_real_, length(sel$solution_terms) + 1L)
   } else {
     sel <- sel_cv$sel$search_path
     ce_out <- sel_cv$sel$ce
@@ -403,7 +403,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   inds <- validset$inds
 
   # Initialize objects where to store the results:
-  solution_terms_mat <- matrix(nrow = n, ncol = nterms_max - refmodel$intercept)
+  solution_terms_mat <- matrix(nrow = n, ncol = nterms_max - 1L)
   loo_sub <- replicate(nterms_max, rep(NA, n), simplify = FALSE)
   mu_sub <- replicate(
     nterms_max,

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -237,7 +237,7 @@ cv_varsel.refmodel <- function(
               ce = ce_out,
               solution_terms = sel$solution_terms,
               pct_solution_terms_cv,
-              nterms_all = count_terms_in_formula(refmodel$formula),
+              nterms_all = count_terms_in_formula(refmodel$formula) - 1L,
               nterms_max,
               method,
               cv_method,
@@ -403,10 +403,10 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   inds <- validset$inds
 
   # Initialize objects where to store the results:
-  solution_terms_mat <- matrix(nrow = n, ncol = nterms_max - 1L)
-  loo_sub <- replicate(nterms_max, rep(NA, n), simplify = FALSE)
+  solution_terms_mat <- matrix(nrow = n, ncol = nterms_max)
+  loo_sub <- replicate(nterms_max + 1L, rep(NA, n), simplify = FALSE)
   mu_sub <- replicate(
-    nterms_max,
+    nterms_max + 1L,
     structure(rep(NA, nrow(mu_offs)),
               nobs_orig = attr(mu_offs, "nobs_orig"),
               class = sub("augmat", "augvec", oldClass(mu_offs), fixed = TRUE)),
@@ -419,7 +419,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     # x C) needs special care.
     if (!is.null(refmodel$family$cats)) {
       mu_sub_oscale <- replicate(
-        nterms_max,
+        nterms_max + 1L,
         structure(rep(NA, n * length(refmodel$family$cats)),
                   nobs_orig = n,
                   class = "augvec"),
@@ -658,7 +658,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   # Post-processing ---------------------------------------------------------
 
   # Submodel predictive performance:
-  summ_sub <- lapply(seq_len(nterms_max), function(k) {
+  summ_sub <- lapply(seq_len(nterms_max + 1L), function(k) {
     summ_k <- list(lppd = loo_sub[[k]], mu = mu_sub[[k]], wcv = validset$wcv)
     if (refmodel$family$for_latent) {
       summ_k$oscale <- list(lppd = loo_sub_oscale[[k]], mu = mu_sub_oscale[[k]],

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -640,7 +640,11 @@ fit_cumul <- function(formula, data, family, weights, ...) {
                   "attempt to find suitable starting values failed",
                   sep = "|"),
             attr(fitobj, "condition")$message)) {
-    # Try to fix this automatically by specifying `start` values.
+    # Try to fix this automatically by specifying `start` values (the check for
+    # the intercept being present is just performed to show that *by
+    # construction*, we expect an intercept here; later code might be general
+    # enough to deal with a missing intercept, but that's not the point).
+    stopifnot(attr(terms(formula), "intercept") == 1)
     ncoefs <- count_terms_in_formula(formula) -
       attr(terms(formula), "intercept")
     start_coefs <- rep(0, ncoefs)

--- a/R/formula.R
+++ b/R/formula.R
@@ -686,17 +686,10 @@ to_character_rhs <- function(rhs) {
 ## @param list_of_terms Subset of terms from formula.
 ## @param duplicates if FALSE removes linear terms if their corresponding smooth
 ##   is included. Default TRUE
-## @param add_icpt Only relevant if `length(list_of_terms) == 0`. A single
-##   logical value indicating whether to add the intercept.
-## @return number of terms
-count_terms_chosen <- function(list_of_terms, duplicates = TRUE,
-                               add_icpt = FALSE) {
+## @return number of terms (counting the intercept as a term)
+count_terms_chosen <- function(list_of_terms, duplicates = TRUE) {
   if (length(list_of_terms) == 0) {
-    if (!add_icpt) {
-      return(0)
-    } else {
-      list_of_terms <- "1"
-    }
+    list_of_terms <- "1"
   }
   formula <- make_formula(list_of_terms)
   return(

--- a/R/formula.R
+++ b/R/formula.R
@@ -312,7 +312,7 @@ split_formula <- function(formula, return_group_terms = TRUE, data = NULL,
     )
   }
 
-  ## exclude the intercept if there is no intercept in the reference model
+  ## exclude the intercept if there is no intercept in `formula`
   if (!global_intercept) {
     allterms_nobias <- unlist(lapply(allterms_, function(term) {
       paste0(term, " + 0")
@@ -740,13 +740,6 @@ eval_el2 <- function(formula, data) {
 lhs <- function(x) {
   x <- as.formula(x)
   if (length(x) == 3L) update(x, . ~ 1) else NULL
-}
-
-## remove intercept from formula
-## @param formula a model formula
-## @return the updated formula without intercept
-delete.intercept <- function(formula) {
-  return(update(formula, . ~ . - 1))
 }
 
 ## collapse a list of terms including contrasts

--- a/R/formula.R
+++ b/R/formula.R
@@ -643,8 +643,7 @@ select_possible_terms_size <- function(chosen, terms, size) {
     linear <- terms_new$individual_terms
     dups <- setdiff(linear[!is.na(match(linear, additive))], chosen)
 
-    size_crr <- count_terms_chosen(c(chosen, x), duplicates = TRUE) -
-      length(dups)
+    size_crr <- count_terms_chosen(c(chosen, x)) - length(dups)
     if (size_crr == size) {
       if (length(dups) > 0) {
         tt <- terms(formula(paste("~", x, "-", paste(dups, collapse = "-"))))

--- a/R/methods.R
+++ b/R/methods.R
@@ -1190,7 +1190,7 @@ suggest_size.vsel <- function(
   } else {
     # Above, `object$nterms_max` includes the intercept (if present), so we need
     # to include it here, too:
-    suggested_size <- min(res) + object$refmodel$intercept
+    suggested_size <- min(res) + 1L
     # We don't use `na.rm = TRUE` in min() to be as cautious as possible. In
     # fact, we could refine this to remove `NA`s after the first non-`NA` value
     # (meaning that if there is no non-`NA` value, no `NA`s will be removed),
@@ -1198,7 +1198,7 @@ suggest_size.vsel <- function(
     # possible (because `NA`s after the first non-`NA` value are also strange).
   }
 
-  return(suggested_size - object$refmodel$intercept)
+  return(suggested_size - 1L)
 }
 
 # Make the parameter name(s) for the intercept(s) adhere to the naming scheme

--- a/R/methods.R
+++ b/R/methods.R
@@ -149,8 +149,7 @@ proj_helper <- function(object, newdata, offsetnew, weightsnew, onesub_fun,
       }
       projs <- Filter(
         function(x) {
-          count_terms_chosen(x$solution_terms, add_icpt = TRUE) %in%
-            (filter_nterms + 1)
+          count_terms_chosen(x$solution_terms) %in% (filter_nterms + 1)
         },
         object
       )
@@ -206,7 +205,7 @@ proj_helper <- function(object, newdata, offsetnew, weightsnew, onesub_fun,
   }
 
   names(projs) <- sapply(projs, function(proj) {
-    count_terms_chosen(proj$solution_terms, add_icpt = TRUE)
+    count_terms_chosen(proj$solution_terms)
   })
 
   preds <- lapply(projs, function(proj) {

--- a/R/methods.R
+++ b/R/methods.R
@@ -1188,9 +1188,7 @@ suggest_size.vsel <- function(
       }
     }
   } else {
-    # Above, `object$nterms_max` includes the intercept (if present), so we need
-    # to include it here, too:
-    suggested_size <- min(res) + 1L
+    suggested_size <- min(res)
     # We don't use `na.rm = TRUE` in min() to be as cautious as possible. In
     # fact, we could refine this to remove `NA`s after the first non-`NA` value
     # (meaning that if there is no non-`NA` value, no `NA`s will be removed),
@@ -1198,7 +1196,7 @@ suggest_size.vsel <- function(
     # possible (because `NA`s after the first non-`NA` value are also strange).
   }
 
-  return(suggested_size - 1L)
+  return(suggested_size)
 }
 
 # Make the parameter name(s) for the intercept(s) adhere to the naming scheme

--- a/R/projpred-package.R
+++ b/R/projpred-package.R
@@ -56,7 +56,7 @@
 #' * Submodel with multilevel and additive terms: [gamm4::gamm4()].
 #'
 #' Setting the global option `projpred.extra_verbose` to `TRUE` will print out
-#' which submodel **projpred** is currently projecting onto as well as (if
+#' which submodel \pkg{projpred} is currently projecting onto as well as (if
 #' `method = "forward"` and `verbose = TRUE` in `varsel()` or `cv_varsel()`)
 #' which submodel has been selected at those steps of the forward search for
 #' which a percentage (of the maximum submodel size that the search is run up

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -43,12 +43,13 @@
 #'   CV.
 #' @param formula The full formula to use for the search procedure. For custom
 #'   reference models, this does not necessarily coincide with the reference
-#'   model's formula. For general information on formulas in \R, see
-#'   [`formula`]. For multilevel formulas, see also package \pkg{lme4} (in
-#'   particular, functions [lme4::lmer()] and [lme4::glmer()]). For additive
+#'   model's formula. For general information about formulas in \R, see
+#'   [`formula`]. For information about possible right-hand side (i.e.,
+#'   predictor) terms in `formula` here, see the main vignette and section
+#'   "Formula terms" below. For multilevel formulas, see also package \pkg{lme4}
+#'   (in particular, functions [lme4::lmer()] and [lme4::glmer()]). For additive
 #'   formulas, see also packages \pkg{mgcv} (in particular, function
-#'   [mgcv::gam()]) and \pkg{gamm4} (in particular, function [gamm4::gamm4()])
-#'   as well as the notes in section "Formula terms" below.
+#'   [mgcv::gam()]) and \pkg{gamm4} (in particular, function [gamm4::gamm4()]).
 #' @param ref_predfun Prediction function for the linear predictor of the
 #'   reference model, including offsets (if existing). See also section
 #'   "Arguments `ref_predfun`, `proj_predfun`, and `div_minimizer`" below. If

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -120,6 +120,11 @@
 #'
 #' # Formula terms
 #'
+#' A reference model lacking an intercept can be used, but it will always be
+#' projected onto submodels which *include* an intercept. The reason is that
+#' even if the true intercept in the reference model is zero, this does not need
+#' to hold for the submodels.
+#'
 #' For additive models (still an experimental feature), only [mgcv::s()] and
 #' [mgcv::t2()] are currently supported as smooth terms. Furthermore, these need
 #' to be called without any arguments apart from the predictor names (symbols).

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -120,10 +120,11 @@
 #'
 #' # Formula terms
 #'
-#' A reference model lacking an intercept can be used, but it will always be
-#' projected onto submodels which *include* an intercept. The reason is that
-#' even if the true intercept in the reference model is zero, this does not need
-#' to hold for the submodels.
+#' Although bad practice (in general), a reference model lacking an intercept
+#' can be used within \pkg{projpred}. However, it will always be projected onto
+#' submodels which *include* an intercept. The reason is that even if the true
+#' intercept in the reference model is zero, this does not need to hold for the
+#' submodels.
 #'
 #' For additive models (still an experimental feature), only [mgcv::s()] and
 #' [mgcv::t2()] are currently supported as smooth terms. Furthermore, these need

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -993,9 +993,9 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   if (!as.logical(attr(terms(formula), "intercept"))) {
     # Add an intercept to `formula` so that we always project onto submodels
     # *including* an intercept (see the discussion at #96):
-    message("Adding an intercept to `formula` (which is the full-model ",
-            "formula used for the search) so that the projection is always ",
-            "performed onto submodels *including* an intercept.")
+    message("Adding an intercept to `formula` (the full-model formula used ",
+            "for the search) so that the projection is always performed onto ",
+            "submodels *including* an intercept.")
     formula <- update(formula, . ~ . + 1)
   }
   fml_extractions <- extract_terms_response(formula)

--- a/R/search.R
+++ b/R/search.R
@@ -7,8 +7,7 @@ search_forward <- function(p_ref, refmodel, nterms_max, verbose = TRUE, opt,
   }
 
   chosen <- character()
-  total_terms <- count_terms_chosen(search_terms)
-  stop_search <- min(total_terms, nterms_max_with_icpt)
+  stop_search <- nterms_max_with_icpt
   submodls <- c()
 
   for (size in seq_len(stop_search)) {

--- a/R/search.R
+++ b/R/search.R
@@ -7,10 +7,9 @@ search_forward <- function(p_ref, refmodel, nterms_max, verbose = TRUE, opt,
   }
 
   chosen <- character()
-  stop_search <- nterms_max_with_icpt
   submodls <- c()
 
-  for (size in seq_len(stop_search)) {
+  for (size in seq_len(nterms_max_with_icpt)) {
     cands <- select_possible_terms_size(chosen, search_terms, size = size)
     if (is.null(cands))
       next

--- a/R/search.R
+++ b/R/search.R
@@ -1,13 +1,14 @@
 search_forward <- function(p_ref, refmodel, nterms_max, verbose = TRUE, opt,
                            search_terms, ...) {
-  iq <- ceiling(quantile(seq_len(nterms_max), 1:10 / 10))
+  nterms_max_with_icpt <- nterms_max + 1L
+  iq <- ceiling(quantile(seq_len(nterms_max_with_icpt), 1:10 / 10))
   if (is.null(search_terms)) {
     stop("Did not expect `search_terms` to be `NULL`. Please report this.")
   }
 
   chosen <- character()
   total_terms <- count_terms_chosen(search_terms)
-  stop_search <- min(total_terms, nterms_max)
+  stop_search <- min(total_terms, nterms_max_with_icpt)
   submodls <- c()
 
   for (size in seq_len(stop_search)) {

--- a/R/search.R
+++ b/R/search.R
@@ -149,7 +149,7 @@ search_L1 <- function(p_ref, refmodel, nterms_max, penalty, opt) {
   terms_ <- attr(tt, "term.labels")
   search_path <- search_L1_surrogate(
     p_ref, nlist(x, weights = refmodel$wobs), refmodel$family,
-    refmodel$intercept, ncol(x), penalty, opt
+    intercept = TRUE, ncol(x), penalty, opt
   )
   solution_terms <- collapse_contrasts_solution_path(
     refmodel$formula, colnames(x)[search_path$solution_terms],

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -391,7 +391,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
 select <- function(method, p_sel, refmodel, nterms_max, penalty, verbose, opt,
                    search_terms = NULL, ...) {
   if (method == "l1") {
-    search_path <- search_L1(p_sel, refmodel, nterms_max - refmodel$intercept,
+    search_path <- search_L1(p_sel, refmodel, nterms_max - 1L,
                              penalty, opt)
     search_path$p_sel <- p_sel
     return(search_path)
@@ -467,7 +467,7 @@ parse_args_varsel <- function(refmodel, method, refit_prj, nterms_max,
   if (is.null(nterms_max)) {
     nterms_max <- 19
   }
-  nterms_max <- min(max_nv_possible, nterms_max + refmodel$intercept)
+  nterms_max <- min(max_nv_possible, nterms_max + 1L)
 
   return(nlist(method, refit_prj, nterms_max, nclusters, search_terms))
 }

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -365,7 +365,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
     solution_terms = search_path$solution_terms,
     ce = sapply(submodels, "[[", "ce"),
     nterms_max,
-    nterms_all = count_terms_in_formula(refmodel$formula),
+    nterms_all = count_terms_in_formula(refmodel$formula) - 1L,
     method = method,
     cv_method = NULL,
     validate_search = NULL,
@@ -391,8 +391,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
 select <- function(method, p_sel, refmodel, nterms_max, penalty, verbose, opt,
                    search_terms = NULL, ...) {
   if (method == "l1") {
-    search_path <- search_L1(p_sel, refmodel, nterms_max - 1L,
-                             penalty, opt)
+    search_path <- search_L1(p_sel, refmodel, nterms_max, penalty, opt)
     search_path$p_sel <- p_sel
     return(search_path)
   } else if (method == "forward") {
@@ -463,11 +462,13 @@ parse_args_varsel <- function(refmodel, method, refit_prj, nterms_max,
   search_terms_unq <- unique(unlist(
     strsplit(search_terms, split = "+", fixed = TRUE)
   ))
-  max_nv_possible <- count_terms_chosen(search_terms_unq, duplicates = TRUE)
+  max_nv_possible <- count_terms_chosen(
+    search_terms_unq, duplicates = TRUE
+  ) - 1L
   if (is.null(nterms_max)) {
     nterms_max <- 19
   }
-  nterms_max <- min(max_nv_possible, nterms_max + 1L)
+  nterms_max <- min(max_nv_possible, nterms_max)
 
   return(nlist(method, refit_prj, nterms_max, nclusters, search_terms))
 }

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -462,9 +462,7 @@ parse_args_varsel <- function(refmodel, method, refit_prj, nterms_max,
   search_terms_unq <- unique(unlist(
     strsplit(search_terms, split = "+", fixed = TRUE)
   ))
-  max_nv_possible <- count_terms_chosen(
-    search_terms_unq, duplicates = TRUE
-  ) - 1L
+  max_nv_possible <- count_terms_chosen(search_terms_unq) - 1L
   if (is.null(nterms_max)) {
     nterms_max <- 19
   }

--- a/man/projpred-package.Rd
+++ b/man/projpred-package.Rd
@@ -57,7 +57,7 @@ families.
 }
 
 Setting the global option \code{projpred.extra_verbose} to \code{TRUE} will print out
-which submodel \strong{projpred} is currently projecting onto as well as (if
+which submodel \pkg{projpred} is currently projecting onto as well as (if
 \code{method = "forward"} and \code{verbose = TRUE} in \code{varsel()} or \code{cv_varsel()})
 which submodel has been selected at those steps of the forward search for
 which a percentage (of the maximum submodel size that the search is run up

--- a/man/refmodel-init-get.Rd
+++ b/man/refmodel-init-get.Rd
@@ -54,12 +54,13 @@ arguments passed to \code{\link[=extend_family]{extend_family()}} (apart from \c
 
 \item{formula}{The full formula to use for the search procedure. For custom
 reference models, this does not necessarily coincide with the reference
-model's formula. For general information on formulas in \R, see
-\code{\link{formula}}. For multilevel formulas, see also package \pkg{lme4} (in
-particular, functions \code{\link[lme4:lmer]{lme4::lmer()}} and \code{\link[lme4:glmer]{lme4::glmer()}}). For additive
+model's formula. For general information about formulas in \R, see
+\code{\link{formula}}. For information about possible right-hand side (i.e.,
+predictor) terms in \code{formula} here, see the main vignette and section
+"Formula terms" below. For multilevel formulas, see also package \pkg{lme4}
+(in particular, functions \code{\link[lme4:lmer]{lme4::lmer()}} and \code{\link[lme4:glmer]{lme4::glmer()}}). For additive
 formulas, see also packages \pkg{mgcv} (in particular, function
-\code{\link[mgcv:gam]{mgcv::gam()}}) and \pkg{gamm4} (in particular, function \code{\link[gamm4:gamm4]{gamm4::gamm4()}})
-as well as the notes in section "Formula terms" below.}
+\code{\link[mgcv:gam]{mgcv::gam()}}) and \pkg{gamm4} (in particular, function \code{\link[gamm4:gamm4]{gamm4::gamm4()}}).}
 
 \item{family}{An object of class \code{family} representing the observation model
 (i.e., the distributional family for the response) of the \emph{submodels}.

--- a/man/refmodel-init-get.Rd
+++ b/man/refmodel-init-get.Rd
@@ -175,10 +175,11 @@ Some arguments are for \eqn{K}-fold cross-validation (\eqn{K}-fold CV) only;
 see \code{\link[=cv_varsel]{cv_varsel()}} for the use of \eqn{K}-fold CV in \pkg{projpred}.
 }
 \section{Formula terms}{
-A reference model lacking an intercept can be used, but it will always be
-projected onto submodels which \emph{include} an intercept. The reason is that
-even if the true intercept in the reference model is zero, this does not need
-to hold for the submodels.
+Although bad practice (in general), a reference model lacking an intercept
+can be used within \pkg{projpred}. However, it will always be projected onto
+submodels which \emph{include} an intercept. The reason is that even if the true
+intercept in the reference model is zero, this does not need to hold for the
+submodels.
 
 For additive models (still an experimental feature), only \code{\link[mgcv:s]{mgcv::s()}} and
 \code{\link[mgcv:t2]{mgcv::t2()}} are currently supported as smooth terms. Furthermore, these need

--- a/man/refmodel-init-get.Rd
+++ b/man/refmodel-init-get.Rd
@@ -175,6 +175,11 @@ Some arguments are for \eqn{K}-fold cross-validation (\eqn{K}-fold CV) only;
 see \code{\link[=cv_varsel]{cv_varsel()}} for the use of \eqn{K}-fold CV in \pkg{projpred}.
 }
 \section{Formula terms}{
+A reference model lacking an intercept can be used, but it will always be
+projected onto submodels which \emph{include} an intercept. The reason is that
+even if the true intercept in the reference model is zero, this does not need
+to hold for the submodels.
+
 For additive models (still an experimental feature), only \code{\link[mgcv:s]{mgcv::s()}} and
 \code{\link[mgcv:t2]{mgcv::t2()}} are currently supported as smooth terms. Furthermore, these need
 to be called without any arguments apart from the predictor names (symbols).

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -2270,14 +2270,15 @@ vsel_tester <- function(
   }
 
   # nterms_max
-  nterms_max_expected <- solterms_len_expected + 1
+  nterms_max_expected <- solterms_len_expected
   if (search_trms_empty_size) {
     nterms_max_expected <- nterms_max_expected + 1
   }
   expect_equal(vs$nterms_max, nterms_max_expected, info = info_str)
 
   # nterms_all
-  expect_identical(vs$nterms_all, count_terms_in_formula(vs$refmodel$formula),
+  expect_identical(vs$nterms_all,
+                   count_terms_in_formula(vs$refmodel$formula) - 1L,
                    info = info_str)
 
   # method
@@ -2359,10 +2360,8 @@ smmry_tester <- function(smmry, vsel_expected, nterms_max_expected = NULL,
                    info = info_str)
   expect_identical(smmry$nobs_test, nrow(vsel_expected$d_test$data),
                    info = info_str)
-  # In summary.vsel(), `nterms_max` and output element `nterms` do not count the
-  # intercept (whereas `vsel_expected$nterms_max` does):
   if (is.null(nterms_max_expected)) {
-    nterms_ch <- vsel_expected$nterms_max - 1
+    nterms_ch <- vsel_expected$nterms_max
   } else {
     nterms_ch <- nterms_max_expected
   }

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -350,9 +350,8 @@ refmodel_tester <- function(
   # Test the general structure of the object:
   refmod_nms <- c(
     "fit", "formula", "div_minimizer", "family", "eta", "mu", "mu_offs", "dis",
-    "y", "intercept", "proj_predfun", "fetch_data", "wobs", "wsample", "offset",
-    "cvfun", "cvfits", "extract_model_data", "ref_predfun", "cvrefbuilder",
-    "y_oscale"
+    "y", "proj_predfun", "fetch_data", "wobs", "wsample", "offset", "cvfun",
+    "cvfits", "extract_model_data", "ref_predfun", "cvrefbuilder", "y_oscale"
   )
   refmod_class_expected <- "refmodel"
   if (is_datafit) {
@@ -597,13 +596,6 @@ refmodel_tester <- function(
     }
   }
   expect_identical(refmod$y, y_expected, info = info_str)
-
-  # intercept
-  expect_type(refmod$intercept, "logical")
-  expect_length(refmod$intercept, 1)
-  expect_false(is.na(refmod$intercept), info = info_str)
-  # As long as models without an intercept are not supported by projpred:
-  expect_true(refmod$intercept, info = info_str)
 
   # proj_predfun
   expect_type(refmod$proj_predfun, "closure")
@@ -1545,7 +1537,7 @@ projection_tester <- function(p,
   # submodl
   sub_trms_crr <- p$solution_terms
   if (length(sub_trms_crr) == 0) {
-    sub_trms_crr <- as.character(as.numeric(p$refmodel$intercept))
+    sub_trms_crr <- "1"
   }
   if (!from_vsel_L1_search) {
     y_nm <- as.character(p$refmodel$formula)[2]
@@ -1965,8 +1957,7 @@ vsel_tester <- function(
   } else {
     wobs_expected_crr <- vs$refmodel$wobs
   }
-  solterms_for_sub <- c(as.character(as.numeric(vs$refmodel$intercept)),
-                        vs$solution_terms)
+  solterms_for_sub <- c("1", vs$solution_terms)
   for (i in seq_along(vs$search_path$submodls)) {
     sub_trms_crr <- head(solterms_for_sub, i)
     if (length(sub_trms_crr) > 1) {
@@ -2370,8 +2361,7 @@ smmry_tester <- function(smmry, vsel_expected, nterms_max_expected = NULL,
     # size (see issue #307):
     nterms_ch <- nterms_ch - 1
   }
-  expect_identical(smmry$nterms, nterms_ch,
-                   info = info_str)
+  expect_equal(smmry$nterms, nterms_ch, info = info_str)
   expect_true(smmry$search_included %in% c("search included",
                                            "search not included"),
               info = info_str)

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -1536,8 +1536,8 @@ projection_tester <- function(p,
   if (is.numeric(solterms_expected)) {
     expect_length(p$solution_terms, solterms_expected)
     # Same check, but using count_terms_chosen():
-    expect_equal(count_terms_chosen(p$solution_terms, add_icpt = TRUE),
-                 solterms_expected + 1, info = info_str)
+    expect_equal(count_terms_chosen(p$solution_terms), solterms_expected + 1,
+                 info = info_str)
   } else if (is.character(solterms_expected)) {
     expect_identical(p$solution_terms, solterms_expected, info = info_str)
   }

--- a/tests/testthat/test_methods_vsel.R
+++ b/tests/testthat/test_methods_vsel.R
@@ -314,12 +314,14 @@ test_that("`stat` works", {
       suggsize <- suppressWarnings(
         suggest_size(vss[[tstsetup_vs]], stat = stat_crr, seed = suggsize_seed)
       )
-      expect_true(is.vector(suggsize, "numeric"),
-                  info = paste(tstsetup, stat_crr, sep = "__"))
       expect_length(suggsize, 1)
       if (!is.na(suggsize)) {
+        expect_true(is.vector(suggsize, "numeric"),
+                    info = paste(tstsetup, stat_crr, sep = "__"))
         expect_true(suggsize >= 0, info = paste(tstsetup, stat_crr, sep = "__"))
       } else {
+        expect_identical(suggsize, NA,
+                         info = paste(tstsetup, stat_crr, sep = "__"))
         expect_true(
           vss[[tstsetup_vs]]$nterms_max < vss[[tstsetup_vs]]$nterms_all,
           info = paste(tstsetup, stat_crr, sep = "__")

--- a/tests/testthat/test_refmodel.R
+++ b/tests/testthat/test_refmodel.R
@@ -100,8 +100,8 @@ test_that("offsets specified via argument `offset` work", {
     tolerance = 1e-12,
     info = "rstanarm.glm.gauss.stdformul.with_wobs.with_offs"
   )
-  nms_compare <- c("eta", "mu", "mu_offs", "dis", "y", "intercept", "wobs",
-                   "wsample", "offset", "y_oscale")
+  nms_compare <- c("eta", "mu", "mu_offs", "dis", "y", "wobs", "wsample",
+                   "offset", "y_oscale")
   expect_equal(
     refmod_offs_arg[nms_compare],
     refmods$rstanarm.glm.gauss.stdformul.with_wobs.with_offs[nms_compare],

--- a/tests/testthat/test_refmodel.R
+++ b/tests/testthat/test_refmodel.R
@@ -130,12 +130,12 @@ test_that("offsets specified via argument `offset` work", {
     tolerance = 1e-12,
     info = "rstanarm.glm.gauss.stdformul.with_wobs.with_offs"
   )
-  nms_compare <- c("eta", "mu", "mu_offs", "dis", "y", "wobs", "wsample",
-                   "offset", "y_oscale")
+  nms_compare <- c("div_minimizer", "eta", "mu", "mu_offs", "dis", "y",
+                   "proj_predfun", "wobs", "wsample", "offset", "y_oscale")
   expect_equal(
     refmod_offs_arg[nms_compare],
     refmods$rstanarm.glm.gauss.stdformul.with_wobs.with_offs[nms_compare],
-    tolerance = 1e-12,
+    tolerance = .Machine$double.eps,
     info = "rstanarm.glm.gauss.stdformul.with_wobs.with_offs"
   )
 })


### PR DESCRIPTION
This fixes #96 by always projecting onto submodels including an intercept, even for reference models which lack an intercept (which are eventually made possible by this PR).

Several simplifications and some other enhancements are also performed, e.g., in commit 1fa4374d023506b00be4ff6d12bac98b8017f5f9.

See the commit messages and the newly added `NEWS.md` entry for details.