### PR TITLE
Fix bug for augmented-data projection with subsampled LOO

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Fixed a bug in the printed number of projected draws for the performance evaluation when calling `print.vselsummary()` based on output from `varsel()` with `refit_prj = FALSE`.
 * Fixed a bug sometimes causing an error when predicting from a submodel that is a GLM and has interactions. (GitHub: #420)
 * Fixed a bug introduced in version 2.6.0, causing an incompatibility of K-fold CV with R versions < 4.2.0. (GitHub: #423, #427)
-* Fixed a bug for the augmented-data projection in combination with subsampled LOO. (GitHub: #433)
+* Fixed a bug for the augmented-data projection in combination with subsampled PSIS-LOO CV. (GitHub: #433)
 
 # projpred 2.6.0
 
@@ -212,7 +212,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 ## Major changes
 
-* Added support for weighted LOO proportional-to-size subsampling based on [Magnusson et al. (2019)](https://proceedings.mlr.press/v97/magnusson19a.html). However, subsampled LOO CV is now regarded as experimental. Therefore, a corresponding warning is thrown when calling `cv_varsel()` with `nloo < n` where `n` denotes the number of observations. (GitHub: #94, #252, commit feea39e)
+* Added support for weighted LOO proportional-to-size subsampling based on [Magnusson et al. (2019)](https://proceedings.mlr.press/v97/magnusson19a.html). However, subsampled PSIS-LOO CV is currently regarded as experimental. Therefore, a corresponding warning is thrown when calling `cv_varsel()` with `nloo < n` where `n` denotes the number of observations. (GitHub: #94, #252, commit feea39e)
 * Automatically explore both linear and smooths components in GAM models. This allows the user to gauge the impact of the smooth term against its linear counterpart.
 * Fast approximate LOO computation for `validate_search = FALSE` in `cv_varsel()`.
 * Formerly, the defaults for arguments `nclusters` (= `1`) and `nclusters_pred` (= `5`) of `varsel()` and `cv_varsel()` were set internally (the user-visible defaults were `NULL`). Now, `nclusters` and `ndraws_pred` (note the `ndraws_pred`, not `nclusters_pred`) have non-`NULL` user-visible defaults of `20` and `400`, respectively. In general, this increases the runtime of these functions a lot. With respect to `cv_varsel()`, the new vignette (see [vignettes](https://mc-stan.org/projpred/articles/)) mentions two ways to quickly obtain some rough preliminary results which in general should not be used as final results, though: (i) `varsel()` and (ii) `cv_varsel()` with `validate_search = FALSE` (which only takes effect for `cv_method = "LOO"`). (GitHub: #291 and several commits beforehand, in particular bbd0f0a, babe031, 4ef95d3, and ce7d1e0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Fixed a bug in the printed number of projected draws for the performance evaluation when calling `print.vselsummary()` based on output from `varsel()` with `refit_prj = FALSE`.
 * Fixed a bug sometimes causing an error when predicting from a submodel that is a GLM and has interactions. (GitHub: #420)
 * Fixed a bug introduced in version 2.6.0, causing an incompatibility of K-fold CV with R versions < 4.2.0. (GitHub: #423, #427)
+* Fixed a bug for the augmented-data projection in combination with subsampled LOO. (GitHub: #433)
 
 # projpred 2.6.0
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -19,11 +19,11 @@
 #'   contrast to a standard LOO CV). In the `"kfold"` case, a \eqn{K}-fold CV is
 #'   performed.
 #' @param nloo **Caution:** Still experimental. Only relevant if `cv_method =
-#'   "LOO"`. Number of subsampled LOO CV folds, i.e., number of observations
-#'   used for the LOO CV (anything between 1 and the original number of
-#'   observations). Smaller values lead to faster computation but higher
-#'   uncertainty in the evaluation part. If `NULL`, all observations are used,
-#'   but for faster experimentation, one can set this to a smaller value.
+#'   "LOO"`. Number of subsampled PSIS-LOO CV folds, i.e., number of
+#'   observations used for the LOO CV (anything between 1 and the original
+#'   number of observations). Smaller values lead to faster computation but
+#'   higher uncertainty in the evaluation part. If `NULL`, all observations are
+#'   used, but for faster experimentation, one can set this to a smaller value.
 #' @param K Only relevant if `cv_method = "kfold"` and if the reference model
 #'   was created with `cvfits` being `NULL` (which is the case for
 #'   [get_refmodel.stanreg()] and [brms::get_refmodel.brmsfit()]). Number of
@@ -44,9 +44,9 @@
 #'   `NA`, then the PRNG state is reset (to the state before calling
 #'   [cv_varsel()]) upon exiting [cv_varsel()]. Here, `seed` is used for
 #'   clustering the reference model's posterior draws (if `!is.null(nclusters)`
-#'   or `!is.null(nclusters_pred)`), for subsampling LOO CV folds (if `nloo` is
-#'   smaller than the number of observations), for sampling the folds in
-#'   \eqn{K}-fold CV, and for drawing new group-level effects when predicting
+#'   or `!is.null(nclusters_pred)`), for subsampling PSIS-LOO CV folds (if
+#'   `nloo` is smaller than the number of observations), for sampling the folds
+#'   in \eqn{K}-fold CV, and for drawing new group-level effects when predicting
 #'   from a multilevel submodel (however, not yet in case of a GAMM).
 #' @param parallel A single logical value indicating whether to run costly parts
 #'   of the CV in parallel (`TRUE`) or not (`FALSE`). See also section "Note"
@@ -425,7 +425,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   if (nloo < 1) {
     stop("nloo must be at least 1")
   } else if (nloo < n) {
-    warning("Subsampled LOO CV is still experimental.")
+    warning("Subsampled PSIS-LOO CV is still experimental.")
   }
   # validset <- loo_subsample(n, nloo, pareto_k)
   loo_ref_oscale <- apply(loglik_forPSIS + lw, 2, log_sum_exp)

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -555,6 +555,11 @@ divmin_augdat <- function(formula, data, family, weights, projpred_var,
     stop("Family `", family$family, "` is not supported by divmin_augdat().")
   }
 
+  # Coerce augmented-data matrices to ordinary matrices and augmented-length
+  # vectors to ordinary vectors so that external packages may subset as usual:
+  projpred_ws_aug <- unclass(projpred_ws_aug)
+  attr(projpred_ws_aug, "nobs_orig") <- NULL
+
   if (ncol(projpred_ws_aug) < getOption("projpred.prll_prj_trigger", Inf)) {
     # Sequential case. Actually, we could simply use ``%do_projpred%` <-
     # foreach::`%do%`` here and then proceed as in the parallel case, but that
@@ -584,22 +589,20 @@ divmin_augdat <- function(formula, data, family, weights, projpred_var,
     if (!requireNamespace("foreach", quietly = TRUE)) {
       stop("Please install the 'foreach' package.")
     }
-    # Unfortunately, iterators::iter() seems to conflict with augmented-data
-    # matrices (see note below). Thus, `requireNamespace("iterators")` is not
-    # necessary here.
+    if (!requireNamespace("iterators", quietly = TRUE)) {
+      stop("Please install the 'iterators' package.")
+    }
     dot_args <- list(...)
     `%do_projpred%` <- foreach::`%dopar%`
     return(foreach::foreach(
-      # Unfortunately, iterators::iter() seems to conflict with augmented-data
-      # matrices, even if using unclass(). Thus, iterate over the indices:
-      s = seq_len(ncol(projpred_ws_aug)),
+      projpred_w_aug_s = iterators::iter(projpred_ws_aug, by = "column"),
       .export = c(
-        "sdivmin", "formula", "data", "family", "projpred_ws_aug",
-        "projpred_formula_no_random", "projpred_random", "dot_args"
+        "sdivmin", "formula", "data", "family", "projpred_formula_no_random",
+        "projpred_random", "dot_args"
       ),
       .noexport = c(
         "object", "p_sel", "p_pred", "search_path", "p_ref", "refmodel",
-        "linkobjs"
+        "projpred_var", "projpred_ws_aug", "linkobjs"
       )
     ) %do_projpred% {
       do.call(
@@ -607,7 +610,7 @@ divmin_augdat <- function(formula, data, family, weights, projpred_var,
         c(list(formula = formula,
                data = data,
                family = family,
-               weights = projpred_ws_aug[, s],
+               weights = as.vector(projpred_w_aug_s),
                projpred_formula_no_random = projpred_formula_no_random,
                projpred_random = projpred_random),
           dot_args)

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -502,7 +502,7 @@ control_callback <- function(family, ...) {
 
 # Needed to avoid a NOTE in `R CMD check`:
 if (getRversion() >= package_version("2.15.1")) {
-  utils::globalVariables("s")
+  utils::globalVariables("projpred_w_aug_s")
   utils::globalVariables("projpred_internal_w_aug")
 }
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -2393,7 +2393,7 @@ cv_proportions.ranking <- function(object, cumulate = FALSE, ...) {
   cv_props <- do.call(cbind, lapply(
     setNames(nm = object[["fulldata"]]),
     function(predictor_j) {
-      # We need `na.rm = TRUE` for subsampled LOO CV:
+      # We need `na.rm = TRUE` for subsampled PSIS-LOO CV:
       colMeans(cv_paths == predictor_j, na.rm = TRUE)
     }
   ))

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -237,7 +237,7 @@ weighted_summary_means <- function(y_wobs_test, family, wdraws, mu, dis, cl_ref,
         val <- res_ref$value + res_diff$value
         val.se <- sqrt(res_ref$se^2 + res_diff$se^2)
         if (stat %in% c("rmse", "auc")) {
-          # TODO (subsampling LOO-CV): Use bootstrap for lower and upper
+          # TODO (subsampled PSIS-LOO CV): Use bootstrap for lower and upper
           # confidence interval bounds.
           warning("Lower and upper confidence interval bounds of performance ",
                   "statistic `", stat, "` are based on a normal ",
@@ -291,9 +291,9 @@ check_sub_NA <- function(summ_sub_k, el_nm) {
 ## ..., N and N denoting the number of observations) contains the weight of the
 ## CV fold that observation i is in. In case of varsel() output, this is `NULL`.
 ## Currently, these `wcv` are nonconstant (and not `NULL`) only in case of
-## subsampled LOO CV. The actual observation weights (specified by the user) are
-## contained in `y_wobs_test$wobs`. These are already taken into account by
-## `<refmodel_object>$family$ll_fun()` (or
+## subsampled PSIS-LOO CV. The actual observation weights (specified by the
+## user) are contained in `y_wobs_test$wobs`. These are already taken into
+## account by `<refmodel_object>$family$ll_fun()` (or
 ## `<refmodel_object>$family$latent_ll_oscale()`) and are thus already taken
 ## into account in `lppd`. However, `mu` does not take them into account, so
 ## some further adjustments are necessary below.

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -97,11 +97,11 @@ used for each predictor.}
 \item{verbose}{A single logical value indicating whether to print out
 additional information during the computations.}
 
-\item{nloo}{\strong{Caution:} Still experimental. Only relevant if \code{cv_method = "LOO"}. Number of subsampled LOO CV folds, i.e., number of observations
-used for the LOO CV (anything between 1 and the original number of
-observations). Smaller values lead to faster computation but higher
-uncertainty in the evaluation part. If \code{NULL}, all observations are used,
-but for faster experimentation, one can set this to a smaller value.}
+\item{nloo}{\strong{Caution:} Still experimental. Only relevant if \code{cv_method = "LOO"}. Number of subsampled PSIS-LOO CV folds, i.e., number of
+observations used for the LOO CV (anything between 1 and the original
+number of observations). Smaller values lead to faster computation but
+higher uncertainty in the evaluation part. If \code{NULL}, all observations are
+used, but for faster experimentation, one can set this to a smaller value.}
 
 \item{K}{Only relevant if \code{cv_method = "kfold"} and if the reference model
 was created with \code{cvfits} being \code{NULL} (which is the case for
@@ -143,9 +143,9 @@ results can be obtained again if needed. Passed to argument \code{seed} of
 \code{NA}, then the PRNG state is reset (to the state before calling
 \code{\link[=cv_varsel]{cv_varsel()}}) upon exiting \code{\link[=cv_varsel]{cv_varsel()}}. Here, \code{seed} is used for
 clustering the reference model's posterior draws (if \code{!is.null(nclusters)}
-or \code{!is.null(nclusters_pred)}), for subsampling LOO CV folds (if \code{nloo} is
-smaller than the number of observations), for sampling the folds in
-\eqn{K}-fold CV, and for drawing new group-level effects when predicting
+or \code{!is.null(nclusters_pred)}), for subsampling PSIS-LOO CV folds (if
+\code{nloo} is smaller than the number of observations), for sampling the folds
+in \eqn{K}-fold CV, and for drawing new group-level effects when predicting
 from a multilevel submodel (however, not yet in case of a GAMM).}
 
 \item{search_terms}{Only relevant for forward search. A custom character

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -2296,7 +2296,7 @@ vsel_tester <- function(
     expect_identical(dim(vs$solution_terms_cv),
                      c(n_folds, solterms_len_expected),
                      info = info_str)
-    # We need the addition of `NA_character_` because of subsampled LOO CV:
+    # We need the addition of `NA_character_` because of subsampled PSIS-LOO CV:
     expect_true(
       all(vs$solution_terms_cv %in% c(trms_universe_split, NA_character_)),
       info = info_str

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -873,6 +873,9 @@ options(projpred.warn_wobs_ppd = FALSE)
 options(projpred.verbose_project = FALSE)
 # Suppress instability warnings:
 options(projpred.warn_instable_projections = FALSE)
+# Run the check for attribute `nobs_orig` when subsetting `augmat` and `augvec`
+# objects:
+options(projpred.check_nobs_orig = TRUE)
 
 search_trms_tst <- list(
   default_search_trms = list(),

--- a/tests/testthat/test_augdat.R
+++ b/tests/testthat/test_augdat.R
@@ -55,6 +55,8 @@ test_that("t.augmat()", {
 ## `[.augmat`() -----------------------------------------------------------
 
 test_that("`[.augmat`()", {
+  # Subsetting:
+  # Subsetting with selection of all elements:
   expect_identical(augmtst[], augmtst)
   # Subsetting columns:
   expect_identical(augmtst[, 1:2],
@@ -70,25 +72,36 @@ test_that("`[.augmat`()", {
                    structure(head(xtst, nobs_orig_tst * ncat_tst),
                              nobs_orig = nobs_orig_tst,
                              class = "augvec"))
-  # Subsetting rows (in fact, this is not of interest, at least currently):
-  xrow1 <- xtst[nobs_orig_tst * ncat_tst * (seq_len(ndraws_tst) - 1L) + 1L]
-  expect_identical(augmtst[1, , drop = FALSE],
-                   structure(t(xrow1),
-                             nobs_orig = nobs_orig_tst,
+  # Subsetting rows:
+  xrows1 <- xtst[as.vector(t(sapply(
+    nobs_orig_tst * (seq_len(ncat_tst) - 1L) + 1L,
+    function(idx) {
+      nobs_orig_tst * ncat_tst * (seq_len(ndraws_tst) - 1L) + idx
+    }
+  )))]
+  xrows1 <- matrix(xrows1, nrow = ncat_tst)
+  expect_identical(augmtst[nobs_orig_tst * (seq_len(ncat_tst) - 1L) + 1L, ,
+                           drop = FALSE],
+                   structure(xrows1,
+                             nobs_orig = 1L,
                              class = "augmat"))
-  expect_identical(augmtst[1, ],
-                   structure(xrow1,
-                             nobs_orig = nobs_orig_tst,
-                             class = "augvec"))
+  expect_error(augmtst[1, ], "is_wholenumber.+ is not TRUE")
+  expect_error(augmtst[1, , drop = FALSE], "is_wholenumber.+ is not TRUE")
   # Subsetting rows and columns:
-  expect_identical(augmtst[1:2, 1:2],
-                   structure(arrtst[1:2, 1, 1:2],
-                             nobs_orig = nobs_orig_tst,
-                             class = "augmat"))
-  expect_identical(augmtst[1, 1],
-                   structure(head(xtst, 1),
-                             nobs_orig = nobs_orig_tst,
+  expect_identical(
+    augmtst[sort(c(nobs_orig_tst * (seq_len(ncat_tst) - 1L) + 1L,
+                   nobs_orig_tst * (seq_len(ncat_tst) - 1L) + 2L)), 1:2],
+    structure(cbind(as.vector(arrtst[1:2, , 1]), as.vector(arrtst[1:2, , 2])),
+              nobs_orig = 2L,
+              class = "augmat")
+  )
+  expect_identical(augmtst[nobs_orig_tst * (seq_len(ncat_tst) - 1L) + 1L, 1],
+                   structure(xrows1[, 1],
+                             nobs_orig = 1L,
                              class = "augvec"))
+  expect_error(augmtst[1:3, 1:2], "is_wholenumber.+ is not TRUE")
+  expect_error(augmtst[1, 1], "is_wholenumber.+ is not TRUE")
+  expect_error(augmtst[1, 1, drop = FALSE], "is_wholenumber.+ is not TRUE")
 
   # Assigning:
   augmtst[1, 1] <- 0
@@ -119,18 +132,17 @@ test_that("t.augvec()", {
 ## `[.augvec`() -----------------------------------------------------------
 
 test_that("`[.augvec`()", {
+  # Subsetting:
   expect_identical(augvtst[], augvtst)
-  expect_identical(augvtst[1:2],
-                   structure(head(xtst, 2),
-                             nobs_orig = nobs_orig_tst,
+  xrows1_1 <- xtst[nobs_orig_tst * (seq_len(ncat_tst) - 1L) + 1L]
+  expect_identical(augvtst[nobs_orig_tst * (seq_len(ncat_tst) - 1L) + 1L],
+                   structure(xrows1_1,
+                             nobs_orig = 1L,
                              class = "augvec"))
-  expect_identical(augvtst[1],
-                   structure(head(xtst, 1),
-                             nobs_orig = nobs_orig_tst,
-                             class = "augvec"))
+  expect_error(augvtst[1], "is_wholenumber.+ is not TRUE")
   expect_identical(augvtst[integer()],
-                   structure(head(xtst, 0),
-                             nobs_orig = nobs_orig_tst,
+                   structure(integer(),
+                             nobs_orig = 0L,
                              class = "augvec"))
 
   # Assigning:

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1233,8 +1233,8 @@ test_that("setting `nloo` smaller than the number of observations works", {
                              "L1", "forward")
     }
     # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics and also because of the warning concerning subsampled LOO CV
-    # (see issue #94):
+    # diagnostics and also because of the warning concerning subsampled PSIS-LOO
+    # CV (see issue #94):
     cvvs_nloo <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]],
            nloo = nloo_tst),


### PR DESCRIPTION
This fixes a bug for the augmented-data projection in combination with subsampled PSIS-LOO CV: When subsetting the rows of an augmented-rows matrix (class `augmat`) or the elements of an augmented-length vector (class `augvec`), attribute `nobs_orig` was not adapted, so by this PR, it is adapted correctly.

Reprex:
```r
data(inhaler, package = "brms")
inhaler$rating <- paste0("rtg", inhaler$rating)
inhaler$rating <- as.factor(inhaler$rating)
library(rstanarm)
rfit <- stan_polr(rating ~ period + carry + treat,
                  data = inhaler,
                  prior = R2(location = 0.5, what = "median"),
                  chains = 1,
                  iter = 500,
                  seed = 1140350788,
                  refresh = 0)

### If the desired version is not installed:
devtools::load_all(".")
###
### If the desired version is installed:
# library(projpred)
###

cvvs <- cv_varsel(rfit,
                  validate_search = FALSE,
                  nloo = 141,
                  nclusters = 3,
                  nclusters_pred = 5,
                  nterms_max = 2,
                  seed = 46782345)

```
Previously (i.e., before this PR), this reprex failed (with `Error in augmat2arr(mu) : is_wholenumber(n_discr) is not TRUE`). With this PR, this reprex runs through.

Nevertheless, subsampled PSIS-LOO CV is still an experimental feature, see #94.