### PR TITLE
Error in case of non-predictor arguments of `s()` or `t2()`

### DIFF
--- a/R/formula.R
+++ b/R/formula.R
@@ -97,13 +97,13 @@ extract_response <- function(response) {
 ## @param terms list of terms to parse
 ## @return a vector of smooth terms
 parse_additive_terms <- function(terms) {
-  excluded_terms <- c("te")
+  excluded_terms <- c("te", "ti")
   smooth_terms <- c("s", "t2")
   excluded <- unlist(sapply(excluded_terms, function(et) {
     grep(make_function_regexp(et), terms)
   }))
   if (sum(excluded) > 0) {
-    stop("te terms are not supported, please use t2 instead.")
+    stop("te() and ti() terms are not supported, please use t2() instead.")
   }
   smooth <- unname(unlist(sapply(smooth_terms, function(et) {
     terms[grep(make_function_regexp(et), terms)]

--- a/R/formula.R
+++ b/R/formula.R
@@ -105,9 +105,9 @@ parse_additive_terms <- function(terms) {
   if (any(excluded)) {
     stop("te() and ti() terms are not supported, please use t2() instead.")
   }
-  smooth <- unname(unlist(sapply(smooth_terms, function(et) {
-    grep(make_function_regexp(et), terms, value = TRUE)
-  })))
+  smooth <- unlist(lapply(smooth_terms, function(st) {
+    grep(make_function_regexp(st), terms, value = TRUE)
+  }))
   if (any(grepl("\\(.+,.+=.+\\)", smooth))) {
     stop("In s() and t2() terms, arguments other than predictors are not ",
          "allowed.")

--- a/R/formula.R
+++ b/R/formula.R
@@ -99,10 +99,10 @@ extract_response <- function(response) {
 parse_additive_terms <- function(terms) {
   excluded_terms <- c("te", "ti")
   smooth_terms <- c("s", "t2")
-  excluded <- unlist(sapply(excluded_terms, function(et) {
-    grep(make_function_regexp(et), terms)
-  }))
-  if (sum(excluded) > 0) {
+  excluded <- sapply(excluded_terms, function(et) {
+    any(grepl(make_function_regexp(et), terms))
+  })
+  if (any(excluded)) {
     stop("te() and ti() terms are not supported, please use t2() instead.")
   }
   smooth <- unname(unlist(sapply(smooth_terms, function(et) {

--- a/R/formula.R
+++ b/R/formula.R
@@ -106,7 +106,7 @@ parse_additive_terms <- function(terms) {
     stop("te() and ti() terms are not supported, please use t2() instead.")
   }
   smooth <- unname(unlist(sapply(smooth_terms, function(et) {
-    terms[grep(make_function_regexp(et), terms)]
+    grep(make_function_regexp(et), terms, value = TRUE)
   })))
   return(smooth)
 }

--- a/R/formula.R
+++ b/R/formula.R
@@ -108,6 +108,10 @@ parse_additive_terms <- function(terms) {
   smooth <- unname(unlist(sapply(smooth_terms, function(et) {
     grep(make_function_regexp(et), terms, value = TRUE)
   })))
+  if (any(grepl("\\(.+,.+=.+\\)", smooth))) {
+    stop("In s() and t2() terms, arguments other than predictors are not ",
+         "allowed.")
+  }
   return(smooth)
 }
 


### PR DESCRIPTION
This is a follow-up for #269 (which was based on [this comment](https://github.com/stan-dev/projpred/issues/156#issuecomment-949656410) and the discussion following it in issue #156). PR #269 was only concerned with *documenting* that in `s()` and `t2()` terms, arguments other than predictors are not allowed. Here, we also throw an appropriate *error message*. However, this still does not address #238 yet (but at least we now throw an appropriate error message).