### PR TITLE
Quick fix for #211

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,7 +32,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Fixed a bug causing `predict.refmodel()` to require `newdata` to contain the response variable in case of a **brms** reference model. This is similar to paul-buerkner/brms#1457, but concerns `predict.refmodel()` (paul-buerkner/brms#1457 referred to predictions from the *submodels*). In order to make this `predict.refmodel()` fix work, **brms** version 2.19.0 or later is needed. (GitHub: #381)
 * Slightly improved the calculation of predictive variances to make them less prone to numerical inaccuracies. (GitHub: #199)
 * In case of the `brms::categorical()` family, strip underscores from response category names in `as.matrix.projection()` output, as done by **brms**. (GitHub: #394)
-* Fixed #211, a bug causing output element `p_type` of `project()` to be incorrect in case of `refit_prj = FALSE`, `!is.null(nclusters)`, and an `object` of class `vsel` that was created with a non-clustered (thinned) projection during the search phase. (GitHub: #401)
+* Fixed #211, a bug causing output element `p_type` of `project()` to be incorrect in case of `refit_prj = FALSE`, `!is.null(nclusters)`, and an `object` of class `vsel` that was created with a non-clustered (thinned) projection during the search phase. The fix comes with a slightly different behavior of `proj_predict()` for `datafit`s: It will not draw `nresample_clusters` times from the posterior-projection predictive distribution (which is based on the same single projected draw), but only once. (GitHub: #401)
 
 # projpred 2.4.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Fixed a bug causing `predict.refmodel()` to require `newdata` to contain the response variable in case of a **brms** reference model. This is similar to paul-buerkner/brms#1457, but concerns `predict.refmodel()` (paul-buerkner/brms#1457 referred to predictions from the *submodels*). In order to make this `predict.refmodel()` fix work, **brms** version 2.19.0 or later is needed. (GitHub: #381)
 * Slightly improved the calculation of predictive variances to make them less prone to numerical inaccuracies. (GitHub: #199)
 * In case of the `brms::categorical()` family, strip underscores from response category names in `as.matrix.projection()` output, as done by **brms**. (GitHub: #394)
+* Fixed #211, a bug causing output element `p_type` of `project()` to be incorrect in case of `refit_prj = FALSE`, `!is.null(nclusters)`, and an `object` of class `vsel` that was created with a non-clustered (thinned) projection during the search phase. (GitHub: #401)
 
 # projpred 2.4.0
 

--- a/R/project.R
+++ b/R/project.R
@@ -24,7 +24,7 @@
 #'   submodels (again) (`TRUE`) or to retrieve the fitted submodels from
 #'   `object` (`FALSE`). For an `object` which is not of class `vsel`,
 #'   `refit_prj` must be `TRUE`. Note that currently, `refit_prj = FALSE`
-#'   requires some caution, see GitHub issues #168 and #211.
+#'   requires some caution, see GitHub issue #168.
 #' @param ndraws Only relevant if `refit_prj` is `TRUE`. Number of posterior
 #'   draws to be projected. Ignored if `nclusters` is not `NULL` or if the
 #'   reference model is of class `datafit` (in which case one cluster is used).
@@ -179,7 +179,7 @@ project <- function(object, nterms = NULL, solution_terms = NULL,
 
   if (!refit_prj) {
     warning("Currently, `refit_prj = FALSE` requires some caution, see GitHub ",
-            "issues #168 and #211.")
+            "issue #168.")
   }
 
   if (!is.null(solution_terms)) {
@@ -260,9 +260,14 @@ project <- function(object, nterms = NULL, solution_terms = NULL,
   )
 
   # Output:
+  if (refit_prj) {
+    refdist_eval <- p_ref
+  } else {
+    refdist_eval <- object$search_path$p_sel
+  }
   projs <- lapply(submodls, function(submodl) {
     proj_k <- submodl
-    proj_k$p_type <- !is.null(nclusters)
+    proj_k$p_type <- refdist_eval$clust_used
     proj_k$refmodel <- refmodel
     class(proj_k) <- "projection"
     return(proj_k)

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -39,7 +39,7 @@ is not of class \code{vsel}, \code{solution_terms} must not be \code{NULL}.}
 submodels (again) (\code{TRUE}) or to retrieve the fitted submodels from
 \code{object} (\code{FALSE}). For an \code{object} which is not of class \code{vsel},
 \code{refit_prj} must be \code{TRUE}. Note that currently, \code{refit_prj = FALSE}
-requires some caution, see GitHub issues #168 and #211.}
+requires some caution, see GitHub issue #168.}
 
 \item{ndraws}{Only relevant if \code{refit_prj} is \code{TRUE}. Number of posterior
 draws to be projected. Ignored if \code{nclusters} is not \code{NULL} or if the

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -173,7 +173,7 @@ if (run_vs) {
         excl_nonargs(args_prj_vs_i)
       )),
       paste("^Currently, `refit_prj = FALSE` requires some caution, see GitHub",
-            "issues #168 and #211\\.$"),
+            "issue #168\\.$"),
       info = args_prj_vs_i$tstsetup_vsel
     )
   })
@@ -697,7 +697,7 @@ test_that(paste(
                             transform = FALSE, .seed = seed2_tst,
                             nterms = 0:nterms, refit_prj = FALSE),
       paste("^Currently, `refit_prj = FALSE` requires some caution, see GitHub",
-            "issues #168 and #211\\.$"),
+            "issue #168\\.$"),
       info = fam$family
     )
 

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -342,7 +342,7 @@ test_that(paste(
           datafits[[args_prj_vs_datafit[[tstsetup]]$tstsetup_datafit]],
         solterms_expected = solterms_expected_crr,
         nprjdraws_expected = 1L,
-        p_type_expected = TRUE,
+        p_type_expected = FALSE,
         from_vsel_L1_search = with_L1,
         info_str = tstsetup
       )
@@ -367,7 +367,7 @@ test_that(paste(
         refmod_expected =
           datafits[[args_prj_vs_datafit[[tstsetup]]$tstsetup_datafit]],
         nprjdraws_expected = 1L,
-        p_type_expected = TRUE,
+        p_type_expected = FALSE,
         prjdraw_weights_expected = prjs_vs_datafit[[tstsetup]][[1]]$wdraws_prj,
         from_vsel_L1_search = with_L1
       )
@@ -452,6 +452,7 @@ test_that(paste(
     }
     pp_tester(pps_vs_datafit[[tstsetup]],
               len_expected = length(nterms_crr),
+              nprjdraws_out_expected = 1L,
               info_str = tstsetup)
     pp_with_args <- proj_predict(
       prjs_vs_datafit[[tstsetup]],
@@ -463,7 +464,7 @@ test_that(paste(
     )
     pp_tester(pp_with_args,
               len_expected = 1L,
-              nprjdraws_out_expected = tail(nresample_clusters_tst, 1),
+              nprjdraws_out_expected = 1L,
               nobsv_expected = tail(nobsv_tst, 1),
               info_str = paste(tstsetup, "with_args", sep = "__"))
     if (run_snaps) {

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -328,8 +328,8 @@ test_that(paste(
       set.seed(args_vs_i$seed)
       p_sel_dummy <- get_refdist(refmods[[tstsetup_ref]],
                                  nclusters = vs_indep$nprjdraws_search)
-      # As soon as GitHub issues #168 and #211 are fixed, we can use
-      # `refit_prj = FALSE` here:
+      # As soon as GitHub issue #168 is fixed, we can use `refit_prj = FALSE`
+      # here:
       expect_warning(
         pl_indep <- proj_linpred(
           vs_indep,
@@ -362,8 +362,8 @@ test_that(paste(
         set.seed(args_vs_i$seed)
         p_sel_dummy <- get_refdist(refmods[[tstsetup_ref]],
                                    nclusters = vs_indep$nprjdraws_search)
-        # As soon as GitHub issues #168 and #211 are fixed, we can use
-        # `refit_prj = FALSE` here:
+        # As soon as GitHub issue #168 is fixed, we can use `refit_prj = FALSE`
+        # here:
         dat_indep_crr[[paste0(".", y_nm_crr)]] <- d_test_crr$y
         pl_indep_lat <- proj_linpred(
           vs_indep,


### PR DESCRIPTION
This fixes #211, at least in a quick way. Later, we may implement more of the suggestions from https://github.com/stan-dev/projpred/issues/211#issue-1006476680.

In the tests, `datafit`s will now have `project()$p_type = FALSE` because for `datafit`s, we have `nclusters = S = 1`, meaning that `get_refdist()` will call itself with `ndraws = 1` and `nclusters = NULL`. The new behavior also means that for `datafit`s, `proj_predict()` will not draw `nresample_clusters` (default: `1000`) times from the predictive distribution based on the same single projected draw.