### PR TITLE
Fix R-devel issue

### DIFF
--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -59,7 +59,7 @@ extfam_tester <- function(extfam,
         fam_orig_nms <- c(fam_orig_nms, "simulate")
       }
     }
-    expect_named(fam_orig, fam_orig_nms, info = info_str)
+    expect_true(all(fam_orig_nms %in% names(fam_orig)), info = info_str)
   }
 
   ## For `extfam` -----------------------------------------------------------
@@ -94,13 +94,7 @@ extfam_tester <- function(extfam,
   }
   extfam_nms_add <- c(extfam_nms_add, extfam_nms_add2)
   extfam_nms <- c(fam_orig_nms, extfam_nms_add)
-  if (fam_orig$family %in% bfam_nms) {
-    expect_true(all(extfam_nms %in% names(extfam)), info = info_str)
-  } else {
-    expect_named(extfam, extfam_nms,
-                 ignore.order = extfam$for_augdat || extfam$for_latent,
-                 info = info_str)
-  }
+  expect_true(all(extfam_nms %in% names(extfam)), info = info_str)
 
   # Detailed tests ----------------------------------------------------------
 

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -922,6 +922,7 @@ test_that(paste(
   "L1 search warns if an interaction term is selected before all involved",
   "main effects have been selected"
 ), {
+  skip_if_not(run_vs)
   warn_L1_ia_orig <- options(projpred.warn_L1_interactions = TRUE)
   args_fit_i <- args_fit$rstanarm.glm.gauss.stdformul.with_wobs.with_offs
   skip_if_not(!is.null(args_fit_i))


### PR DESCRIPTION
This fixes #398. Commit c1a304bcffb0d7490d2fabd7c625b851ee88a6f8 fixes an issue in the tests that is not related to the development version of R (it only came up in the win-builder run on R-devel).