### PR TITLE
Quick fix for bug introduced by #433

### DIFF
--- a/R/augdat.R
+++ b/R/augdat.R
@@ -130,7 +130,7 @@ t.augvec <- function(x) {
   } else {
     nobs_orig_x_out <- nrow(x_out) / n_discr
   }
-  if (isTRUE(getOption("projpred.check_nobs_orig", FALSE))) {
+  if (isTRUE(getOption("projpred.subset_aug_checks", FALSE))) {
     # This check is not run by default because it would require a custom str()
     # and print() method for `augmat` objects and because there would be a high
     # risk of false positive alarms if there are generics other than str() and
@@ -161,7 +161,7 @@ t.augvec <- function(x) {
   stopifnot(is_wholenumber(n_discr))
   n_discr <- as.integer(round(n_discr))
   nobs_orig_x_out <- length(x_out) / n_discr
-  if (isTRUE(getOption("projpred.check_nobs_orig", FALSE))) {
+  if (isTRUE(getOption("projpred.subset_aug_checks", FALSE))) {
     # See `[.augmat` for why this check is not run by default.
     stopifnot(is_wholenumber(nobs_orig_x_out))
   }

--- a/R/augdat.R
+++ b/R/augdat.R
@@ -121,7 +121,14 @@ t.augvec <- function(x) {
   nobs_orig_x <- attr(x, "nobs_orig")
   stopifnot(!is.null(nobs_orig_x))
   n_discr <- nrow(x) / nobs_orig_x
-  stopifnot(is_wholenumber(n_discr))
+  if (isTRUE(getOption("projpred.subset_aug_checks", FALSE))) {
+    # This check is not run by default because it could require custom str() and
+    # print() (or even more) methods for `augmat` objects and because there
+    # could be a high risk of false positive alarms if external functions like
+    # str() and print() use a "head" of this matrix (or if external functions
+    # iterate over the rows one-by-one and use subsetting for that).
+    stopifnot(is_wholenumber(n_discr))
+  }
   n_discr <- as.integer(round(n_discr))
   cls_out <- oldClass(x)
   if (is.null(dim(x_out))) {
@@ -131,11 +138,8 @@ t.augvec <- function(x) {
     nobs_orig_x_out <- nrow(x_out) / n_discr
   }
   if (isTRUE(getOption("projpred.subset_aug_checks", FALSE))) {
-    # This check is not run by default because it would require a custom str()
-    # and print() method for `augmat` objects and because there would be a high
-    # risk of false positive alarms if there are generics other than str() and
-    # print() which use a "head" of this matrix (or also if other functions
-    # iterate over the rows one-by-one and use subsetting for that).
+    # See above for why this check is not run by default (in this case, we
+    # indeed had a false alarm at least once).
     stopifnot(is_wholenumber(nobs_orig_x_out))
   }
   nobs_orig_x_out <- as.integer(round(nobs_orig_x_out))
@@ -158,11 +162,16 @@ t.augvec <- function(x) {
   nobs_orig_x <- attr(x, "nobs_orig")
   stopifnot(!is.null(nobs_orig_x))
   n_discr <- length(x) / nobs_orig_x
-  stopifnot(is_wholenumber(n_discr))
+  if (isTRUE(getOption("projpred.subset_aug_checks", FALSE))) {
+    # See `[.augmat` for why this check is not run by default (in this case, we
+    # indeed had a false alarm at least once).
+    stopifnot(is_wholenumber(n_discr))
+  }
   n_discr <- as.integer(round(n_discr))
   nobs_orig_x_out <- length(x_out) / n_discr
   if (isTRUE(getOption("projpred.subset_aug_checks", FALSE))) {
-    # See `[.augmat` for why this check is not run by default.
+    # See `[.augmat` for why this check is not run by default (in this case, we
+    # indeed had a false alarm at least once).
     stopifnot(is_wholenumber(nobs_orig_x_out))
   }
   nobs_orig_x_out <- as.integer(round(nobs_orig_x_out))

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -875,7 +875,7 @@ options(projpred.verbose_project = FALSE)
 options(projpred.warn_instable_projections = FALSE)
 # Run the check for attribute `nobs_orig` when subsetting `augmat` and `augvec`
 # objects:
-options(projpred.check_nobs_orig = TRUE)
+options(projpred.subset_aug_checks = TRUE)
 
 search_trms_tst <- list(
   default_search_trms = list(),


### PR DESCRIPTION
This is a quick fix for a bug introduced by PR #433. Illustration of the bug (the RDS file is available [here](https://github.com/stan-dev/projpred/files/11982734/arr1.zip)):
```r
arr1 <- readRDS("arr1.rds")
devtools::load_all()
str(arr2augmat(arr1, margin_draws = 1))
```
At the current state of `master` (commit 5717fd49ff69c844b01861ee113cff42fc60e2b6), the last line fails with the error
```
Error in `[.augvec`(ob, !is.na(ob)) : is_wholenumber(n_discr) is not TRUE
```
With this PR, the last line does not fail anymore.

It is only a quick fix because as a longer-term objective, it would probably be better to replace the role of attribute `nobs_orig` by an attribute that refers to the number of (possibly latent) response categories. The reason is that subsetting the rows of an augmented-rows matrix (or the elements of an augmented-length vector) is only legal in terms of the observations (individuals), not in terms of the (possibly latent) response categories. So the number of (possibly latent) response categories should always stay the same, in contrast to the number of observations. `str()` (and possibly other functions) may not adhere to the subsetting convention we are requiring, but even in those cases, it should be ok to assume the number of (possibly latent) response categories not to change (for `str()`, this is indeed correct). I'm sorry that the `nobs_orig` thing seems to have been a bad design choice from my side in PR #322.