### PR TITLE
Re-rank lower-order interaction terms after L1 search and take permutations of main-effect terms in interactions into account when predicting with `predict.subfit()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,7 @@ Imports:
     methods,
     utils,
     Rcpp,
+    gtools,
     ggplot2,
     scales,
     rstantools (>= 2.0.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Although bad practice (in general), a reference model lacking an intercept can now be used within **projpred**. However, it will always be projected onto submodels which *include* an intercept. The reason is that even if the true intercept in the reference model is zero, this does not need to hold for the submodels. An informational message mentioning the projection onto intercept-including submodels is thrown when **projpred** encounters a reference model lacking an intercept. (GitHub: #96, #391)
 * In case of non-predictor arguments of `s()` or `t2()`, **projpred** now throws an error. (This had already been documented before, but a suitable error message was missing.) (GitHub: #393, based on #156 and #269)
 * In case of the `brms::categorical()` family (supported since version 2.4.0), **projpred** now strips underscores from response category names in `as.matrix.projection()` output, as done by **brms**. (GitHub: #394)
-* L1 search now throws a warning if an interaction term is selected before all involved main effects have been selected. (GitHub: #395)
+* L1 search now throws a warning if an interaction term is selected before all involved main-effect terms have been selected. (GitHub: #395)
 * Documented that in multilevel (group-level) terms, function calls on the right-hand side of the `|` character (e.g., `(1 | gr(group_variable))`, which is possible in **brms**) are currently not allowed in **projpred**. A corresponding error message has also been added. (GitHub: #319)
 * Due to internal refactoring:
     

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,14 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 # projpred 2.6.0.9000
 
+## Minor changes
+
+* If an L1 search selects an interaction term before all involved lower-order interaction terms (including main-effect terms) have been selected, the predictor ranking is now automatically modified so that the lower-order interaction terms come before this interaction term. A corresponding warning is thrown, which may be deactivated by setting the global option `projpred.warn_L1_interactions` to `FALSE`. Previously, beginning with version 2.5.0, only a warning was thrown and this only if an L1 search selected an interaction term before all involved *main-effect* terms had been selected. (GitHub: #420)
+
 ## Bug fixes
 
 * Fixed a bug in the printed number of projected draws for the performance evaluation when calling `print.vselsummary()` based on output from `varsel()` with `refit_prj = FALSE`.
+* Fixed a bug sometimes causing an error when predicting from a submodel that is a GLM and has interactions. (GitHub: #420)
 
 # projpred 2.6.0
 

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -1086,26 +1086,8 @@ predict.subfit <- function(object, newdata = NULL, ...) {
       # Need to ensure that the columns of `x` match the coefficients (note that
       # `rownames(beta)` is the same as `colnames(object$x)`, see the tests):
       nms_to_use <- c("(Intercept)", colnames(object$x))
-      if (!all(nms_to_use %in% colnames(x))) {
-        for (ia_idx in grep(":", nms_to_use)) {
-          ia_split <- strsplit(nms_to_use[ia_idx], ":")[[1]]
-          ia_perms_split <- gtools::permutations(n = length(ia_split),
-                                                 r = length(ia_split),
-                                                 v = ia_split, set = FALSE)
-          ia_perms <- apply(ia_perms_split, 1, paste, collapse = ":",
-                            simplify = FALSE)
-          ia_perms <- unlist(ia_perms)
-          ia_reordered <- intersect(ia_perms, colnames(x))
-          if (length(ia_reordered) == 0) {
-            ia_reordered <- NA_character_
-          } else if (length(ia_reordered) > 1) {
-            stop("Unexpected length of `ia_reordered`. Please contact the ",
-                 "package maintainer.")
-          }
-          nms_to_use[ia_idx] <- ia_reordered
-        }
-      }
-      if (all(nms_to_use %in% colnames(x))) {
+      nms_to_use <- reorder_ias(nms_to_use, colnames(x))
+      if (all(!is.na(nms_to_use)) && all(nms_to_use %in% colnames(x))) {
         x <- x[, nms_to_use, drop = FALSE]
       } else {
         stop("The column names of the new model matrix don't match the ",

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -1084,15 +1084,6 @@ predict.subfit <- function(object, newdata = NULL, ...) {
       x <- model.matrix(delete.response(terms(object$formula)), data = newdata,
                         xlev = object$xlvls)
       if (!identical(colnames(x), c("(Intercept)", colnames(object$x)))) {
-        # Note: In the following `if` condition, we were previously using
-        # `identical(sort(colnames(x)),
-        #            sort(c("(Intercept)", colnames(object$x))))`
-        # instead of
-        # `all(c("(Intercept)", colnames(object$x)) %in% colnames(x))`.
-        # However, the case where `x` has non-intercept columns that `object$x`
-        # doesn't have may occur in case of an L1 search with interactions being
-        # selected before all involved main effects are selected (and at least
-        # one of the main effects being a categorical predictor).
         if (all(c("(Intercept)", colnames(object$x)) %in% colnames(x))) {
           x <- x[, c("(Intercept)", colnames(object$x)), drop = FALSE]
         } else {

--- a/R/misc.R
+++ b/R/misc.R
@@ -600,3 +600,44 @@ parse_wobs_ppd <- function(wobs, n_obs) {
   }
   return(wobs)
 }
+
+# Constructs all possible permutations of a single interaction term `ia` (given
+# as a single character string):
+all_ia_perms <- function(ia) {
+  ia_split <- strsplit(ia, ":")[[1]]
+  ia_perms_split <- gtools::permutations(n = length(ia_split),
+                                         r = length(ia_split),
+                                         v = ia_split, set = FALSE)
+  return(unlist(
+    apply(ia_perms_split, 1, paste, collapse = ":", simplify = FALSE)
+  ))
+}
+
+# Reorders the main-effect terms involved in a single interaction term `ia`
+# (given as a single character string) such that it matches a corresponding
+# interaction term in a character vector `y` (e.g., `a:b` is considered to be
+# the same as `b:a`):
+reorder_ia <- function(ia, y) {
+  ia_perms <- all_ia_perms(ia)
+  ia_reordered <- intersect(ia_perms, y)
+  if (length(ia_reordered) == 0) {
+    ia_reordered <- NA_character_
+  } else if (length(ia_reordered) > 1) {
+    stop("Unexpected length of `ia_reordered`. Please contact the package ",
+         "maintainer.")
+  }
+  return(ia_reordered)
+}
+
+# For each interaction term in a character vector `x`, this function reorders
+# the main-effect terms involved in it such that the reordered interaction term
+# matches a corresponding interaction term in a character vector `y` (e.g.,
+# `a:b` is considered to be the same as `b:a`):
+reorder_ias <- function(x, y) {
+  ia_idxs <- grep(":", x)
+  ia_idxs <- ia_idxs[!x[ia_idxs] %in% y]
+  for (ia_idx in ia_idxs) {
+    x[ia_idx] <- reorder_ia(x[ia_idx], y)
+  }
+  return(x)
+}

--- a/R/misc.R
+++ b/R/misc.R
@@ -603,8 +603,12 @@ parse_wobs_ppd <- function(wobs, n_obs) {
 
 # Constructs all possible permutations of a single interaction term `ia` (given
 # as a single character string):
-all_ia_perms <- function(ia) {
-  ia_split <- strsplit(ia, ":")[[1]]
+all_ia_perms <- function(ia, is_split = FALSE) {
+  if (is_split) {
+    ia_split <- ia
+  } else {
+    ia_split <- strsplit(ia, ":")[[1]]
+  }
   ia_perms_split <- gtools::permutations(n = length(ia_split),
                                          r = length(ia_split),
                                          v = ia_split, set = FALSE)

--- a/R/search.R
+++ b/R/search.R
@@ -198,8 +198,9 @@ search_L1 <- function(p_ref, refmodel, nterms_max, penalty, opt) {
                   "forward search to avoid this. Now ranking the lower-order ",
                   "interaction terms before this interaction term.")
         }
+        ias_lower <- setdiff(ias_lower, prev_terms)
         ias_lower <- ias_lower[order(match(ias_lower, solution_terms_orig))]
-        new_head <- c(prev_terms, setdiff(ias_lower, prev_terms), ia)
+        new_head <- c(prev_terms, ias_lower, ia)
         solution_terms <- c(new_head, setdiff(solution_terms, new_head))
         solution_terms <- utils::head(solution_terms, nterms_max)
       }

--- a/tests/testthat/helpers/predictor_handlers.R
+++ b/tests/testthat/helpers/predictor_handlers.R
@@ -1,12 +1,3 @@
-# A function for reversing the order of the individual terms in ":" interaction
-# terms:
-revIA <- function(trms) {
-  trms_split <- strsplit(grep(":", trms, value = TRUE), ":")
-  return(unlist(lapply(trms_split, function(trm_split) {
-    paste(rev(trm_split), collapse = ":")
-  })))
-}
-
 # Expand poly() terms, e.g., `poly(x, 2, raw = TRUE)` to
 # `poly(x, 2, raw = TRUE)1` and `poly(x, 2, raw = TRUE)2`:
 expand_poly <- function(trms, info_str) {

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -1900,6 +1900,9 @@ pp_tester <- function(pp,
 # @param method_expected The expected `vs$method` object.
 # @param cv_method_expected The expected `vs$cv_method` object.
 # @param valsearch_expected The expected `vs$validate_search` object.
+# @param refit_prj_expected A single logical value indicating whether argument
+#   `refit_prj` was set to `TRUE` when calling varsel() or cv_varsel() for
+#   creating `vs` (`TRUE`) or not (`FALSE`).
 # @param cl_search_expected The expected `vs$clust_used_search` object.
 # @param cl_eval_expected The expected `vs$clust_used_eval` object.
 # @param nprjdraws_search_expected The expected `vs$nprjdraws_search` object.
@@ -1928,6 +1931,7 @@ vsel_tester <- function(
     method_expected,
     cv_method_expected = NULL,
     valsearch_expected = NULL,
+    refit_prj_expected = TRUE,
     cl_search_expected = !from_datafit,
     cl_eval_expected = !from_datafit,
     nprjdraws_search_expected = if (!from_datafit) nclusters_tst else 1L,
@@ -1958,6 +1962,9 @@ vsel_tester <- function(
   if (method_expected == "L1") {
     cl_search_expected <- !from_datafit
     nprjdraws_search_expected <- 1
+    if (!refit_prj_expected) {
+      nprjdraws_eval_expected <- 1
+    }
   }
   if (search_trms_empty_size) {
     # This is the "empty_size" setting, so we have to subtract the skipped model

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -1924,8 +1924,19 @@ vsel_tester <- function(
     refit_prj_expected = TRUE,
     cl_search_expected = !from_datafit,
     cl_eval_expected = !from_datafit,
-    nprjdraws_search_expected = if (!from_datafit) nclusters_tst else 1L,
-    nprjdraws_eval_expected = if (!from_datafit) nclusters_pred_tst else 1L,
+    nprjdraws_search_expected = if (from_datafit || method_expected == "L1") {
+      1L
+    } else {
+      nclusters_tst
+    },
+    nprjdraws_eval_expected = if (from_datafit || (!refit_prj_expected &&
+                                                   method_expected == "L1")) {
+      1L
+    } else if (!refit_prj_expected) {
+      nclusters_tst
+    } else {
+      nclusters_pred_tst
+    },
     seed_expected = seed_tst,
     nloo_expected = NULL,
     search_trms_empty_size = FALSE,
@@ -1951,10 +1962,6 @@ vsel_tester <- function(
   }
   if (method_expected == "L1") {
     cl_search_expected <- !from_datafit
-    nprjdraws_search_expected <- 1
-    if (!refit_prj_expected) {
-      nprjdraws_eval_expected <- 1
-    }
   }
   if (search_trms_empty_size) {
     # This is the "empty_size" setting, so we have to subtract the skipped model

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -857,9 +857,8 @@ outdmin_tester_trad <- function(
                        info = info_str)
           trms_to_test <- labels(terms(outdmin_totest[[j]]$formula))
           trms_ch <- labels(terms(sub_formul[[j]]))
-          expect_true(setequal(c(trms_to_test, revIA(trms_to_test)),
-                               c(trms_ch, revIA(trms_ch))),
-                      info = info_str)
+          trms_ch <- reorder_ias(trms_ch, trms_to_test)
+          expect_identical(trms_to_test, trms_ch, info = info_str)
         }
 
         x_to_test <- outdmin_totest[[j]]$x

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -252,8 +252,6 @@ test_that(paste(
         datafits[[args_vs_datafit[[tstsetup]]$tstsetup_datafit]],
       solterms_len_expected = args_vs_datafit[[tstsetup]]$nterms_max,
       method_expected = meth_exp_crr,
-      nprjdraws_search_expected = 1L,
-      nprjdraws_eval_expected = 1L,
       search_trms_empty_size =
         length(args_vs_datafit[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs_datafit[[tstsetup]]$search_terms)),
@@ -284,8 +282,6 @@ test_that(paste(
       method_expected = meth_exp_crr,
       cv_method_expected = "kfold",
       valsearch_expected = args_cvvs_datafit[[tstsetup]]$validate_search,
-      nprjdraws_search_expected = 1L,
-      nprjdraws_eval_expected = 1L,
       search_trms_empty_size =
         length(args_cvvs_datafit[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs_datafit[[tstsetup]]$search_terms)),

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -237,6 +237,14 @@ test_that(paste(
     if (is.null(meth_exp_crr)) {
       meth_exp_crr <- ifelse(mod_crr == "glm", "L1", "forward")
     }
+    extra_tol_crr <- 1.5
+    if (any(grepl(":", ranking(vss_datafit[[tstsetup]])[["fulldata"]]))) {
+      ### Testing for non-increasing element `ce` (for increasing model size)
+      ### doesn't make sense if the ranking of predictors involved in
+      ### interactions has been changed, so we choose a higher `extra_tol`:
+      extra_tol_crr <- 3
+      ###
+    }
     vsel_tester(
       vss_datafit[[tstsetup]],
       from_datafit = TRUE,
@@ -249,7 +257,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_vs_datafit[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs_datafit[[tstsetup]]$search_terms)),
-      extra_tol = 1.5,
+      extra_tol = extra_tol_crr,
       info_str = tstsetup
     )
   }

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -166,9 +166,9 @@ if (run_vs) {
   })
 
   prjs_vs_datafit <- lapply(args_prj_vs_datafit, function(args_prj_vs_i) {
+    args_prj_vs_i$refit_prj <- FALSE
     do.call(project, c(
-      list(object = vss_datafit[[args_prj_vs_i$tstsetup_vsel]],
-           refit_prj = FALSE),
+      list(object = vss_datafit[[args_prj_vs_i$tstsetup_vsel]]),
       excl_nonargs(args_prj_vs_i)
     ))
   })
@@ -307,10 +307,10 @@ test_that("project(): `object` of class \"datafit\" fails", {
   for (tstsetup in tstsetups) {
     args_prj_i <- args_prj[[tstsetup]]
     if (!args_prj_i$tstsetup_ref %in% names(datafits)) next
+    args_prj_i$refit_prj <- FALSE
     expect_error(
       do.call(project, c(
-        list(object = datafits[[args_prj_i$tstsetup_ref]],
-             refit_prj = FALSE),
+        list(object = datafits[[args_prj_i$tstsetup_ref]]),
         excl_nonargs(args_prj_i)
       )),
       paste("^project\\(\\) does not support an `object` of class",

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -22,8 +22,6 @@ test_that(paste(
       refmod_expected = refmods[[tstsetup_ref]],
       solterms_len_expected = args_vs[[tstsetup]]$nterms_max,
       method_expected = meth_exp_crr,
-      nprjdraws_search_expected = args_vs[[tstsetup]]$nclusters,
-      nprjdraws_eval_expected = args_vs[[tstsetup]]$nclusters_pred,
       search_trms_empty_size =
         length(args_vs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs[[tstsetup]]$search_terms)),
@@ -167,8 +165,6 @@ test_that(paste(
       ),
       solterms_len_expected = args_vs_i$nterms_max,
       method_expected = meth_exp_crr,
-      nprjdraws_search_expected = args_vs_i$nclusters,
-      nprjdraws_eval_expected = args_vs_i$nclusters_pred,
       search_trms_empty_size =
         length(args_vs_i$search_terms) &&
         all(grepl("\\+", args_vs_i$search_terms)),
@@ -299,8 +295,6 @@ test_that(paste(
       ),
       solterms_len_expected = args_vs_i$nterms_max,
       method_expected = meth_exp_crr,
-      nprjdraws_search_expected = args_vs_i$nclusters,
-      nprjdraws_eval_expected = args_vs_i$nclusters_pred,
       search_trms_empty_size =
         length(args_vs_i$search_terms) &&
         all(grepl("\\+", args_vs_i$search_terms)),
@@ -573,8 +567,6 @@ test_that("`refit_prj` works", {
       solterms_len_expected = args_vs_i$nterms_max,
       method_expected = meth_exp_crr,
       refit_prj_expected = FALSE,
-      nprjdraws_search_expected = args_vs_i$nclusters,
-      nprjdraws_eval_expected = args_vs_i$nclusters,
       search_trms_empty_size =
         length(args_vs_i$search_terms) &&
         all(grepl("\\+", args_vs_i$search_terms)),
@@ -623,8 +615,6 @@ test_that(paste(
           refmod_expected = refmods[[args_vs_i$tstsetup_ref]],
           solterms_len_expected = args_vs_i$nterms_max,
           method_expected = "L1",
-          nprjdraws_search_expected = args_vs_i$nclusters,
-          nprjdraws_eval_expected = args_vs_i$nclusters_pred,
           info_str = tstsetup
         )
         # Expect equality for all components not related to prediction:
@@ -710,8 +700,6 @@ test_that(paste(
           refmod_expected = refmods[[args_vs_i$tstsetup_ref]],
           solterms_len_expected = args_vs_i$nterms_max,
           method_expected = "forward",
-          nprjdraws_search_expected = args_vs_i$nclusters,
-          nprjdraws_eval_expected = args_vs_i$nclusters_pred,
           search_trms_empty_size =
             length(args_vs_i$search_terms) &&
             all(grepl("\\+", args_vs_i$search_terms)),
@@ -912,8 +900,6 @@ test_that("for L1 search, `penalty` has an expected effect", {
       refmod_expected = refmods[[args_vs_i$tstsetup_ref]],
       solterms_len_expected = nterms_max_crr,
       method_expected = "L1",
-      nprjdraws_search_expected = args_vs_i$nclusters,
-      nprjdraws_eval_expected = args_vs_i$nclusters_pred,
       info_str = tstsetup
     )
     # Check that the variables with no cost are selected first and the ones
@@ -976,8 +962,7 @@ test_that("L1 search handles three-way (second-order) interactions correctly", {
     refmod_expected = refmod,
     solterms_len_expected = count_terms_in_formula(refmod$formula) - 1L,
     method_expected = "L1",
-    nprjdraws_search_expected = 1L,
-    nprjdraws_eval_expected = 1L,
+    refit_prj_expected = FALSE,
     ### Testing for non-increasing element `ce` (for increasing model size)
     ### doesn't make sense if the ranking of predictors involved in interactions
     ### has been changed, so we choose a higher `extra_tol` than by default:
@@ -1083,8 +1068,6 @@ test_that(paste(
       method_expected = meth_exp_crr,
       cv_method_expected = args_cvvs[[tstsetup]]$cv_method,
       valsearch_expected = args_cvvs[[tstsetup]]$validate_search,
-      nprjdraws_search_expected = args_cvvs[[tstsetup]]$nclusters,
-      nprjdraws_eval_expected = args_cvvs[[tstsetup]]$nclusters_pred,
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
@@ -1190,8 +1173,6 @@ test_that("`refit_prj` works", {
       refit_prj_expected = FALSE,
       cv_method_expected = args_cvvs_i$cv_method,
       valsearch_expected = args_cvvs_i$validate_search,
-      nprjdraws_search_expected = args_cvvs_i$nclusters,
-      nprjdraws_eval_expected = args_cvvs_i$nclusters,
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
         all(grepl("\\+", args_cvvs_i$search_terms)),
@@ -1265,8 +1246,6 @@ test_that("setting `nloo` smaller than the number of observations works", {
       method_expected = meth_exp_crr,
       cv_method_expected = "LOO",
       valsearch_expected = args_cvvs_i$validate_search,
-      nprjdraws_search_expected = args_cvvs_i$nclusters,
-      nprjdraws_eval_expected = args_cvvs_i$nclusters_pred,
       nloo_expected = nloo_tst,
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
@@ -1327,8 +1306,6 @@ test_that("`validate_search` works", {
       method_expected = meth_exp_crr,
       cv_method_expected = "LOO",
       valsearch_expected = FALSE,
-      nprjdraws_search_expected = args_cvvs_i$nclusters,
-      nprjdraws_eval_expected = args_cvvs_i$nclusters_pred,
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
         all(grepl("\\+", args_cvvs_i$search_terms)),
@@ -1479,8 +1456,6 @@ test_that(paste(
       method_expected = meth_exp_crr,
       cv_method_expected = "kfold",
       valsearch_expected = args_cvvs_i$validate_search,
-      nprjdraws_search_expected = args_cvvs_i$nclusters,
-      nprjdraws_eval_expected = args_cvvs_i$nclusters_pred,
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
         all(grepl("\\+", args_cvvs_i$search_terms)),
@@ -1613,8 +1588,6 @@ test_that(paste(
       method_expected = meth_exp_crr,
       cv_method_expected = "kfold",
       valsearch_expected = args_cvvs_i$validate_search,
-      nprjdraws_search_expected = args_cvvs_i$nclusters,
-      nprjdraws_eval_expected = args_cvvs_i$nclusters_pred,
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
         all(grepl("\\+", args_cvvs_i$search_terms)),

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -558,6 +558,15 @@ test_that("`refit_prj` works", {
       meth_exp_crr <- ifelse(mod_crr == "glm" && prj_crr != "augdat",
                              "L1", "forward")
     }
+    extra_tol_crr <- 1.1
+    if (meth_exp_crr == "L1" &&
+        any(grepl(":", ranking(vs_reuse)[["fulldata"]]))) {
+      ### Testing for non-increasing element `ce` (for increasing model size)
+      ### doesn't make sense if the ranking of predictors involved in
+      ### interactions has been changed, so we choose a higher `extra_tol`:
+      extra_tol_crr <- 1.2
+      ###
+    }
     vsel_tester(
       vs_reuse,
       refmod_expected = refmods[[args_vs_i$tstsetup_ref]],
@@ -569,6 +578,7 @@ test_that("`refit_prj` works", {
       search_trms_empty_size =
         length(args_vs_i$search_terms) &&
         all(grepl("\\+", args_vs_i$search_terms)),
+      extra_tol = extra_tol_crr,
       info_str = tstsetup
     )
   }

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -534,6 +534,7 @@ test_that("`refit_prj` works", {
   }
   for (tstsetup in tstsetups) {
     args_vs_i <- args_vs[[tstsetup]]
+    args_vs_i$refit_prj <- FALSE
     if (args_vs_i$prj_nm == "augdat" && args_vs_i$fam_nm == "cumul") {
       warn_expected <- "non-integer #successes in a binomial glm!"
     } else if (!is.null(args_vs_i$avoid.increase)) {
@@ -543,8 +544,7 @@ test_that("`refit_prj` works", {
     }
     expect_warning(
       vs_reuse <- do.call(varsel, c(
-        list(object = refmods[[args_vs_i$tstsetup_ref]],
-             refit_prj = FALSE),
+        list(object = refmods[[args_vs_i$tstsetup_ref]]),
         excl_nonargs(args_vs_i)
       )),
       warn_expected,
@@ -1168,9 +1168,9 @@ test_that("`refit_prj` works", {
   }
   for (tstsetup in tstsetups) {
     args_cvvs_i <- args_cvvs[[tstsetup]]
+    args_cvvs_i$refit_prj <- FALSE
     cvvs_reuse <- suppressWarnings(do.call(cv_varsel, c(
-      list(object = refmods[[args_cvvs_i$tstsetup_ref]],
-           refit_prj = FALSE),
+      list(object = refmods[[args_cvvs_i$tstsetup_ref]]),
       excl_nonargs(args_cvvs_i)
     )))
     mod_crr <- args_cvvs_i$mod_nm


### PR DESCRIPTION
By this PR, we now automatically re-rank lower-order interaction terms after an L1 search and we also take permutations of main-effect terms (within a given interaction term) into account when predicting with `predict.subfit()`. See the newly added `NEWS.md` entries and the commit messages for details. An illustration is given by the modified unit tests.