### PR TITLE
Reduce peak memory usage of `kfold_varsel()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 ## Minor changes
 
 * Enhancements in the vignettes. In particular, the new functions `ranking()`, `cv_proportions()`, and `plot.cv_proportions()` (see "Major changes" above) are now illustrated in the main vignette. (GitHub: #407, #411)
+* Reduced the peak memory usage of `cv_varsel()` with `cv_method = "kfold"`. (GitHub: #419)
 
 ## Bug fixes
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -948,8 +948,8 @@ get_kfold <- function(refmodel, K, verbose) {
         verb_out("-----\nRefitting the reference model K = ", K, " times ",
                  "(using the fold-wise training data) ...")
       }
-      nobs <- refmodel$nobs
-      folds <- cv_folds(nobs, K = K, seed = sample.int(.Machine$integer.max, 1))
+      folds <- cv_folds(refmodel$nobs, K = K,
+                        seed = sample.int(.Machine$integer.max, 1))
       cvfits <- refmodel$cvfun(folds)
       verb_out("-----", verbose = verbose)
     } else {

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -958,7 +958,6 @@ get_kfold <- function(refmodel, K, verbose) {
            "`?init_refmodel`).")
     }
   } else {
-    K <- length(refmodel$cvfits$fits)
     cvfits <- refmodel$cvfits
     folds <- attr(cvfits, "folds")
     cvfits <- cvfits$fits

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -958,9 +958,8 @@ get_kfold <- function(refmodel, K, verbose) {
            "`?init_refmodel`).")
     }
   } else {
-    cvfits <- refmodel$cvfits
-    folds <- attr(cvfits, "folds")
-    cvfits <- cvfits$fits
+    folds <- attr(refmodel$cvfits, "folds")
+    cvfits <- refmodel$cvfits$fits
   }
   return(lapply(seq_len(K), function(k) {
     cvfit <- cvfits[[k]]

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -963,20 +963,15 @@ get_kfold <- function(refmodel, K, verbose) {
     folds <- attr(cvfits, "folds")
     cvfits <- cvfits$fits
   }
-  cvfits <- lapply(seq_len(K), function(k) {
+  return(lapply(seq_len(K), function(k) {
     cvfit <- cvfits[[k]]
     # Add the omitted observation indices for this fold:
     cvfit$omitted <- which(folds == k)
     # Add the fold index:
     cvfit$projpred_k <- k
-    return(cvfit)
-  })
-  return(lapply(cvfits, init_kfold_refmodel, refmodel = refmodel))
-}
-
-init_kfold_refmodel <- function(cvfit, refmodel) {
-  return(list(refmodel = refmodel$cvrefbuilder(cvfit),
-              omitted = cvfit$omitted))
+    return(list(refmodel = refmodel$cvrefbuilder(cvfit),
+                omitted = cvfit$omitted))
+  }))
 }
 
 # ## decide which points to go through in the validation (i.e., which points

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -277,7 +277,7 @@ parse_args_cv_varsel <- function(refmodel, cv_method, K, validate_search) {
 
   if (cv_method == "kfold") {
     if (!is.null(refmodel$cvfits)) {
-      K <- attr(refmodel$cvfits, "K")
+      K <- length(refmodel$cvfits$fits)
     }
     stopifnot(!is.null(K))
     if (length(K) > 1 || !is.numeric(K) || !is_wholenumber(K)) {
@@ -959,7 +959,7 @@ get_kfold <- function(refmodel, K, verbose) {
     }
   } else {
     cvfits <- refmodel$cvfits
-    K <- attr(cvfits, "K")
+    K <- length(cvfits$fits)
     folds <- attr(cvfits, "folds")
     cvfits <- cvfits$fits
   }

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -958,8 +958,8 @@ get_kfold <- function(refmodel, K, verbose) {
            "`?init_refmodel`).")
     }
   } else {
+    K <- length(refmodel$cvfits$fits)
     cvfits <- refmodel$cvfits
-    K <- length(cvfits$fits)
     folds <- attr(cvfits, "folds")
     cvfits <- cvfits$fits
   }

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -82,13 +82,12 @@
 #' @param cvfits For \eqn{K}-fold CV only. A `list` containing a sub-`list`
 #'   called `fits` containing the \eqn{K} model fits from which reference model
 #'   structures are created. The `cvfits` `list` (i.e., the super-`list`) needs
-#'   to have attributes `K` and `folds`: `K` has to be a single integer giving
-#'   the number of folds and `folds` has to be an integer vector giving the fold
-#'   indices (one fold index per observation). Each element of `cvfits$fits`
-#'   (i.e., each of the \eqn{K} model fits) needs to be a list. Only one of
-#'   `cvfits` and `cvfun` needs to be provided (for \eqn{K}-fold CV). Note that
-#'   `cvfits` takes precedence over `cvfun`, i.e., if both are provided,
-#'   `cvfits` is used.
+#'   to have an attribute called `folds`, consisting of an integer vector giving
+#'   the fold indices (one fold index per observation). Each element of
+#'   `cvfits$fits` (i.e., each of the \eqn{K} model fits) needs to be a list.
+#'   Only one of `cvfits` and `cvfun` needs to be provided (for \eqn{K}-fold
+#'   CV). Note that `cvfits` takes precedence over `cvfun`, i.e., if both are
+#'   provided, `cvfits` is used.
 #' @param cvfun For \eqn{K}-fold CV only. A function that, given a fold indices
 #'   vector, fits the reference model separately for each fold and returns the
 #'   \eqn{K} model fits as a `list`. Each of the \eqn{K} model fits needs to be

--- a/man/refmodel-init-get.Rd
+++ b/man/refmodel-init-get.Rd
@@ -126,13 +126,12 @@ i.e., if both are provided, \code{cvfits} is used.}
 \item{cvfits}{For \eqn{K}-fold CV only. A \code{list} containing a sub-\code{list}
 called \code{fits} containing the \eqn{K} model fits from which reference model
 structures are created. The \code{cvfits} \code{list} (i.e., the super-\code{list}) needs
-to have attributes \code{K} and \code{folds}: \code{K} has to be a single integer giving
-the number of folds and \code{folds} has to be an integer vector giving the fold
-indices (one fold index per observation). Each element of \code{cvfits$fits}
-(i.e., each of the \eqn{K} model fits) needs to be a list. Only one of
-\code{cvfits} and \code{cvfun} needs to be provided (for \eqn{K}-fold CV). Note that
-\code{cvfits} takes precedence over \code{cvfun}, i.e., if both are provided,
-\code{cvfits} is used.}
+to have an attribute called \code{folds}, consisting of an integer vector giving
+the fold indices (one fold index per observation). Each element of
+\code{cvfits$fits} (i.e., each of the \eqn{K} model fits) needs to be a list.
+Only one of \code{cvfits} and \code{cvfun} needs to be provided (for \eqn{K}-fold
+CV). Note that \code{cvfits} takes precedence over \code{cvfun}, i.e., if both are
+provided, \code{cvfits} is used.}
 
 \item{cvrefbuilder}{For \eqn{K}-fold CV only. A function that, given a
 reference model fit for fold \eqn{k \in \{1, ..., K\}}{k = 1, ..., K} (this


### PR DESCRIPTION
This (more precisely, commit e11edc75e330be205a6a28b619eaeb4f11b7a2f7) reduces the peak memory usage of `kfold_varsel()` massively by avoiding that the output of `select()` and `get_submodls()` from all CV folds is stored in common (very large) objects (`search_path_cv` and `submodls_cv`). This movement of large portions of code should also be beneficial for a future parallelization across CV folds (because with this PR, we have all code that needs to be run on one worker within a single function) and in my opinion, it also enhances the readability of `kfold_varsel()`.

The readability of `kfold_varsel()`-related functions is also enhanced by commits 23b274ef11b7b2932f0d537332c06d37c6bf5352 to c64ac577a32053947910d3233d49869abd7b72ec which are just refactoring commits.