### PR TITLE
testing removal of except function

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -962,7 +962,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
 
   # Handle the submodels' performance evaluation results:
   sub_foldwise <- simplify2array(lapply(res_cv, "[[", "summaries_sub"),
-                                 higher = FALSE, except = NULL)
+                                 higher = FALSE)
   sub <- apply(sub_foldwise, 1, rbind2list)
   idxs_sorted_by_fold <- unlist(lapply(list_cv, function(fold) {
     fold$omitted


### PR DESCRIPTION
# Removal of `Except` Argument in CV_Varsel Simplify2 Array

Attempt to fix #423. Very simple fix (unless I am missing something fundamental), I am removing the `except=NULL` argument, for the simplify2array function, called in the `kfold_varsel` function. I ran through with the example from the `cv_varsel` documentation.

```
dat_gauss <- data.frame(y = df_gaussian$y, df_gaussian$x)
  fit <- rstanarm::stan_glm(
    y ~ X1 + X2 + X3 + X4 + X5, family = gaussian(), data = dat_gauss,
    QR = TRUE, chains = 2, iter = 1000, refresh = 0, seed = 9876
  )
  # Run cv_varsel() (with small values for `K`, `nterms_max`, `nclusters`,
  # and `nclusters_pred`, but only for the sake of speed in this example;
  # this is not recommended in general):

  ref_model <- get_refmodel(fit)

  cvvs <- cv_varsel(object=ref_model,  
  method ="kfold",
  cv_method = if (!inherits(object, "datafit")) "LOO" else "kfold",
  ndraws = NULL,
  nclusters = 5,
  ndraws_pred = 10,
  nclusters_pred = NULL,
  refit_prj = !inherits(object, "datafit"),
  nterms_max = 3,
  penalty = NULL,
  verbose = TRUE,
  nloo = NULL,
  K =2,
  lambda_min_ratio = 1e-5,
  nlambda = 150,
  thresh = 1e-6,
  regul = 1e-4,
  validate_search = TRUE,
  seed = 5555,
  search_terms = NULL,
  parallel = getOption("projpred.prll_cv", FALSE))

```

I compared the outputs of these two calls:

```
sub_foldwise <- simplify2array(lapply(res_cv, "[[", "summaries_sub"),
                                 higher = FALSE)

sub_foldwise <- simplify2array(lapply(res_cv, "[[", "summaries_sub"),
                                 higher = FALSE, except=NULL)

```

And they appear to be the same (although I am no expert so I may be missing something. I am currently running this an an example dataset of my own to also see if this works. 

I know this is such a minor change, but I hope it helps a little! Sorry again for all of the hassle with my questions :) 

