### PR TITLE
Progress bar for `project()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 ## Minor changes
 
 * If an L1 search selects an interaction term before all involved lower-order interaction terms (including main-effect terms) have been selected, the predictor ranking is now automatically modified so that the lower-order interaction terms come before this interaction term. A corresponding warning is thrown, which may be deactivated by setting the global option `projpred.warn_L1_interactions` to `FALSE`. Previously, beginning with version 2.5.0, only a warning was thrown and this only if an L1 search selected an interaction term before all involved *main-effect* terms had been selected. (GitHub: #420)
+* Added a progress bar for `project()` (when using the built-in divergence minimizers). For this, `project()` has gained a new argument `verbose` which can also be controlled via the global option `projpred.verbose_project`. By default, the new progress bar is activated. (GitHub: #421)
 
 ## Bug fixes
 

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -9,7 +9,7 @@ if (getRversion() >= package_version("2.15.1")) {
   utils::globalVariables("projpred_formula_no_random_s")
 }
 
-divmin <- function(formula, projpred_var, ...) {
+divmin <- function(formula, projpred_var, projpred_verbose = FALSE, ...) {
   trms_all <- extract_terms_response(formula)
   has_grp <- length(trms_all$group_terms) > 0
   has_add <- length(trms_all$additive_terms) > 0
@@ -55,7 +55,15 @@ divmin <- function(formula, projpred_var, ...) {
     # foreach::`%do%`` here and then proceed as in the parallel case, but that
     # would require adding more "hard" dependencies (because packages 'foreach'
     # and 'iterators' would have to be moved from `Suggests:` to `Imports:`).
+    if (projpred_verbose) {
+      pb <- utils::txtProgressBar(min = 0, max = length(formulas), style = 3,
+                                  initial = 0)
+      on.exit(close(pb))
+    }
     return(lapply(seq_along(formulas), function(s) {
+      if (projpred_verbose) {
+        on.exit(utils::setTxtProgressBar(pb, s))
+      }
       sdivmin(
         formula = formulas[[s]],
         projpred_var = projpred_var[, s, drop = FALSE],
@@ -501,7 +509,7 @@ if (getRversion() >= package_version("2.15.1")) {
 }
 
 divmin_augdat <- function(formula, data, family, weights, projpred_var,
-                          projpred_ws_aug, ...) {
+                          projpred_ws_aug, projpred_verbose = FALSE, ...) {
   trms_all <- extract_terms_response(formula)
   has_grp <- length(trms_all$group_terms) > 0
   projpred_formula_no_random <- NA
@@ -554,7 +562,15 @@ divmin_augdat <- function(formula, data, family, weights, projpred_var,
     # foreach::`%do%`` here and then proceed as in the parallel case, but that
     # would require adding more "hard" dependencies (because packages 'foreach'
     # and 'iterators' would have to be moved from `Suggests:` to `Imports:`).
+    if (projpred_verbose) {
+      pb <- utils::txtProgressBar(min = 0, max = ncol(projpred_ws_aug),
+                                  style = 3, initial = 0)
+      on.exit(close(pb))
+    }
     return(lapply(seq_len(ncol(projpred_ws_aug)), function(s) {
+      if (projpred_verbose) {
+        on.exit(utils::setTxtProgressBar(pb, s))
+      }
       sdivmin(
         formula = formula,
         data = data,

--- a/R/project.R
+++ b/R/project.R
@@ -45,6 +45,12 @@
 #'   (however, not yet in case of a GAMM) and having global option
 #'   `projpred.mlvl_pred_new` set to `TRUE`. (Such a prediction takes place when
 #'   calculating output elements `dis` and `ce`.)
+#' @param verbose A single logical value indicating whether to print out
+#'   additional information during the computations. More precisely, this gets
+#'   passed as `projpred_verbose` to the divergence minimizer function of the
+#'   `refmodel` object. For the built-in divergence minimizers, this only has an
+#'   effect in case of sequential computations (not in case of parallel
+#'   projection, which is described in [projpred-package]).
 #' @inheritParams varsel
 #' @param ... Arguments passed to [get_refmodel()] (if [get_refmodel()] is
 #'   actually used; see argument `object`) as well as to the divergence
@@ -143,6 +149,7 @@
 #' @export
 project <- function(object, nterms = NULL, solution_terms = NULL,
                     refit_prj = TRUE, ndraws = 400, nclusters = NULL, seed = NA,
+                    verbose = getOption("projpred.verbose_project", TRUE),
                     regul = 1e-4, ...) {
   if (inherits(object, "datafit")) {
     stop("project() does not support an `object` of class \"datafit\".")
@@ -258,7 +265,7 @@ project <- function(object, nterms = NULL, solution_terms = NULL,
       outdmins = object$search_path$outdmins
     ),
     nterms = nterms, p_ref = p_ref, refmodel = refmodel, regul = regul,
-    refit_prj = refit_prj, ...
+    refit_prj = refit_prj, projpred_verbose = verbose, ...
   )
 
   # Output:

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -5,8 +5,7 @@
 # class `submodl`.
 get_submodl_prj <- function(solution_terms, p_ref, refmodel, regul = 1e-4,
                             ...) {
-  validparams <- validate_wobs_wdraws(refmodel$wobs, p_ref$wdraws_prj,
-                                      p_ref$mu)
+  validparams <- validate_wobs_wdraws(refmodel$wobs, p_ref$wdraws_prj, p_ref$mu)
   wobs <- validparams$wobs
   wdraws_prj <- validparams$wdraws_prj
 

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -12,6 +12,7 @@ project(
   ndraws = 400,
   nclusters = NULL,
   seed = NA,
+  verbose = getOption("projpred.verbose_project", TRUE),
   regul = 1e-04,
   ...
 )
@@ -63,6 +64,13 @@ drawing new group-level effects when predicting from a multilevel submodel
 (however, not yet in case of a GAMM) and having global option
 \code{projpred.mlvl_pred_new} set to \code{TRUE}. (Such a prediction takes place when
 calculating output elements \code{dis} and \code{ce}.)}
+
+\item{verbose}{A single logical value indicating whether to print out
+additional information during the computations. More precisely, this gets
+passed as \code{projpred_verbose} to the divergence minimizer function of the
+\code{refmodel} object. For the built-in divergence minimizers, this only has an
+effect in case of sequential computations (not in case of parallel
+projection, which is described in \link{projpred-package}).}
 
 \item{regul}{A number giving the amount of ridge regularization when
 projecting onto (i.e., fitting) submodels which are GLMs. Usually there is

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -866,6 +866,8 @@ options(projpred.warn_L1_interactions = FALSE)
 # Suppress the warning thrown by proj_predict() in case of observation weights
 # that are not all equal to `1`:
 options(projpred.warn_wobs_ppd = FALSE)
+# Suppress the verbose-mode progress bar in project():
+options(projpred.verbose_project = FALSE)
 
 search_trms_tst <- list(
   default_search_trms = list(),


### PR DESCRIPTION
This adds a progress bar to `project()` (at least when using the built-in divergence minimizers). Illustration for the traditional (and latent) projection:
```r
# Data --------------------------------------------------------------------

data("df_gaussian", package = "projpred")
df_gaussian <- df_gaussian[1:41, ]
dat <- data.frame(y = df_gaussian$y, df_gaussian$x)
dat$group <- gl(n = 8, k = floor(nrow(dat) / 8), length = nrow(dat),
                labels = paste0("gr", seq_len(8)))
dat$addgrp <- gl(n = 10, k = floor(nrow(dat) / 10), length = nrow(dat),
                 labels = paste0("agr", seq_len(10)))
dat$addgrp <- as.character(dat$addgrp)
set.seed(457211)
group_icpts_truth <- rnorm(nlevels(dat$group), sd = 6)
group_X1_truth <- rnorm(nlevels(dat$group), sd = 6)
icpt <- -4.2
dat$y <- icpt +
  group_icpts_truth[dat$group] +
  group_X1_truth[dat$group] * dat$X1
dat$y <- rnorm(nrow(dat), mean = dat$y, sd = 4)

# Fit with brms -----------------------------------------------------------

suppressPackageStartupMessages(library(brms))
options(mc.cores = parallel::detectCores(logical = FALSE))
fit <- brm(y ~ X1 + X2 + X3 + X4 + X5 + (1 + X1 | group) + (1 | addgrp),
           data = dat,
           control = list(adapt_delta = 0.9),
           seed = 1140350788)

# projpred ----------------------------------------------------------------

devtools::load_all() # Use `library(projpred)` if installed.

refm <- get_refmodel(fit)

prj <- project(
  refm,
  ndraws = 30,
  solution_terms = c("(1 | group)", "X1", "X3", "(X1 | group)", "X2")
)

prj <- project(
  refm,
  ndraws = 30,
  solution_terms = c("(1 | group)", "X1", "X3", "(X1 | group)", "X2"),
  verbose = FALSE
)

options(projpred.verbose_project = FALSE)
prj <- project(
  refm,
  ndraws = 30,
  solution_terms = c("(1 | group)", "X1", "X3", "(X1 | group)", "X2")
)

options(projpred.verbose_project = NULL)
prj <- project(
  refm,
  ndraws = 30,
  solution_terms = c("(1 | group)", "X1", "X3", "(X1 | group)", "X2")
)
```
Illustration for the augmented-data projection:
```r
# Data --------------------------------------------------------------------

data(inhaler, package = "brms")
inhaler$rating <- paste0("rtg", inhaler$rating)
inhaler$rating <- as.factor(inhaler$rating)

# Fit with rstanarm -------------------------------------------------------

library(rstanarm)
options(mc.cores = parallel::detectCores(logical = FALSE))
fit <- stan_polr(rating ~ period + carry + treat,
                 data = inhaler,
                 prior = R2(location = 0.5, what = "median"),
                 seed = 1140350788)

# projpred ----------------------------------------------------------------

devtools::load_all() # Use `library(projpred)` if installed.

refm <- get_refmodel(fit)

prj <- project(
  refm,
  ndraws = 30,
  solution_terms = c("carry", "treat")
)

prj <- project(
  refm,
  ndraws = 30,
  solution_terms = c("carry", "treat"),
  verbose = FALSE
)

options(projpred.verbose_project = FALSE)
prj <- project(
  refm,
  ndraws = 30,
  solution_terms = c("carry", "treat")
)

options(projpred.verbose_project = NULL)
prj <- project(
  refm,
  ndraws = 30,
  solution_terms = c("carry", "treat")
)
```