### PR TITLE
Fix incompatibility with R < 4.2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 * Fixed a bug in the printed number of projected draws for the performance evaluation when calling `print.vselsummary()` based on output from `varsel()` with `refit_prj = FALSE`.
 * Fixed a bug sometimes causing an error when predicting from a submodel that is a GLM and has interactions. (GitHub: #420)
+* Fixed an incompatibility of K-fold CV with R versions < 4.2.0. (GitHub: #423, #427)
 
 # projpred 2.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 * Fixed a bug in the printed number of projected draws for the performance evaluation when calling `print.vselsummary()` based on output from `varsel()` with `refit_prj = FALSE`.
 * Fixed a bug sometimes causing an error when predicting from a submodel that is a GLM and has interactions. (GitHub: #420)
-* Fixed an incompatibility of K-fold CV with R versions < 4.2.0. (GitHub: #423, #427)
+* Fixed a bug introduced in version 2.6.0, causing an incompatibility of K-fold CV with R versions < 4.2.0. (GitHub: #423, #427)
 
 # projpred 2.6.0
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -963,8 +963,17 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
   solution_terms_cv <- do.call(rbind, lapply(res_cv, "[[", "predictor_ranking"))
 
   # Handle the submodels' performance evaluation results:
-  sub_foldwise <- simplify2array(lapply(res_cv, "[[", "summaries_sub"),
-                                 higher = FALSE, except = NULL)
+  sub_foldwise <- lapply(res_cv, "[[", "summaries_sub")
+  if (getRversion() >= package_version("4.2.0")) {
+    sub_foldwise <- simplify2array(sub_foldwise, higher = FALSE, except = NULL)
+  } else {
+    sub_foldwise <- simplify2array(sub_foldwise, higher = FALSE)
+    if (is.null(dim(sub_foldwise))) {
+      sub_dim <- dim(solution_terms_cv)
+      sub_dim[2] <- sub_dim[2] + 1L # +1 is for the empty model
+      dim(sub_foldwise) <- rev(sub_dim)
+    }
+  }
   sub <- apply(sub_foldwise, 1, rbind2list)
   idxs_sorted_by_fold <- unlist(lapply(list_cv, function(fold) {
     fold$omitted


### PR DESCRIPTION
Fixes #423. The special case requiring `except = NULL` in `simplify2array()` is `nterms_max = 0`:
```r
data("df_gaussian", package = "projpred")
df_gaussian <- df_gaussian[1:29, ]
dat <- data.frame(y = df_gaussian$y, df_gaussian$x)
library(rstanarm)
rfit <- stan_glm(y ~ X1 + X2 + X3 + X4 + X5,
                 data = dat,
                 chains = 1,
                 iter = 500,
                 seed = 1140350788,
                 refresh = 0)

### If fixed version is not installed:
devtools::load_all(".")
###
### If fixed version is installed:
# library(projpred)
###

cvvs <- cv_varsel(rfit,
                  method = "forward",
                  cv_method = "kfold",
                  K = 2,
                  nclusters = 3,
                  nclusters_pred = 5,
                  nterms_max = 0,
                  seed = 46782345)

```