### PR TITLE
`plot.vsel()`: Possibly color points and uncertainty bars according to CV ranking proportions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Added a new argument `parallel` to `cv_varsel()`. With `parallel = TRUE`, costly parts of **projpred**'s cross-validation (CV) can be run in parallel. See the documentation of that new argument (and section "Note" of `cv_varsel()`'s documentation) for details. (GitHub: #422)
 * Throw a warning for issue #323 (for multilevel Gaussian models, the projection onto the full model can be instable). (GitHub: #426)
 * `plot.vsel()`: The uncertainty bars are slightly thicker now and the points slightly larger. (GitHub: #429)
+* `plot.vsel()`: Added argument `ranking_colored` for coloring the points and the uncertainty bars according to the magnitude of the (possibly cumulated) CV ranking proportions. (GitHub: #430; thanks to @yannmclatchie for the suggestion)
 
 ## Bug fixes
 

--- a/man/plot.vsel.Rd
+++ b/man/plot.vsel.Rd
@@ -18,6 +18,7 @@
   ranking_abbreviate_args = list(),
   ranking_repel = NULL,
   ranking_repel_args = list(),
+  ranking_colored = FALSE,
   cumulate = FALSE,
   text_angle = NULL,
   ...
@@ -111,6 +112,16 @@ the plotting area, using \code{\link[ggrepel:geom_text_repel]{ggrepel::geom_text
 passed to \code{\link[ggrepel:geom_text_repel]{ggrepel::geom_text_repel()}} or \code{\link[ggrepel:geom_text_repel]{ggrepel::geom_label_repel()}} in
 case of \code{ranking_repel = "text"} or \code{ranking_repel = "label"},
 respectively.}
+
+\item{ranking_colored}{A single logical value indicating whether the points
+and the uncertainty bars should be gradient-colored according to the CV
+ranking proportions (\code{TRUE}) or not (\code{FALSE}). The CV ranking proportions
+may be cumulated (see argument \code{cumulate}). Note that the point and the
+uncertainty bar at submodel size 0 (i.e., at the intercept-only model) are
+always colored in gray because the intercept is forced to be selected
+before any predictors are selected (in other words, the reason is that for
+submodel size 0, the question of variability across CV folds is not
+appropriate in the first place).}
 
 \item{cumulate}{Passed to argument \code{cumulate} of \code{\link[=cv_proportions]{cv_proportions()}}. Affects
 the ranking proportions given on the x-axis (below the full-data predictor

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1702,7 +1702,7 @@ cre_args_plot_vsel <- function(args_obj) {
         lapply(rk_max_tst, function(rk_max_crr) {
           lapply(rk_abbv_tst, function(rk_abbv_crr) {
             lapply(rk_repel_tst, function(rk_repel_crr) {
-              lapply(rk_col_tst["colFALSE"], function(rk_col_crr) {
+              lapply(rk_col_tst, function(rk_col_crr) {
                 lapply(cumulate_tst, function(cumulate_crr) {
                   lapply(angle_tst, function(angle_crr) {
                     return(c(

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -926,6 +926,9 @@ rk_repel_tst <- list(
                    ranking_repel_args = list(seed = seed3_tst))
 )
 
+rk_col_tst <- as.list(setNames(nm = c(FALSE, TRUE)))
+names(rk_col_tst) <- paste0("col", names(rk_col_tst))
+
 cumulate_tst <- as.list(setNames(nm = c(FALSE, TRUE)))
 names(cumulate_tst) <- paste0("cu", names(cumulate_tst))
 
@@ -1699,16 +1702,19 @@ cre_args_plot_vsel <- function(args_obj) {
         lapply(rk_max_tst, function(rk_max_crr) {
           lapply(rk_abbv_tst, function(rk_abbv_crr) {
             lapply(rk_repel_tst, function(rk_repel_crr) {
-              lapply(cumulate_tst, function(cumulate_crr) {
-                lapply(angle_tst, function(angle_crr) {
-                  return(c(
-                    nlist(tstsetup_vsel),
-                    only_nonargs(args_obj[[tstsetup_vsel]]),
-                    list(nterms_max = nterms_crr),
-                    rk_max_crr, rk_abbv_crr, rk_repel_crr,
-                    list(cumulate = cumulate_crr),
-                    angle_crr
-                  ))
+              lapply(rk_col_tst["colFALSE"], function(rk_col_crr) {
+                lapply(cumulate_tst, function(cumulate_crr) {
+                  lapply(angle_tst, function(angle_crr) {
+                    return(c(
+                      nlist(tstsetup_vsel),
+                      only_nonargs(args_obj[[tstsetup_vsel]]),
+                      list(nterms_max = nterms_crr),
+                      rk_max_crr, rk_abbv_crr, rk_repel_crr,
+                      list(ranking_colored = rk_col_crr,
+                           cumulate = cumulate_crr),
+                      angle_crr
+                    ))
+                  })
                 })
               })
             })

--- a/tests/testthat/test_methods_vsel.R
+++ b/tests/testthat/test_methods_vsel.R
@@ -277,6 +277,20 @@ test_that("`x` of class \"vsel\" (created by varsel()) works", {
       } else {
         tstsetup_target <- tstsetup
       }
+    } else if (args_plot_i$ranking_colored) {
+      matches_tstsetup <- sapply(names(plots_vs), function(tstsetup2) {
+        args_plot_i2 <- args_plot_vs[[tstsetup2]]
+        if (!setequal(names(args_plot_i), names(args_plot_i2))) {
+          return(FALSE)
+        }
+        identical(args_plot_i[setdiff(names(args_plot_i), "ranking_colored")],
+                  args_plot_i2[setdiff(names(args_plot_i2), "ranking_colored")])
+      })
+      if (any(matches_tstsetup)) {
+        tstsetup_target <- names(which.max(matches_tstsetup))
+      } else {
+        tstsetup_target <- tstsetup
+      }
     } else if (args_plot_i$cumulate) {
       matches_tstsetup <- sapply(names(plots_vs), function(tstsetup2) {
         args_plot_i2 <- args_plot_vs[[tstsetup2]]
@@ -313,7 +327,7 @@ test_that("`x` of class \"vsel\" (created by cv_varsel()) works", {
                         "ranking_nterms_max")
   common_for_rk_max <- c("tstsetup_vsel", "text_angle", "nterms_max",
                          "ranking_abbreviate", "ranking_repel",
-                         "cumulate")
+                         "ranking_colored", "cumulate")
   for (tstsetup in names(plots_cvvs)) {
     args_plot_i <- args_plot_cvvs[[tstsetup]]
     if (identical(args_plot_i$ranking_nterms_max, NA)) {
@@ -392,8 +406,8 @@ test_that(paste(
 ), {
   skip_if_not(run_vs)
   tstsetups <- grep(paste("\\.default_nterms_max_smmry", "\\.default_rk_max",
-                          "\\.default_abbv", "\\.default_repel", "\\.cuFALSE",
-                          "\\.default_angle", sep = ".*"),
+                          "\\.default_abbv", "\\.default_repel", "\\.colFALSE",
+                          "\\.cuFALSE", "\\.default_angle", sep = ".*"),
                     names(plots_vs), value = TRUE)
   for (tstsetup in tstsetups) {
     args_plot_i <- args_plot_vs[[tstsetup]]
@@ -417,8 +431,8 @@ test_that(paste(
 ), {
   skip_if_not(run_cvvs)
   tstsetups <- grep(paste("\\.default_nterms_max_smmry", "\\.default_rk_max",
-                          "\\.default_abbv", "\\.default_repel", "\\.cuFALSE",
-                          "\\.default_angle", sep = ".*"),
+                          "\\.default_abbv", "\\.default_repel", "\\.colFALSE",
+                          "\\.cuFALSE", "\\.default_angle", sep = ".*"),
                     names(plots_cvvs), value = TRUE)
   for (tstsetup in tstsetups) {
     args_plot_i <- args_plot_cvvs[[tstsetup]]

--- a/tests/testthat/test_methods_vsel.R
+++ b/tests/testthat/test_methods_vsel.R
@@ -277,28 +277,15 @@ test_that("`x` of class \"vsel\" (created by varsel()) works", {
       } else {
         tstsetup_target <- tstsetup
       }
-    } else if (args_plot_i$ranking_colored) {
+    } else if (args_plot_i$ranking_colored || args_plot_i$cumulate) {
+      not_common_here <- c("ranking_colored", "cumulate")
       matches_tstsetup <- sapply(names(plots_vs), function(tstsetup2) {
         args_plot_i2 <- args_plot_vs[[tstsetup2]]
         if (!setequal(names(args_plot_i), names(args_plot_i2))) {
           return(FALSE)
         }
-        identical(args_plot_i[setdiff(names(args_plot_i), "ranking_colored")],
-                  args_plot_i2[setdiff(names(args_plot_i2), "ranking_colored")])
-      })
-      if (any(matches_tstsetup)) {
-        tstsetup_target <- names(which.max(matches_tstsetup))
-      } else {
-        tstsetup_target <- tstsetup
-      }
-    } else if (args_plot_i$cumulate) {
-      matches_tstsetup <- sapply(names(plots_vs), function(tstsetup2) {
-        args_plot_i2 <- args_plot_vs[[tstsetup2]]
-        if (!setequal(names(args_plot_i), names(args_plot_i2))) {
-          return(FALSE)
-        }
-        identical(args_plot_i[setdiff(names(args_plot_i), "cumulate")],
-                  args_plot_i2[setdiff(names(args_plot_i2), "cumulate")])
+        identical(args_plot_i[setdiff(names(args_plot_i), not_common_here)],
+                  args_plot_i2[setdiff(names(args_plot_i2), not_common_here)])
       })
       if (any(matches_tstsetup)) {
         tstsetup_target <- names(which.max(matches_tstsetup))


### PR DESCRIPTION
This adds argument called `ranking_colored` to `plot.vsel()` which, when set to `TRUE` (default: `FALSE`) will color the points and the uncertainty bars according to the magnitude of the (possibly cumulated) CV ranking proportions.

Thanks to @yannmclatchie for the suggestion!