### PR TITLE
Docs: Avoid slightly imprecise formulations

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -1,4 +1,4 @@
-#' Variable selection with cross-validation
+#' Run search and performance evaluation with cross-validation
 #'
 #' Run the *search* part and the *evaluation* part for a projection predictive
 #' variable selection. The search part determines the solution path, i.e., the
@@ -33,9 +33,9 @@
 #'   this is known to bias the predictive performance estimates of the selected
 #'   submodels. However, setting this to `FALSE` can sometimes be useful because
 #'   comparing the results to the case where this argument is `TRUE` gives an
-#'   idea of how strongly the variable selection is (over-)fitted to the data
-#'   (the difference corresponds to the search degrees of freedom or the
-#'   effective number of parameters introduced by the search).
+#'   idea of how strongly the search is (over-)fitted to the data (the
+#'   difference corresponds to the search degrees of freedom or the effective
+#'   number of parameters introduced by the search).
 #' @param seed Pseudorandom number generation (PRNG) seed by which the same
 #'   results can be obtained again if needed. Passed to argument `seed` of
 #'   [set.seed()], but can also be `NA` to not call [set.seed()] at all. Here,
@@ -92,9 +92,9 @@
 #'     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
 #'   )
 #'
-#'   # Variable selection with cross-validation (with small values
-#'   # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-#'   # sake of speed in this example; this is not recommended in general):
+#'   # Run cv_varsel() (with small values for `nterms_max`, `nclusters`, and
+#'   # `nclusters_pred`, but only for the sake of speed in this example; this is
+#'   # not recommended in general):
 #'   cvvs <- cv_varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
 #'                     seed = 5555)
 #'   # Now see, for example, `?print.vsel`, `?plot.vsel`, `?suggest_size.vsel`,

--- a/R/methods.R
+++ b/R/methods.R
@@ -1880,13 +1880,14 @@ cv_ids <- function(n, K, out = c("foldwise", "indices"),
   return(cv)
 }
 
-#' Retrieve predictor solution path or predictor combination
+#' Retrieve the full-data solution path from a [varsel()] or [cv_varsel()] run
+#' or the predictor combination from a projection
 #'
-#' This function retrieves the "solution terms" from an `object`. For `vsel`
-#' objects (returned by [varsel()] or [cv_varsel()]), this is the predictor
-#' solution path of the variable selection. For `projection` objects (returned
-#' by [project()], possibly as elements of a `list`), this is the predictor
-#' combination onto which the projection was performed.
+#' This function retrieves the so-called *solution terms* from an `object`. For
+#' `vsel` objects (returned by [varsel()] or [cv_varsel()]), this is the
+#' full-data solution path from the search phase. For `projection` objects
+#' (returned by [project()], possibly as elements of a `list`), this is the
+#' predictor combination onto which the projection was performed.
 #'
 #' @param object The object from which to retrieve the solution terms. Possible
 #'   classes may be inferred from the names of the corresponding methods (see

--- a/R/methods.R
+++ b/R/methods.R
@@ -566,9 +566,9 @@ proj_predict_aux <- function(proj, newdata, offset, weights,
 #'     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
 #'   )
 #'
-#'   # Variable selection (here without cross-validation and with small values
-#'   # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-#'   # sake of speed in this example; this is not recommended in general):
+#'   # Run varsel() (here without cross-validation and with small values for
+#'   # `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the sake of
+#'   # speed in this example; this is not recommended in general):
 #'   vs <- varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
 #'                seed = 5555)
 #'   print(plot(vs))
@@ -836,9 +836,9 @@ plot.vsel <- function(
 #'     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
 #'   )
 #'
-#'   # Variable selection (here without cross-validation and with small values
-#'   # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-#'   # sake of speed in this example; this is not recommended in general):
+#'   # Run varsel() (here without cross-validation and with small values for
+#'   # `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the sake of
+#'   # speed in this example; this is not recommended in general):
 #'   vs <- varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
 #'                seed = 5555)
 #'   print(summary(vs), digits = 1)
@@ -946,11 +946,10 @@ summary.vsel <- function(
   return(out)
 }
 
-#' Print summary of variable selection
+#' Print summary of a [varsel()] or [cv_varsel()] run
 #'
 #' This is the [print()] method for summary objects created by [summary.vsel()].
-#' It displays a summary of the results of the projection predictive variable
-#' selection.
+#' It displays a summary of the results from a [varsel()] or [cv_varsel()] run.
 #'
 #' @param x An object of class `vselsummary`.
 #' @param ... Arguments passed to [print.data.frame()].
@@ -1028,12 +1027,11 @@ print.vselsummary <- function(x, ...) {
   return(invisible(x))
 }
 
-#' Print results (summary) of variable selection
+#' Print results (summary) of a [varsel()] or [cv_varsel()] run
 #'
 #' This is the [print()] method for `vsel` objects (returned by [varsel()] or
-#' [cv_varsel()]). It displays a summary of the results of the projection
-#' predictive variable selection by first calling [summary.vsel()] and then
-#' [print.vselsummary()].
+#' [cv_varsel()]). It displays a summary of a [varsel()] or [cv_varsel()] run by
+#' first calling [summary.vsel()] and then [print.vselsummary()].
 #'
 #' @param x An object of class `vsel` (returned by [varsel()] or [cv_varsel()]).
 #' @param ... Arguments passed to [summary.vsel()] (apart from argument `digits`
@@ -1151,9 +1149,9 @@ print.vsel <- function(x, ...) {
 #'     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
 #'   )
 #'
-#'   # Variable selection (here without cross-validation and with small values
-#'   # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-#'   # sake of speed in this example; this is not recommended in general):
+#'   # Run varsel() (here without cross-validation and with small values for
+#'   # `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the sake of
+#'   # speed in this example; this is not recommended in general):
 #'   vs <- varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
 #'                seed = 5555)
 #'   print(suggest_size(vs))
@@ -1910,9 +1908,9 @@ cv_ids <- function(n, K, out = c("foldwise", "indices"),
 #'     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
 #'   )
 #'
-#'   # Variable selection (here without cross-validation and with small values
-#'   # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-#'   # sake of speed in this example; this is not recommended in general):
+#'   # Run varsel() (here without cross-validation and with small values for
+#'   # `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the sake of
+#'   # speed in this example; this is not recommended in general):
 #'   vs <- varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
 #'                seed = 5555)
 #'   print(solution_terms(vs))

--- a/R/methods.R
+++ b/R/methods.R
@@ -518,10 +518,14 @@ proj_predict_aux <- function(proj, newdata, offset, weights,
   return(structure(pppd_out, cats = cats_aug))
 }
 
-#' Plot summary statistics of a variable selection
+#' Plot predictive performance
 #'
 #' This is the [plot()] method for `vsel` objects (returned by [varsel()] or
-#' [cv_varsel()]).
+#' [cv_varsel()]). It displays the predictive performance of the reference model
+#' (possibly also that of some other "baseline" model) and that of the submodels
+#' (more precisely, of the submodel *sizes*) along the solution path. For a
+#' tabular representation of the plotted performance statistics, see
+#' [summary.vsel()].
 #'
 #' @inheritParams summary.vsel
 #' @param x An object of class `vsel` (returned by [varsel()] or [cv_varsel()]).
@@ -723,10 +727,13 @@ plot.vsel <- function(
   return(pp)
 }
 
-#' Summary statistics of a variable selection
+#' Summary of a [varsel()] or [cv_varsel()] run
 #'
 #' This is the [summary()] method for `vsel` objects (returned by [varsel()] or
-#' [cv_varsel()]).
+#' [cv_varsel()]), which consists of some general information about the
+#' [varsel()] or [cv_varsel()] run, the full-data solution path, and
+#' user-specified predictive performance statistics. For plotting the latter,
+#' see [plot.vsel()].
 #'
 #' @param object An object of class `vsel` (returned by [varsel()] or
 #'   [cv_varsel()]).

--- a/R/project.R
+++ b/R/project.R
@@ -115,9 +115,9 @@
 #'     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
 #'   )
 #'
-#'   # Variable selection (here without cross-validation and with small values
-#'   # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-#'   # sake of speed in this example; this is not recommended in general):
+#'   # Run varsel() (here without cross-validation and with small values for
+#'   # `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the sake of
+#'   # speed in this example; this is not recommended in general):
 #'   vs <- varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
 #'                seed = 5555)
 #'

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -1,7 +1,8 @@
 # Function to project the reference model onto a single submodel with predictor
 # terms given in `solution_terms`. Note that "single submodel" does not refer to
 # a single fit (there are as many fits for this single submodel as there are
-# projected draws).
+# projected draws). At the end, init_submodl() is called, so the output is of
+# class `submodl`.
 get_submodl_prj <- function(solution_terms, p_ref, refmodel, regul = 1e-4,
                             ...) {
   validparams <- validate_wobs_wdraws(refmodel$wobs, p_ref$wdraws_prj,

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -1,4 +1,4 @@
-#' Variable selection without cross-validation
+#' Run search and performance evaluation without cross-validation
 #'
 #' Run the *search* part and the *evaluation* part for a projection predictive
 #' variable selection. The search part determines the solution path, i.e., the
@@ -170,9 +170,9 @@
 #'     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
 #'   )
 #'
-#'   # Variable selection (here without cross-validation and with small values
-#'   # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-#'   # sake of speed in this example; this is not recommended in general):
+#'   # Run varsel() (here without cross-validation and with small values for
+#'   # `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the sake of
+#'   # speed in this example; this is not recommended in general):
 #'   vs <- varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
 #'                seed = 5555)
 #'   # Now see, for example, `?print.vsel`, `?plot.vsel`, `?suggest_size.vsel`,

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -4,7 +4,7 @@
 \alias{cv_varsel}
 \alias{cv_varsel.default}
 \alias{cv_varsel.refmodel}
-\title{Variable selection with cross-validation}
+\title{Run search and performance evaluation with cross-validation}
 \usage{
 cv_varsel(object, ...)
 
@@ -133,9 +133,9 @@ whether to run the search separately for each CV fold (\code{TRUE}) or not
 this is known to bias the predictive performance estimates of the selected
 submodels. However, setting this to \code{FALSE} can sometimes be useful because
 comparing the results to the case where this argument is \code{TRUE} gives an
-idea of how strongly the variable selection is (over-)fitted to the data
-(the difference corresponds to the search degrees of freedom or the
-effective number of parameters introduced by the search).}
+idea of how strongly the search is (over-)fitted to the data (the
+difference corresponds to the search degrees of freedom or the effective
+number of parameters introduced by the search).}
 
 \item{seed}{Pseudorandom number generation (PRNG) seed by which the same
 results can be obtained again if needed. Passed to argument \code{seed} of
@@ -245,9 +245,9 @@ if (requireNamespace("rstanarm", quietly = TRUE)) {
     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
   )
 
-  # Variable selection with cross-validation (with small values
-  # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-  # sake of speed in this example; this is not recommended in general):
+  # Run cv_varsel() (with small values for `nterms_max`, `nclusters`, and
+  # `nclusters_pred`, but only for the sake of speed in this example; this is
+  # not recommended in general):
   cvvs <- cv_varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
                     seed = 5555)
   # Now see, for example, `?print.vsel`, `?plot.vsel`, `?suggest_size.vsel`,

--- a/man/plot.vsel.Rd
+++ b/man/plot.vsel.Rd
@@ -148,9 +148,9 @@ if (requireNamespace("rstanarm", quietly = TRUE)) {
     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
   )
 
-  # Variable selection (here without cross-validation and with small values
-  # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-  # sake of speed in this example; this is not recommended in general):
+  # Run varsel() (here without cross-validation and with small values for
+  # `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the sake of
+  # speed in this example; this is not recommended in general):
   vs <- varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
                seed = 5555)
   print(plot(vs))

--- a/man/plot.vsel.Rd
+++ b/man/plot.vsel.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/methods.R
 \name{plot.vsel}
 \alias{plot.vsel}
-\title{Plot summary statistics of a variable selection}
+\title{Plot predictive performance}
 \usage{
 \method{plot}{vsel}(
   x,
@@ -89,7 +89,11 @@ A \pkg{ggplot2} plotting object (of class \code{gg} and \code{ggplot}).
 }
 \description{
 This is the \code{\link[=plot]{plot()}} method for \code{vsel} objects (returned by \code{\link[=varsel]{varsel()}} or
-\code{\link[=cv_varsel]{cv_varsel()}}).
+\code{\link[=cv_varsel]{cv_varsel()}}). It displays the predictive performance of the reference model
+(possibly also that of some other "baseline" model) and that of the submodels
+(more precisely, of the submodel \emph{sizes}) along the solution path. For a
+tabular representation of the plotted performance statistics, see
+\code{\link[=summary.vsel]{summary.vsel()}}.
 }
 \details{
 The \code{stats} options \code{"mse"} and \code{"rmse"} are only available for:

--- a/man/print.vsel.Rd
+++ b/man/print.vsel.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/methods.R
 \name{print.vsel}
 \alias{print.vsel}
-\title{Print results (summary) of variable selection}
+\title{Print results (summary) of a \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}} run}
 \usage{
 \method{print}{vsel}(x, ...)
 }
@@ -17,7 +17,6 @@ The output of \code{\link[=summary.vsel]{summary.vsel()}} (invisible).
 }
 \description{
 This is the \code{\link[=print]{print()}} method for \code{vsel} objects (returned by \code{\link[=varsel]{varsel()}} or
-\code{\link[=cv_varsel]{cv_varsel()}}). It displays a summary of the results of the projection
-predictive variable selection by first calling \code{\link[=summary.vsel]{summary.vsel()}} and then
-\code{\link[=print.vselsummary]{print.vselsummary()}}.
+\code{\link[=cv_varsel]{cv_varsel()}}). It displays a summary of a \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}} run by
+first calling \code{\link[=summary.vsel]{summary.vsel()}} and then \code{\link[=print.vselsummary]{print.vselsummary()}}.
 }

--- a/man/print.vselsummary.Rd
+++ b/man/print.vselsummary.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/methods.R
 \name{print.vselsummary}
 \alias{print.vselsummary}
-\title{Print summary of variable selection}
+\title{Print summary of a \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}} run}
 \usage{
 \method{print}{vselsummary}(x, ...)
 }
@@ -16,6 +16,5 @@ The output of \code{\link[=summary.vsel]{summary.vsel()}} (invisible).
 }
 \description{
 This is the \code{\link[=print]{print()}} method for summary objects created by \code{\link[=summary.vsel]{summary.vsel()}}.
-It displays a summary of the results of the projection predictive variable
-selection.
+It displays a summary of the results from a \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}} run.
 }

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -146,9 +146,9 @@ if (requireNamespace("rstanarm", quietly = TRUE)) {
     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
   )
 
-  # Variable selection (here without cross-validation and with small values
-  # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-  # sake of speed in this example; this is not recommended in general):
+  # Run varsel() (here without cross-validation and with small values for
+  # `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the sake of
+  # speed in this example; this is not recommended in general):
   vs <- varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
                seed = 5555)
 

--- a/man/solution_terms.Rd
+++ b/man/solution_terms.Rd
@@ -4,7 +4,8 @@
 \alias{solution_terms}
 \alias{solution_terms.vsel}
 \alias{solution_terms.projection}
-\title{Retrieve predictor solution path or predictor combination}
+\title{Retrieve the full-data solution path from a \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}} run
+or the predictor combination from a projection}
 \usage{
 solution_terms(object, ...)
 
@@ -23,11 +24,11 @@ also the description).}
 A character vector of solution terms.
 }
 \description{
-This function retrieves the "solution terms" from an \code{object}. For \code{vsel}
-objects (returned by \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}}), this is the predictor
-solution path of the variable selection. For \code{projection} objects (returned
-by \code{\link[=project]{project()}}, possibly as elements of a \code{list}), this is the predictor
-combination onto which the projection was performed.
+This function retrieves the so-called \emph{solution terms} from an \code{object}. For
+\code{vsel} objects (returned by \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}}), this is the
+full-data solution path from the search phase. For \code{projection} objects
+(returned by \code{\link[=project]{project()}}, possibly as elements of a \code{list}), this is the
+predictor combination onto which the projection was performed.
 }
 \examples{
 if (requireNamespace("rstanarm", quietly = TRUE)) {

--- a/man/solution_terms.Rd
+++ b/man/solution_terms.Rd
@@ -42,9 +42,9 @@ if (requireNamespace("rstanarm", quietly = TRUE)) {
     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
   )
 
-  # Variable selection (here without cross-validation and with small values
-  # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-  # sake of speed in this example; this is not recommended in general):
+  # Run varsel() (here without cross-validation and with small values for
+  # `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the sake of
+  # speed in this example; this is not recommended in general):
   vs <- varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
                seed = 5555)
   print(solution_terms(vs))

--- a/man/suggest_size.Rd
+++ b/man/suggest_size.Rd
@@ -126,9 +126,9 @@ if (requireNamespace("rstanarm", quietly = TRUE)) {
     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
   )
 
-  # Variable selection (here without cross-validation and with small values
-  # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-  # sake of speed in this example; this is not recommended in general):
+  # Run varsel() (here without cross-validation and with small values for
+  # `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the sake of
+  # speed in this example; this is not recommended in general):
   vs <- varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
                seed = 5555)
   print(suggest_size(vs))

--- a/man/summary.vsel.Rd
+++ b/man/summary.vsel.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/methods.R
 \name{summary.vsel}
 \alias{summary.vsel}
-\title{Summary statistics of a variable selection}
+\title{Summary of a \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}} run}
 \usage{
 \method{summary}{vsel}(
   object,
@@ -92,7 +92,10 @@ An object of class \code{vselsummary}.
 }
 \description{
 This is the \code{\link[=summary]{summary()}} method for \code{vsel} objects (returned by \code{\link[=varsel]{varsel()}} or
-\code{\link[=cv_varsel]{cv_varsel()}}).
+\code{\link[=cv_varsel]{cv_varsel()}}), which consists of some general information about the
+\code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}} run, the full-data solution path, and
+user-specified predictive performance statistics. For plotting the latter,
+see \code{\link[=plot.vsel]{plot.vsel()}}.
 }
 \details{
 The \code{stats} options \code{"mse"} and \code{"rmse"} are only available for:

--- a/man/summary.vsel.Rd
+++ b/man/summary.vsel.Rd
@@ -139,9 +139,9 @@ if (requireNamespace("rstanarm", quietly = TRUE)) {
     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
   )
 
-  # Variable selection (here without cross-validation and with small values
-  # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-  # sake of speed in this example; this is not recommended in general):
+  # Run varsel() (here without cross-validation and with small values for
+  # `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the sake of
+  # speed in this example; this is not recommended in general):
   vs <- varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
                seed = 5555)
   print(summary(vs), digits = 1)

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -4,7 +4,7 @@
 \alias{varsel}
 \alias{varsel.default}
 \alias{varsel.refmodel}
-\title{Variable selection without cross-validation}
+\title{Run search and performance evaluation without cross-validation}
 \usage{
 varsel(object, ...)
 
@@ -218,9 +218,9 @@ if (requireNamespace("rstanarm", quietly = TRUE)) {
     QR = TRUE, chains = 2, iter = 500, refresh = 0, seed = 9876
   )
 
-  # Variable selection (here without cross-validation and with small values
-  # for `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the
-  # sake of speed in this example; this is not recommended in general):
+  # Run varsel() (here without cross-validation and with small values for
+  # `nterms_max`, `nclusters`, and `nclusters_pred`, but only for the sake of
+  # speed in this example; this is not recommended in general):
   vs <- varsel(fit, nterms_max = 3, nclusters = 5, nclusters_pred = 10,
                seed = 5555)
   # Now see, for example, `?print.vsel`, `?plot.vsel`, `?suggest_size.vsel`,


### PR DESCRIPTION
This PR concerns the documentation and mainly avoids the term "variable selection" where strictly speaking, it is not quite appropriate because no final selection is performed (not even the selection of a size). For example, this is the case for `varsel()` and `cv_varsel()` runs. Of course, these functions do run a search and therefore also some kind of selection, but throughout the docs (and the vignette), the term "selection" is rather reserved to the final selection of a submodel or of a submodel size.