### PR TITLE
Tests: Avoid errors in case of unavailable packages

### DIFF
--- a/tests/testthat/helpers/unlist_cust.R
+++ b/tests/testthat/helpers/unlist_cust.R
@@ -9,7 +9,10 @@
 #   next sublist is unnamed or contains an element with name given in
 #   `nm_stop`).
 unlist_cust <- function(x, nm_stop = "mod_nm") {
-  stopifnot(is.list(x), length(x) > 0)
+  stopifnot(is.list(x))
+  if (!length(x)) {
+    return(x)
+  }
   if (is.null(names(x[[1]])) || nm_stop %in% names(x[[1]])) {
     return(x)
   } else {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -452,10 +452,18 @@ dat_indep$offs_col <- offs_indep
 ## Setup ------------------------------------------------------------------
 
 if (!requireNamespace("rstanarm", quietly = TRUE)) {
-  stop("Package \"rstanarm\" is needed for these tests. Please install it.",
-       call. = FALSE)
+  warning("Package 'rstanarm' is needed for the rstanarm tests, but could not ",
+          "be found. Deactivating the rstanarm tests now. Furthermore, in ",
+          "this case, `run_prj`, `run_vs`, and `run_cvvs` are currently set ",
+          "to `FALSE`.")
+  pkg_nms <- character()
+  # TODO: Adapt the tests to avoid the following line, at least if `run_brms` is
+  # `TRUE` (better: avoid it in any case, no matter whether `run_brms` is `TRUE`
+  # or `FALSE`).
+  run_prj <- run_vs <- run_cvvs <- FALSE
+} else {
+  pkg_nms <- "rstanarm"
 }
-pkg_nms <- "rstanarm"
 
 if (run_brms && !requireNamespace("brms", quietly = TRUE)) {
   warning("Package 'brms' is needed for the brms tests, but could not be ",
@@ -755,7 +763,7 @@ args_fit <- lapply(setNames(nm = names(args_fit)), function(args_fit_nm) {
   return(args_fit[[args_fit_nm]])
 })
 
-if (!run_more) {
+if (!run_more && length(pkg_nms)) {
   sel_fits <- c(
     "rstanarm.glm.gauss.stdformul.with_wobs.with_offs",
     "rstanarm.glm.brnll.stdformul.without_wobs.without_offs",
@@ -789,8 +797,11 @@ if (!run_more) {
                      invert = TRUE)
   }
   args_fit <- args_fit[names(args_fit) %in% sel_fits]
-  if (run_brms) {
+  if (run_brms && "rstanarm" %in% pkg_nms) {
     stopifnot(setequal(names(args_fit), sel_fits))
+  } else if (run_brms && !"rstanarm" %in% pkg_nms) {
+    stopifnot(setequal(names(args_fit),
+                       grep("^brms\\.", sel_fits, value = TRUE)))
   } else {
     stopifnot(setequal(names(args_fit),
                        grep("^brms\\.", sel_fits, value = TRUE, invert = TRUE)))

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -55,12 +55,13 @@ if (identical(run_snaps, "")) {
   run_snaps <- as.logical(toupper(run_snaps))
   stopifnot(isTRUE(run_snaps) || isFALSE(run_snaps))
 }
+if (run_snaps && !requireNamespace("rlang", quietly = TRUE)) {
+  warning("Package 'rlang' is needed for snapshot testing, but could not be ",
+          "found. Deactivating snapshot testing now.")
+  run_snaps <- FALSE
+}
 if (run_snaps) {
   testthat_ed_max2 <- edition_get() <= 2
-  if (!requireNamespace("rlang", quietly = TRUE)) {
-    stop("Package \"rlang\" is needed for the snapshots. Please install it.",
-         call. = FALSE)
-  }
 }
 # Run parallel tests?:
 # Notes:
@@ -91,21 +92,23 @@ if (run_prll) {
   # package (which is still slower than a sequential run, though):
   if (!identical(.Platform$OS.type, "windows")) {
     if (!requireNamespace("doParallel", quietly = TRUE)) {
-      stop("Package \"doParallel\" is needed for these tests. Please ",
-           "install it.",
-           call. = FALSE)
+      warning("Package 'doParallel' is needed for the parallel tests, but ",
+              "could not be found. Deactivating the parallel tests now.")
+      run_prll <- FALSE
+    } else {
+      dopar_backend <- "doParallel"
     }
-    dopar_backend <- "doParallel"
   } else {
     # This case (which should not be possible by default) is only included
     # here to demonstrate how parallelization should be used on Windows (but
     # currently, this makes no sense, as explained above).
     if (!requireNamespace("doFuture", quietly = TRUE)) {
-      stop("Package \"doFuture\" is needed for these tests. Please ",
-           "install it.",
-           call. = FALSE)
+      warning("Package 'doFuture' is needed for the parallel tests, but ",
+              "could not be found. Deactivating the parallel tests now.")
+      run_prll <- FALSE
+    } else {
+      dopar_backend <- "doFuture"
     }
-    dopar_backend <- "doFuture"
     if (identical(.Platform$OS.type, "windows")) {
       ### Not used in this case because the 'future.callr' package provides a
       ### faster alternative on Windows (which is still slower than a sequential
@@ -113,11 +116,12 @@ if (run_prll) {
       # future_plan <- "multisession"
       ###
       if (!requireNamespace("future.callr", quietly = TRUE)) {
-        stop("Package \"future.callr\" is needed for these tests. Please ",
-             "install it.",
-             call. = FALSE)
+        warning("Package 'future.callr' is needed for the parallel tests, but ",
+                "could not be found. Deactivating the parallel tests now.")
+        run_prll <- FALSE
+      } else {
+        future_plan <- "callr"
       }
-      future_plan <- "callr"
     } else {
       # This case (which should not be possible by default) is only included
       # here to demonstrate how other systems should be used with the 'doFuture'
@@ -453,11 +457,12 @@ if (!requireNamespace("rstanarm", quietly = TRUE)) {
 }
 pkg_nms <- "rstanarm"
 
+if (run_brms && !requireNamespace("brms", quietly = TRUE)) {
+  warning("Package 'brms' is needed for the brms tests, but could not be ",
+          "found. Deactivating the brms tests now.")
+  run_brms <- FALSE
+}
 if (run_brms) {
-  if (!requireNamespace("brms", quietly = TRUE)) {
-    stop("Package \"brms\" is needed for these tests. Please install it.",
-         call. = FALSE)
-  }
   pkg_nms <- c(pkg_nms, "brms")
   # For storing "brmsfit"s locally:
   file_pth <- testthat::test_path("bfits")

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -45,7 +45,7 @@ args_datafit <- lapply(setNames(
   tstsetup_fit <- args_ref[[tstsetup_ref]]$tstsetup_fit
   c(nlist(tstsetup_fit), only_nonargs(args_fit[[tstsetup_fit]]))
 })
-# The augmented-data projection is not supported yet for `datafit`s:
+# The latent and the augmented-data projection are not supported for `datafit`s:
 args_datafit <- args_datafit[!grepl("\\.(latent|augdat)", names(args_datafit))]
 
 datafits <- lapply(args_datafit, function(args_datafit_i) {

--- a/tests/testthat/test_methods_vsel.R
+++ b/tests/testthat/test_methods_vsel.R
@@ -5,9 +5,17 @@ context("summary(), plot(), suggest_size()")
 test_that("invalid `object` fails", {
   objs_invalid <- nlist(
     NULL,
-    fit = fits[[1]],
-    refmod = refmods[[1]]
+    some_numbers = 1:3,
+    some_letters = head(letters, 17)
   )
+  if (length(fits)) {
+    objs_invalid <- c(
+      objs_invalid,
+      nlist(NULL,
+            fit = fits[[1]],
+            refmod = refmods[[1]])
+    )
+  }
   if (run_prj) {
     objs_invalid <- c(
       objs_invalid,

--- a/tests/testthat/test_proj_pred.R
+++ b/tests/testthat/test_proj_pred.R
@@ -216,16 +216,18 @@ test_that("`object` not of class \"vsel\" and missing `solution_terms` fails", {
     paste("^Please provide an `object` of class \"vsel\" or use argument",
           "`solution_terms`\\.$")
   )
-  expect_error(
-    proj_linpred(fits[[1]], .seed = seed2_tst),
-    paste("^Please provide an `object` of class \"vsel\" or use argument",
-          "`solution_terms`\\.$")
-  )
-  expect_error(
-    proj_linpred(refmods[[1]], .seed = seed2_tst),
-    paste("^Please provide an `object` of class \"vsel\" or use argument",
-          "`solution_terms`\\.$")
-  )
+  if (length(fits)) {
+    expect_error(
+      proj_linpred(fits[[1]], .seed = seed2_tst),
+      paste("^Please provide an `object` of class \"vsel\" or use argument",
+            "`solution_terms`\\.$")
+    )
+    expect_error(
+      proj_linpred(refmods[[1]], .seed = seed2_tst),
+      paste("^Please provide an `object` of class \"vsel\" or use argument",
+            "`solution_terms`\\.$")
+    )
+  }
   if (run_prj) {
     expect_error(
       proj_linpred(c(prjs, list(dat)), .seed = seed2_tst),
@@ -1065,16 +1067,18 @@ test_that("`object` not of class \"vsel\" and missing `solution_terms` fails", {
     paste("^Please provide an `object` of class \"vsel\" or use argument",
           "`solution_terms`\\.$")
   )
-  expect_error(
-    proj_predict(fits[[1]], .seed = seed2_tst),
-    paste("^Please provide an `object` of class \"vsel\" or use argument",
-          "`solution_terms`\\.$")
-  )
-  expect_error(
-    proj_predict(refmods[[1]], .seed = seed2_tst),
-    paste("^Please provide an `object` of class \"vsel\" or use argument",
-          "`solution_terms`\\.$")
-  )
+  if (length(fits)) {
+    expect_error(
+      proj_predict(fits[[1]], .seed = seed2_tst),
+      paste("^Please provide an `object` of class \"vsel\" or use argument",
+            "`solution_terms`\\.$")
+    )
+    expect_error(
+      proj_predict(refmods[[1]], .seed = seed2_tst),
+      paste("^Please provide an `object` of class \"vsel\" or use argument",
+            "`solution_terms`\\.$")
+    )
+  }
   if (run_prj) {
     expect_error(
       proj_predict(c(prjs, list(dat)), .seed = seed2_tst),

--- a/tests/testthat/test_project.R
+++ b/tests/testthat/test_project.R
@@ -298,6 +298,7 @@ test_that(paste(
 })
 
 test_that("`object` not of class \"vsel\" and missing `solution_terms` fails", {
+  skip_if_not(length(fits) > 0)
   expect_error(
     project(fits[[1]]),
     paste("^Please provide an `object` of class \"vsel\" or use argument",

--- a/tests/testthat/test_refmodel.R
+++ b/tests/testthat/test_refmodel.R
@@ -47,6 +47,7 @@ test_that("`object` of class \"stanreg\" or \"brmsfit\" works", {
 })
 
 test_that("missing `data` fails", {
+  skip_if_not_installed("rstanarm")
   fit_nodata <- suppressWarnings(rstanarm::stan_glm(
     dat$y_glm_gauss ~ dat$xco.1 + dat$xco.2 + dat$xco.3 +
       dat$xca.1 + dat$xca.2 + offset(dat$offs_col),
@@ -62,6 +63,7 @@ test_that("missing `data` fails", {
 })
 
 test_that("`formula` as a character string fails", {
+  skip_if_not_installed("rstanarm")
   # If `formula` is a character string, rstanarm::stan_glm() is not able to find
   # objects supplied to arguments `weights` or `offset`, at least when using
   # devtools::test():
@@ -132,6 +134,7 @@ test_that(paste(
   "binomial family with 1-column response and weights which are not all ones",
   "errors"
 ), {
+  skip_if_not_installed("rstanarm")
   dat_prop <- within(dat, {
     ybinprop_glm <- y_glm_binom / wobs_col
   })
@@ -208,11 +211,13 @@ test_that("get_refmodel() is idempotent", {
 context("predict.refmodel()")
 
 test_that("invalid `type` fails", {
+  skip_if_not(length(fits) > 0)
   expect_error(predict(refmods[[1]], dat, type = "zzz"),
                "^type should be one of")
 })
 
 test_that("invalid `ynew` fails", {
+  skip_if_not(length(fits) > 0)
   expect_error(predict(refmods[[1]], dat, ynew = dat),
                "^Argument `ynew` must be a numeric vector\\.$")
 })

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1241,6 +1241,7 @@ test_that("`validate_search` works", {
 ## Arguments specific to K-fold CV ----------------------------------------
 
 test_that("invalid `K` fails", {
+  skip_if_not(length(fits) > 0)
   expect_error(cv_varsel(refmods[[1]], cv_method = "kfold", K = 1),
                "^`K` must be at least 2\\.$")
   expect_error(cv_varsel(refmods[[1]], cv_method = "kfold", K = 1000),


### PR DESCRIPTION
On CRAN, rstanarm doesn't seem to be installed on all test platforms anymore (or the tests are run with packages from `Suggests` excluded), see https://cran.r-project.org/web/checks/check_results_projpred.html (date: May 22, 2023, time: 10:59 UTC). Therefore, we need to catch this in the tests and not throw an error in case of rstanarm being unavailable. This is achieved by this PR.