### PR TITLE
`plot.vsel()`: Increase `size` and `linewidth`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Added a progress bar for `project()` (when using the built-in divergence minimizers). For this, `project()` has gained a new argument `verbose` which can also be controlled via the global option `projpred.verbose_project`. By default, the new progress bar is activated. (GitHub: #421)
 * Added a new argument `parallel` to `cv_varsel()`. With `parallel = TRUE`, costly parts of **projpred**'s cross-validation (CV) can be run in parallel. See the documentation of that new argument (and section "Note" of `cv_varsel()`'s documentation) for details. (GitHub: #422)
 * Throw a warning for issue #323 (for multilevel Gaussian models, the projection onto the full model can be instable). (GitHub: #426)
+* `plot.vsel()`: The uncertainty bars are slightly thicker now and the points slightly larger. (GitHub: #429)
 
 ## Bug fixes
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -877,9 +877,9 @@ plot.vsel <- function(
   }
   pp <- pp +
     # The submodel-specific graphical elements:
-    geom_linerange(alpha = 0.55) +
+    geom_linerange(alpha = 0.55, linewidth = 1) +
     geom_line() +
-    geom_point() +
+    geom_point(size = 3) +
     # Miscellaneous stuff (axes, theming, faceting, etc.):
     scale_x_continuous(
       breaks = breaks, minor_breaks = minor_breaks,


### PR DESCRIPTION
This makes the uncertainty bars in `plot.vsel()` slightly thicker and the points slightly larger. Strictly speaking, this is not necessary at the moment, but when gradient-coloring the points and the uncertainty bars in the future, this will help making the colors easier to distinguish. Furthermore, the points and the uncertainty bars have been very small / thin anyway.