### PR TITLE
Warn if L1 search selects an interaction before main effects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Reduced dependencies. (GitHub: #388)
 * Argument `digits` of `print.vselsummary()` is not used for an internal `round()` call anymore, but passed to argument `digits` of `print.data.frame()`, meaning that it now determines the minimum number of *significant digits* to be printed. (GitHub: #389)
 * Although bad practice (in general), a reference model lacking an intercept can now be used within **projpred**. However, it will always be projected onto submodels which *include* an intercept. The reason is that even if the true intercept in the reference model is zero, this does not need to hold for the submodels. An informational message mentioning the projection onto intercept-including submodels is thrown when **projpred** encounters a reference model lacking an intercept. (GitHub: #96, #391)
+* L1 search now throws a warning if an interaction term is selected before all involved main effects have been selected. (GitHub: #395)
 
 ## Bug fixes
 

--- a/R/search.R
+++ b/R/search.R
@@ -191,6 +191,20 @@ search_L1 <- function(p_ref, refmodel, nterms_max, penalty, opt) {
     class(sub) <- "subfit"
     return(list(sub))
   })
-  return(list(solution_terms = solution_terms[seq_len(nterms_max)],
-              submodls = submodls[seq_len(nterms_max + 1)]))
+  solution_terms <- solution_terms[seq_len(nterms_max)]
+  submodls <- submodls[seq_len(nterms_max + 1)]
+
+  # Check for interaction terms being selected before all involved main effects
+  # have been selected (and throw a warning if that is the case):
+  ia_sel_bef_main <- sapply(grep(":", solution_terms), function(idx_ia) {
+    term_split <- strsplit(solution_terms[idx_ia], ":")[[1]]
+    !all(term_split %in% utils::head(solution_terms, idx_ia - 1L))
+  })
+  if (any(ia_sel_bef_main)) {
+    warning("An interaction has been selected before all involved main ",
+            "effects have been selected. This is a known deficiency of L1 ",
+            "search. Use forward search to avoid this.")
+  }
+
+  return(nlist(solution_terms, submodls))
 }

--- a/R/search.R
+++ b/R/search.R
@@ -200,7 +200,8 @@ search_L1 <- function(p_ref, refmodel, nterms_max, penalty, opt) {
     term_split <- strsplit(solution_terms[idx_ia], ":")[[1]]
     !all(term_split %in% utils::head(solution_terms, idx_ia - 1L))
   })
-  if (any(ia_sel_bef_main)) {
+  if (any(ia_sel_bef_main) &&
+      getOption("projpred.warn_L1_interactions", TRUE)) {
     warning("An interaction has been selected before all involved main ",
             "effects have been selected. This is a known deficiency of L1 ",
             "search. Use forward search to avoid this.")

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -815,6 +815,9 @@ meth_tst <- list(
   L1 = list(method = "L1"),
   forward = list(method = "forward")
 )
+# Suppress the warning for interaction terms being selected before all involved
+# main effects have been selected (only concerns L1 search):
+options(projpred.warn_L1_interactions = FALSE)
 
 search_trms_tst <- list(
   default_search_trms = list(),

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -917,6 +917,7 @@ test_that(paste(
   "L1 search warns if an interaction term is selected before all involved",
   "main effects have been selected"
 ), {
+  warn_L1_ia_orig <- options(projpred.warn_L1_interactions = TRUE)
   args_fit_i <- args_fit$rstanarm.glm.gauss.stdformul.with_wobs.with_offs
   skip_if_not(!is.null(args_fit_i))
   fit_fun_nm <- switch(args_fit_i$pkg_nm,
@@ -946,6 +947,7 @@ test_that(paste(
   idxs_main <- match(soltrms_ia_main, soltrms_all)
   expect_true(any(idx_ia < idxs_main),
               info = "rstanarm.glm.gauss.stdformul.with_wobs.with_offs")
+  options(warn_L1_ia_orig)
 })
 
 # cv_varsel() -------------------------------------------------------------


### PR DESCRIPTION
This addresses #190 further (in addition to commit https://github.com/fweber144/projpred/commit/abe2f482d2c801e5b4271853164d8b6539ad58fa from PR #233 which only addressed the documentation) in that we now throw a warning if an interaction term is selected before all involved main effects have been selected.