### PR TITLE
Improve Pareto k-value warnings, use `loo::sis()` for weighted draws

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Added warnings for most of the problems described in section ["Troubleshooting"](https://mc-stan.org/projpred/articles/projpred.html#troubleshooting) of the main vignette. (GitHub: #431)
 * Output element `p_type` of `project()` has been removed. Instead, output element `const_wdraws_prj` has been added, but its definition is essentially the inverse of former element `p_type` (see the updated documentation of `project()`'s output). This should not be a breaking change for users (as `p_type` was mainly intended for internal use and the new element `const_wdraws_prj` is so, too) but this slightly enhances the cases where `as.matrix.projection()` throws a warning concerning the weights of the projected draws and the cases where `proj_predict()` resamples from the projected draws using argument `nresample_clusters`. (GitHub: #432)
 * Function `do_call()` is deprecated and will be removed in a future release. Where possible, please use direct function calls instead. If this is not possible, please use `do.call()` instead.
-* Improved the handling of PSIS-LOO CV warnings. (GitHub: #434)
+* Improved handling of PSIS-LOO CV warnings. (GitHub: #438)
 
 ## Bug fixes
 
@@ -23,6 +23,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Fixed a bug sometimes causing an error when predicting from a submodel that is a GLM and has interactions. (GitHub: #420)
 * Fixed a bug introduced in version 2.6.0, causing an incompatibility of K-fold CV with R versions < 4.2.0. (GitHub: #423, #427)
 * Fixed a bug for the augmented-data projection in combination with subsampled PSIS-LOO CV. (GitHub: #433)
+* `cv_varsel()` with `validate_search = FALSE` used to call `loo::psis()` (for the submodel performance evaluation PSIS-LOO CV) even in case of draws with different (i.e., nonconstant) weights. In such cases, `loo::sis()` is called now (with a warning). (GitHub: #438)
 
 # projpred 2.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Added warnings for most of the problems described in section ["Troubleshooting"](https://mc-stan.org/projpred/articles/projpred.html#troubleshooting) of the main vignette. (GitHub: #431)
 * Output element `p_type` of `project()` has been removed. Instead, output element `const_wdraws_prj` has been added, but its definition is essentially the inverse of former element `p_type` (see the updated documentation of `project()`'s output). This should not be a breaking change for users (as `p_type` was mainly intended for internal use and the new element `const_wdraws_prj` is so, too) but this slightly enhances the cases where `as.matrix.projection()` throws a warning concerning the weights of the projected draws and the cases where `proj_predict()` resamples from the projected draws using argument `nresample_clusters`. (GitHub: #432)
 * Function `do_call()` is deprecated and will be removed in a future release. Where possible, please use direct function calls instead. If this is not possible, please use `do.call()` instead.
+* Improved the handling of PSIS-LOO CV warnings. (GitHub: #434)
 
 ## Bug fixes
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -602,36 +602,16 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
                                   3 * sqrt(S_for_psis_eval))) < 5
       if (no_psis_eval) {
         if (getOption("projpred.warn_psis", TRUE)) {
-          warn_sis_eval <- paste0(
+          warning(
             "In the recalculation of the reference model's PSIS-LOO CV ",
             "weights for the performance evaluation, the number of draws ",
             "after clustering or thinning is too small for Pareto smoothing. ",
-            "Using standard importance sampling (SIS) instead."
+            "Using standard importance sampling (SIS) instead. Watch out for ",
+            "warnings thrown by the original-draws Pareto smoothing to see ",
+            "whether it makes sense to increase the number of draws ",
+            "(resulting from the clustering or thinning for the performance ",
+            "evaluation). Alternatively, K-fold CV can be used."
           )
-          if (pareto_n07 == 0) {
-            warn_sis_eval <- paste0(
-              warn_sis_eval,
-              " Since there were no k-values > 0.7 in the complete-draws ",
-              "Pareto smoothing, we recommend to increase the number of draws ",
-              "resulting from the clustering or thinning for the performance ",
-              "evaluation until this warning disappears (or to use K-fold CV)."
-            )
-          } else {
-            warn_sis_eval <- paste0(
-              warn_sis_eval,
-              " Since there were k-values > 0.7 in the complete-draws Pareto ",
-              "smoothing, we recommend to perform the checks mentioned in the ",
-              "complete-draws warning message and, if these checks reveal ",
-              "that the complete-draws Pareto smoothing can be used, to ",
-              "increase the number of draws resulting from the clustering or ",
-              "thinning for the performance evaluation until this warning ",
-              "disappears (or rather until this warning is replaced with ",
-              "another warning). If these checks reveal that the ",
-              "complete-draws Pareto smoothing should not be used, then we ",
-              "recommend to use K-fold CV."
-            )
-          }
-          warning(warn_sis_eval)
         }
         # Use loo::sis().
         # In principle, we could rely on loo::psis() here (because in such a
@@ -678,40 +658,16 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     if (importance_sampling_nm == "psis") {
       pareto_n07_eval <- sum(loo::pareto_k_values(sub_psisloo) > 0.7)
       if (pareto_n07_eval > 0 && getOption("projpred.warn_psis", TRUE)) {
-        warn_khat_eval <- paste0(
+        warning(
           "In the recalculation of the reference model's PSIS-LOO CV weights ",
           "for the performance evaluation (based on clustered or thinned ",
           "posterior draws), ", pareto_n07_eval, " (out of ", nloo, ") Pareto ",
-          "k-value(s) exceeded the threshold of 0.7."
+          "k-value(s) exceeded the threshold of 0.7. Watch out for warnings ",
+          "thrown by the original-draws Pareto smoothing to see whether it ",
+          "makes sense to increase the number of draws (resulting from the ",
+          "clustering or thinning for the performance evaluation). ",
+          "Alternatively, K-fold CV can be used."
         )
-        if (pareto_n07 == 0) {
-          warn_khat_eval <- paste0(
-            warn_khat_eval,
-            " Since there were no k-values > 0.7 in the complete-draws Pareto ",
-            "smoothing, we recommend to increase the number of draws ",
-            "resulting from the clustering or thinning for the performance ",
-            "evaluation until this warning disappears (or to use K-fold CV)."
-          )
-        } else {
-          if (S_for_psis_eval == nrow(loglik_forPSIS)) {
-            recomm <- "ignore this warning"
-          } else {
-            recomm <- paste0(
-              "increase the number of draws resulting from the clustering or ",
-              "thinning for the performance evaluation"
-            )
-          }
-          warn_khat_eval <- paste0(
-            warn_khat_eval,
-            " Since there were k-values > 0.7 in the complete-draws Pareto ",
-            "smoothing, we recommend to perform the checks mentioned in the ",
-            "complete-draws warning message and, if these checks reveal that ",
-            "the complete-draws Pareto smoothing can be used, to ", recomm,
-            ". If these checks reveal that the complete-draws Pareto ",
-            "smoothing should not be used, then we recommend to use K-fold CV."
-          )
-        }
-        warning(warn_khat_eval)
       }
     }
     lw_sub <- weights(sub_psisloo)

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -17,13 +17,14 @@
 #'   case, a Pareto-smoothed importance sampling leave-one-out CV (PSIS-LOO CV)
 #'   is performed, which avoids refitting the reference model `nloo` times (in
 #'   contrast to a standard LOO CV). In the `"kfold"` case, a \eqn{K}-fold CV is
-#'   performed.
+#'   performed. See also section "Note" below.
 #' @param nloo **Caution:** Still experimental. Only relevant if `cv_method =
 #'   "LOO"`. Number of subsampled PSIS-LOO CV folds, i.e., number of
-#'   observations used for the LOO CV (anything between 1 and the original
-#'   number of observations). Smaller values lead to faster computation but
-#'   higher uncertainty in the evaluation part. If `NULL`, all observations are
-#'   used, but for faster experimentation, one can set this to a smaller value.
+#'   observations used for the approximate LOO CV (anything between 1 and the
+#'   original number of observations). Smaller values lead to faster computation
+#'   but higher uncertainty in the evaluation part. If `NULL`, all observations
+#'   are used, but for faster experimentation, one can set this to a smaller
+#'   value.
 #' @param K Only relevant if `cv_method = "kfold"` and if the reference model
 #'   was created with `cvfits` being `NULL` (which is the case for
 #'   [get_refmodel.stanreg()] and [brms::get_refmodel.brmsfit()]). Number of
@@ -57,11 +58,18 @@
 #' @note If `validate_search` is `FALSE`, the search is not included in the CV
 #'   so that only a single full-data search is run.
 #'
-#'   For PSIS-LOO CV, \pkg{projpred} calls [loo::psis()] with `r_eff = NA`. This
-#'   is only a problem if there was extreme autocorrelation between the MCMC
-#'   iterations when the reference model was built. In those cases however, the
-#'   reference model should not have been used anyway, so we don't expect
-#'   \pkg{projpred}'s `r_eff = NA` to be a problem.
+#'   For PSIS-LOO CV, \pkg{projpred} calls [loo::psis()] (or, exceptionally,
+#'   [loo::sis()], see below) with `r_eff = NA`. This is only a problem if there
+#'   was extreme autocorrelation between the MCMC iterations when the reference
+#'   model was built. In those cases however, the reference model should not
+#'   have been used anyway, so we don't expect \pkg{projpred}'s `r_eff = NA` to
+#'   be a problem.
+#'
+#'   PSIS cannot be used if the draws have different (i.e., nonconstant) weights
+#'   or if the number of draws is too small. In such cases, \pkg{projpred}
+#'   resorts to standard importance sampling (SIS) and throws a warning about
+#'   this. Throughout the documentation, the term "PSIS" is used even though in
+#'   fact, \pkg{projpred} resorts to SIS in these special cases.
 #'
 #'   With `parallel = TRUE`, costly parts of \pkg{projpred}'s CV are run in
 #'   parallel. Costly parts are the fold-wise searches and performance

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -633,6 +633,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
           }
           warning(warn_sis_eval)
         }
+        # Use loo::sis().
         # In principle, we could rely on loo::psis() here (because in such a
         # case, it would internally switch to SIS automatically), but using
         # loo::sis() explicitly is safer because if the loo package changes its
@@ -641,12 +642,12 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
         # stan-dev/loo#227.
         importance_sampling_nm <- "sis"
       } else {
-        # Use loo::psis():
-        importance_sampling_nm <- "psis"
-        # Note: Usually, we have a small number of projected draws here (400 by
+        # Use loo::psis().
+        # Usually, we have a small number of projected draws here (400 by
         # default), which means that the 'loo' package will automatically
         # perform the regularization from Vehtari et al. (2022,
         # <https://doi.org/10.48550/arXiv.1507.02646>, appendix G).
+        importance_sampling_nm <- "psis"
       }
     } else {
       if (getOption("projpred.warn_psis", TRUE)) {
@@ -657,6 +658,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
           "sampling (PSIS). In general, PSIS is recommended over SIS."
         )
       }
+      # Use loo::sis().
       importance_sampling_nm <- "sis"
     }
     importance_sampling_func <- get(importance_sampling_nm, asNamespace("loo"))

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -394,6 +394,10 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   n <- ncol(loglik_forPSIS)
 
   # PSIS-LOO CV weights:
+  if (length(unique(refmodel$wdraws_ref)) != 1) {
+    stop("Currently, projpred requires the reference model's posterior draws ",
+         "to have constant weights.")
+  }
   # TODO: Check for small number of draws and other loo::psis() warnings.
   # Alternatively, see if utils::capture.output() can be used (search for other
   # occurrences of it).

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -473,7 +473,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   nloo <- min(nloo, n)
   if (nloo < 1) {
     stop("nloo must be at least 1")
-  } else if (nloo < n) {
+  } else if (nloo < n && getOption("projpred.warn_subsampled_loo", TRUE)) {
     warning("Subsampled PSIS-LOO CV is still experimental.")
   }
   # validset <- loo_subsample(n, nloo, pareto_k)

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -640,43 +640,42 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     )
     if (importance_sampling_nm == "psis") {
       pareto_n07_eval <- sum(loo::pareto_k_values(sub_psisloo) > 0.7)
-    }
-    if (importance_sampling_nm == "psis" && pareto_n07_eval > 0 &&
-        getOption("projpred.warn_psis", TRUE)) {
-      warn_khat_eval <- paste0(
-        "In the recalculation of the reference model's PSIS-LOO CV weights ",
-        "for the performance evaluation (based on clustered or thinned ",
-        "posterior draws), ", pareto_n07_eval, " (out of ", nloo, ") Pareto ",
-        "k-value(s) exceeded the threshold of 0.7."
-      )
-      if (pareto_n07 == 0) {
+      if (pareto_n07_eval > 0 && getOption("projpred.warn_psis", TRUE)) {
         warn_khat_eval <- paste0(
-          warn_khat_eval,
-          " Since there were no k-values > 0.7 in the complete-draws Pareto ",
-          "smoothing, we recommend to increase the number of draws resulting ",
-          "from the clustering or thinning for the performance evaluation ",
-          "until this warning disappears (or to use K-fold CV)."
+          "In the recalculation of the reference model's PSIS-LOO CV weights ",
+          "for the performance evaluation (based on clustered or thinned ",
+          "posterior draws), ", pareto_n07_eval, " (out of ", nloo, ") Pareto ",
+          "k-value(s) exceeded the threshold of 0.7."
         )
-      } else {
-        if (S_for_psis_eval == nrow(loglik_forPSIS)) {
-          recomm <- "ignore this warning"
+        if (pareto_n07 == 0) {
+          warn_khat_eval <- paste0(
+            warn_khat_eval,
+            " Since there were no k-values > 0.7 in the complete-draws Pareto ",
+            "smoothing, we recommend to increase the number of draws ",
+            "resulting from the clustering or thinning for the performance ",
+            "evaluation until this warning disappears (or to use K-fold CV)."
+          )
         } else {
-          recomm <- paste0(
-            "increase the number of draws resulting from the clustering or ",
-            "thinning for the performance evaluation"
+          if (S_for_psis_eval == nrow(loglik_forPSIS)) {
+            recomm <- "ignore this warning"
+          } else {
+            recomm <- paste0(
+              "increase the number of draws resulting from the clustering or ",
+              "thinning for the performance evaluation"
+            )
+          }
+          warn_khat_eval <- paste0(
+            warn_khat_eval,
+            " Since there were k-values > 0.7 in the complete-draws Pareto ",
+            "smoothing, we recommend to perform the checks mentioned in the ",
+            "complete-draws warning message and, if these checks reveal that ",
+            "the complete-draws Pareto smoothing can be used, to ", recomm,
+            ". If these checks reveal that the complete-draws Pareto ",
+            "smoothing should not be used, then we recommend to use K-fold CV."
           )
         }
-        warn_khat_eval <- paste0(
-          warn_khat_eval,
-          " Since there were k-values > 0.7 in the complete-draws Pareto ",
-          "smoothing, we recommend to perform the checks mentioned in the ",
-          "complete-draws warning message and, if these checks reveal that ",
-          "the complete-draws Pareto smoothing can be used, to ", recomm, ". ",
-          "If these checks reveal that the complete-draws Pareto smoothing ",
-          "should not be used, then we recommend to use K-fold CV."
-        )
+        warning(warn_khat_eval)
       }
-      warning(warn_khat_eval)
     }
     lw_sub <- weights(sub_psisloo)
     # Take into account that clustered draws usually have different weights:

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -1210,7 +1210,11 @@ get_kfold <- function(refmodel, K, verbose) {
       }
       folds <- cv_folds(refmodel$nobs, K = K,
                         seed = sample.int(.Machine$integer.max, 1))
-      cvfits <- refmodel$cvfun(folds)
+      if (getOption("projpred.warn_kfold_refits", TRUE)) {
+        cvfits <- refmodel$cvfun(folds)
+      } else {
+        cvfits <- suppressWarnings(refmodel$cvfun(folds))
+      }
       verb_out("-----", verbose = verbose)
     } else {
       stop("For a reference model which is not of class `datafit`, either ",

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -693,11 +693,9 @@ fit_cumul <- function(formula, data, family, weights, ...) {
   if (inherits(fitobj, "try-error")) {
     stop(attr(fitobj, "condition")$message)
   }
-  warn_capt <- setdiff(
-    warn_capt,
-    c("Warning in eval(family$initialize) :",
-      "  non-integer #successes in a binomial glm!")
-  )
+  warn_capt <- grep("Warning in .*:$", warn_capt, value = TRUE, invert = TRUE)
+  warn_capt <- grep("non-integer #successes in a binomial glm!$", warn_capt,
+                    value = TRUE, invert = TRUE)
   if (length(warn_capt) > 0) {
     warning(warn_capt)
   }
@@ -760,11 +758,14 @@ fit_cumul_mlvl <- function(formula, data, family, weights, ...) {
   if (inherits(fitobj, "try-error")) {
     stop(attr(fitobj, "condition")$message)
   }
-  warn_capt <- setdiff(
-    warn_capt,
-    c(paste("Warning: Using formula(x) is deprecated when x is a character",
-            "vector of length > 1."),
-      "  Consider formula(paste(x, collapse = \" \")) instead.")
+  warn_capt <- grep(
+    paste("Using formula\\(x\\) is deprecated when x is a character vector of",
+          "length > 1\\.$"),
+    warn_capt, value = TRUE, invert = TRUE
+  )
+  warn_capt <- grep(
+    "Consider formula\\(paste\\(x, collapse = .*\\)\\) instead\\.$",
+    warn_capt, value = TRUE, invert = TRUE
   )
   if (length(warn_capt) > 0) {
     warning(warn_capt)

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -646,7 +646,6 @@ fit_cumul <- function(formula, data, family, weights, ...) {
   # For catching warnings via capture.output() (which is necessary to filter out
   # the warning "non-integer #successes in a binomial glm!"):
   warn_orig <- options(warn = 1)
-  on.exit(options(warn_orig))
   # Call the submodel fitter:
   warn_capt <- utils::capture.output({
     fitobj <- try(do.call(MASS::polr, c(
@@ -658,6 +657,7 @@ fit_cumul <- function(formula, data, family, weights, ...) {
       dot_args
     )), silent = TRUE)
   }, type = "message")
+  options(warn_orig)
   if (inherits(fitobj, "try-error") &&
       grepl(paste("initial value in 'vmmin' is not finite",
                   "attempt to find suitable starting values failed",
@@ -676,6 +676,7 @@ fit_cumul <- function(formula, data, family, weights, ...) {
     # Start with thresholds which imply equal probabilities for the response
     # categories:
     start_thres <- linkfun_raw(seq_len(nthres) / ncats, link_nm = link_nm)
+    warn_orig <- options(warn = 1)
     warn_capt <- utils::capture.output({
       fitobj <- try(do.call(MASS::polr, c(
         list(formula = formula,
@@ -687,6 +688,7 @@ fit_cumul <- function(formula, data, family, weights, ...) {
         dot_args
       )), silent = TRUE)
     }, type = "message")
+    options(warn_orig)
   }
   if (inherits(fitobj, "try-error")) {
     stop(attr(fitobj, "condition")$message)
@@ -741,7 +743,6 @@ fit_cumul_mlvl <- function(formula, data, family, weights, ...) {
   # the warning "Using formula(x) is deprecated when x is a character vector of
   # length > 1. [...]"):
   warn_orig <- options(warn = 1)
-  on.exit(options(warn_orig))
   # Call the submodel fitter:
   warn_capt <- utils::capture.output({
     fitobj <- try(do.call(ordinal::clmm, c(
@@ -755,6 +756,7 @@ fit_cumul_mlvl <- function(formula, data, family, weights, ...) {
       dot_args
     )), silent = TRUE)
   }, type = "message")
+  options(warn_orig)
   if (inherits(fitobj, "try-error")) {
     stop(attr(fitobj, "condition")$message)
   }

--- a/R/project.R
+++ b/R/project.R
@@ -255,6 +255,7 @@ project <- function(object, nterms = NULL, solution_terms = NULL,
   nterms_all <- count_terms_in_formula(refmodel$formula) - 1L
   if (nterms_max == nterms_all &&
       formula_contains_group_terms(refmodel$formula) &&
+      getOption("projpred.warn_instable_projections", TRUE) &&
       (refmodel$family$family == "gaussian" || refmodel$family$for_latent)) {
     warning(
       "In case of the Gaussian family (also in case of the latent projection) ",

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -500,6 +500,7 @@ parse_args_varsel <- function(refmodel, method, refit_prj, nterms_max,
   nterms_max <- min(max_nv_possible, nterms_max)
 
   if (nterms_max == nterms_all && has_group_features &&
+      getOption("projpred.warn_instable_projections", TRUE) &&
       (refmodel$family$family == "gaussian" || refmodel$family$for_latent)) {
     warning(
       "In case of the Gaussian family (also in case of the latent projection) ",

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -54,7 +54,7 @@ augmented-data projection is used. See also section "Details" below.}
 case, a Pareto-smoothed importance sampling leave-one-out CV (PSIS-LOO CV)
 is performed, which avoids refitting the reference model \code{nloo} times (in
 contrast to a standard LOO CV). In the \code{"kfold"} case, a \eqn{K}-fold CV is
-performed.}
+performed. See also section "Note" below.}
 
 \item{ndraws}{Number of posterior draws used in the search part. Ignored if
 \code{nclusters} is not \code{NULL} or in case of L1 search (because L1 search always
@@ -98,10 +98,11 @@ used for each predictor.}
 additional information during the computations.}
 
 \item{nloo}{\strong{Caution:} Still experimental. Only relevant if \code{cv_method = "LOO"}. Number of subsampled PSIS-LOO CV folds, i.e., number of
-observations used for the LOO CV (anything between 1 and the original
-number of observations). Smaller values lead to faster computation but
-higher uncertainty in the evaluation part. If \code{NULL}, all observations are
-used, but for faster experimentation, one can set this to a smaller value.}
+observations used for the approximate LOO CV (anything between 1 and the
+original number of observations). Smaller values lead to faster computation
+but higher uncertainty in the evaluation part. If \code{NULL}, all observations
+are used, but for faster experimentation, one can set this to a smaller
+value.}
 
 \item{K}{Only relevant if \code{cv_method = "kfold"} and if the reference model
 was created with \code{cvfits} being \code{NULL} (which is the case for
@@ -227,11 +228,18 @@ specify \code{search_terms = c("x2", "x3", "x2 + x3")}.
 If \code{validate_search} is \code{FALSE}, the search is not included in the CV
 so that only a single full-data search is run.
 
-For PSIS-LOO CV, \pkg{projpred} calls \code{\link[loo:psis]{loo::psis()}} with \code{r_eff = NA}. This
-is only a problem if there was extreme autocorrelation between the MCMC
-iterations when the reference model was built. In those cases however, the
-reference model should not have been used anyway, so we don't expect
-\pkg{projpred}'s \code{r_eff = NA} to be a problem.
+For PSIS-LOO CV, \pkg{projpred} calls \code{\link[loo:psis]{loo::psis()}} (or, exceptionally,
+\code{\link[loo:sis]{loo::sis()}}, see below) with \code{r_eff = NA}. This is only a problem if there
+was extreme autocorrelation between the MCMC iterations when the reference
+model was built. In those cases however, the reference model should not
+have been used anyway, so we don't expect \pkg{projpred}'s \code{r_eff = NA} to
+be a problem.
+
+PSIS cannot be used if the draws have different (i.e., nonconstant) weights
+or if the number of draws is too small. In such cases, \pkg{projpred}
+resorts to standard importance sampling (SIS) and throws a warning about
+this. Throughout the documentation, the term "PSIS" is used even though in
+fact, \pkg{projpred} resorts to SIS in these special cases.
 
 With \code{parallel = TRUE}, costly parts of \pkg{projpred}'s CV are run in
 parallel. Costly parts are the fold-wise searches and performance

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -867,6 +867,8 @@ meth_tst <- list(
 options(projpred.warn_psis = FALSE)
 # Suppress the subsampled PSIS-LOO CV warnings:
 options(projpred.warn_subsampled_loo = FALSE)
+# Suppress the warnings for the K reference model refits in case of K-fold CV:
+options(projpred.warn_kfold_refits = FALSE)
 # Suppress the warning for interaction terms being selected before all involved
 # main effects have been selected (only concerns L1 search):
 options(projpred.warn_L1_interactions = FALSE)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1235,10 +1235,7 @@ if (run_cvvs) {
   })
   args_cvvs <- unlist_cust(args_cvvs)
 
-  # Use suppressWarnings() because of occasional warnings concerning Pareto k
-  # diagnostics. Additionally to suppressWarnings(), suppressMessages() could be
-  # used here (because of the refits in K-fold CV):
-  cvvss <- suppressWarnings(lapply(args_cvvs, function(args_cvvs_i) {
+  cvvss <- lapply(args_cvvs, function(args_cvvs_i) {
     cvvs_expr <- expression(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]]),
       excl_nonargs(args_cvvs_i)
@@ -1250,7 +1247,7 @@ if (run_cvvs) {
     } else {
       return(eval(cvvs_expr))
     }
-  }))
+  })
   success_cvvs <- !sapply(cvvss, inherits, "try-error")
   err_ok <- sapply(cvvss[!success_cvvs], function(cvvs_err) {
     attr(cvvs_err, "condition")$message ==

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -863,6 +863,8 @@ meth_tst <- list(
   L1 = list(method = "L1"),
   forward = list(method = "forward")
 )
+# Suppress the PSIS warnings:
+options(projpred.warn_psis = FALSE)
 # Suppress the warning for interaction terms being selected before all involved
 # main effects have been selected (only concerns L1 search):
 options(projpred.warn_L1_interactions = FALSE)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -865,6 +865,8 @@ meth_tst <- list(
 )
 # Suppress the PSIS warnings:
 options(projpred.warn_psis = FALSE)
+# Suppress the subsampled PSIS-LOO CV warnings:
+options(projpred.warn_subsampled_loo = FALSE)
 # Suppress the warning for interaction terms being selected before all involved
 # main effects have been selected (only concerns L1 search):
 options(projpred.warn_L1_interactions = FALSE)

--- a/tests/testthat/test_parallel.R
+++ b/tests/testthat/test_parallel.R
@@ -65,10 +65,12 @@ test_that("cv_varsel() in parallel gives the same results as sequentially", {
   tstsetups <- grep("\\.glm\\.", names(cvvss), value = TRUE)
   for (tstsetup in tstsetups) {
     args_cvvs_i <- args_cvvs[[tstsetup]]
-    cvvs_repr <- do.call(cv_varsel, c(
+    # Use suppressWarnings() because of occasional warnings concerning Pareto k
+    # diagnostics:
+    cvvs_repr <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]]),
       excl_nonargs(args_cvvs_i)
-    ))
+    )))
     expect_equal(cvvs_repr, cvvss[[tstsetup]], info = tstsetup)
   }
 })

--- a/tests/testthat/test_parallel.R
+++ b/tests/testthat/test_parallel.R
@@ -65,12 +65,10 @@ test_that("cv_varsel() in parallel gives the same results as sequentially", {
   tstsetups <- grep("\\.glm\\.", names(cvvss), value = TRUE)
   for (tstsetup in tstsetups) {
     args_cvvs_i <- args_cvvs[[tstsetup]]
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
-    cvvs_repr <- suppressWarnings(do.call(cv_varsel, c(
+    cvvs_repr <- do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]]),
       excl_nonargs(args_cvvs_i)
-    )))
+    ))
     expect_equal(cvvs_repr, cvvss[[tstsetup]], info = tstsetup)
   }
 })

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1152,10 +1152,20 @@ test_that("`refit_prj` works", {
   for (tstsetup in tstsetups) {
     args_cvvs_i <- args_cvvs[[tstsetup]]
     args_cvvs_i$refit_prj <- FALSE
-    cvvs_reuse <- do.call(cv_varsel, c(
-      list(object = refmods[[args_cvvs_i$tstsetup_ref]]),
-      excl_nonargs(args_cvvs_i)
-    ))
+    if (args_cvvs_i$prj_nm == "augdat" && args_cvvs_i$fam_nm == "cumul") {
+      warn_expected <- "non-integer #successes in a binomial glm!"
+    } else if (!is.null(args_cvvs_i$avoid.increase)) {
+      warn_expected <- warn_mclogit
+    } else {
+      warn_expected <- NA
+    }
+    expect_warning(
+      cvvs_reuse <- do.call(cv_varsel, c(
+        list(object = refmods[[args_cvvs_i$tstsetup_ref]]),
+        excl_nonargs(args_cvvs_i)
+      )),
+      warn_expected
+    )
     mod_crr <- args_cvvs_i$mod_nm
     fam_crr <- args_cvvs_i$fam_nm
     prj_crr <- args_cvvs_i$prj_nm

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1126,10 +1126,12 @@ test_that("`seed` works (and restores the RNG state afterwards)", {
     cvvs_orig <- cvvss[[tstsetup]]
     rand_orig <- runif(1) # Just to advance `.Random.seed[2]`.
     .Random.seed_repr1 <- .Random.seed
-    cvvs_repr <- do.call(cv_varsel, c(
+    # Use suppressWarnings() because of occasional warnings concerning Pareto k
+    # diagnostics:
+    cvvs_repr <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]]),
       excl_nonargs(args_cvvs_i)
-    ))
+    )))
     .Random.seed_repr2 <- .Random.seed
     rand_new <- runif(1) # Just to advance `.Random.seed[2]`.
     # Expected equality:
@@ -1152,20 +1154,10 @@ test_that("`refit_prj` works", {
   for (tstsetup in tstsetups) {
     args_cvvs_i <- args_cvvs[[tstsetup]]
     args_cvvs_i$refit_prj <- FALSE
-    if (args_cvvs_i$prj_nm == "augdat" && args_cvvs_i$fam_nm == "cumul") {
-      warn_expected <- "non-integer #successes in a binomial glm!"
-    } else if (!is.null(args_cvvs_i$avoid.increase)) {
-      warn_expected <- warn_mclogit
-    } else {
-      warn_expected <- NA
-    }
-    expect_warning(
-      cvvs_reuse <- do.call(cv_varsel, c(
-        list(object = refmods[[args_cvvs_i$tstsetup_ref]]),
-        excl_nonargs(args_cvvs_i)
-      )),
-      warn_expected
-    )
+    cvvs_reuse <- suppressWarnings(do.call(cv_varsel, c(
+      list(object = refmods[[args_cvvs_i$tstsetup_ref]]),
+      excl_nonargs(args_cvvs_i)
+    )))
     mod_crr <- args_cvvs_i$mod_nm
     fam_crr <- args_cvvs_i$fam_nm
     prj_crr <- args_cvvs_i$prj_nm
@@ -1195,7 +1187,9 @@ test_that("`refit_prj` works", {
 
 test_that("invalid `nloo` fails", {
   for (tstsetup in names(refmods)) {
-    expect_error(cv_varsel(refmods[[tstsetup]], nloo = -1),
+    # Use suppressWarnings() because of occasional warnings concerning Pareto k
+    # diagnostics:
+    expect_error(suppressWarnings(cv_varsel(refmods[[tstsetup]], nloo = -1)),
                  "^nloo must be at least 1$",
                  info = tstsetup)
   }
@@ -1211,11 +1205,13 @@ test_that(paste(
                     value = TRUE)
   for (tstsetup in tstsetups) {
     args_cvvs_i <- args_cvvs[[tstsetup]]
-    cvvs_nloo <- do.call(cv_varsel, c(
+    # Use suppressWarnings() because of occasional warnings concerning Pareto k
+    # diagnostics:
+    cvvs_nloo <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]],
            nloo = nloo_tst),
       excl_nonargs(args_cvvs_i)
-    ))
+    )))
     expect_equal(cvvs_nloo, cvvss[[tstsetup]], info = tstsetup)
   }
 })
@@ -1236,11 +1232,13 @@ test_that("setting `nloo` smaller than the number of observations works", {
       meth_exp_crr <- ifelse(mod_crr == "glm" && prj_crr != "augdat",
                              "L1", "forward")
     }
-    cvvs_nloo <- do.call(cv_varsel, c(
+    # Use suppressWarnings() because of occasional warnings concerning Pareto k
+    # diagnostics:
+    cvvs_nloo <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]],
            nloo = nloo_tst),
       excl_nonargs(args_cvvs_i)
-    ))
+    )))
     vsel_tester(
       cvvs_nloo,
       with_cv = TRUE,
@@ -1335,11 +1333,13 @@ test_that("`validate_search` works", {
       meth_exp_crr <- ifelse(mod_crr == "glm" && prj_crr != "augdat",
                              "L1", "forward")
     }
-    cvvs_valsearch <- do.call(cv_varsel, c(
+    # Use suppressWarnings() because of occasional warnings concerning Pareto k
+    # diagnostics:
+    cvvs_valsearch <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]],
            validate_search = FALSE),
       excl_nonargs(args_cvvs_i)
-    ))
+    )))
     vsel_tester(
       cvvs_valsearch,
       with_cv = TRUE,

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -576,6 +576,47 @@ test_that("`refit_prj` works", {
   }
 })
 
+## Warning for full Gaussian multilevel models ----------------------------
+
+test_that(paste(
+  "the warning for full Gaussian multilevel models is thrown correctly"
+), {
+  skip_if_not(run_more)
+  skip_if_not(run_vs)
+  warn_instable_orig <- options(projpred.warn_instable_projections = NULL)
+  tstsetups <- names(vss)
+  pick_these <- sapply(tstsetups, function(tstsetup) {
+    refmod_i <- refmods[[args_vs[[tstsetup]]$tstsetup_ref]]
+    return(
+      (refmod_i$family$family == "gaussian" || refmod_i$family$for_latent) &&
+        is.null(args_vs[[tstsetup]]$search_terms)
+    )
+  })
+  tstsetups <- tstsetups[pick_these]
+  skip_if_not(length(tstsetups) > 0)
+  for (tstsetup in tstsetups) {
+    args_vs_i <- args_vs[[tstsetup]]
+    if (identical(args_vs_i$nterms_max, unname(ntermss[args_vs_i$mod_nm])) &&
+        any(grepl("\\|", labels(terms(
+          args_fit[[args_vs_i$tstsetup_fit]]$formula
+        ))))) {
+      warn_expected <- "the projection onto the full model can be instable"
+    } else {
+      warn_expected <- NA
+    }
+    args_vs_i$refit_prj <- FALSE
+    expect_warning(
+      vs_tmp <- do.call(varsel, c(
+        list(object = refmods[[args_vs_i$tstsetup_ref]]),
+        excl_nonargs(args_vs_i)
+      )),
+      warn_expected,
+      info = tstsetup
+    )
+  }
+  options(warn_instable_orig)
+})
+
 ## Regularization ---------------------------------------------------------
 
 # In fact, `regul` is already checked in `test_project.R`, so the `regul` tests
@@ -1265,47 +1306,6 @@ test_that("setting `nloo` smaller than the number of observations works", {
                    info = paste(tstsetup, vsel_nm, sep = "__"))
     }
   }
-})
-
-## Warning for full Gaussian multilevel models ----------------------------
-
-test_that(paste(
-  "the warning for full Gaussian multilevel models is thrown correctly"
-), {
-  skip_if_not(run_more)
-  skip_if_not(run_vs)
-  warn_instable_orig <- options(projpred.warn_instable_projections = NULL)
-  tstsetups <- names(vss)
-  pick_these <- sapply(tstsetups, function(tstsetup) {
-    refmod_i <- refmods[[args_vs[[tstsetup]]$tstsetup_ref]]
-    return(
-      (refmod_i$family$family == "gaussian" || refmod_i$family$for_latent) &&
-        is.null(args_vs[[tstsetup]]$search_terms)
-    )
-  })
-  tstsetups <- tstsetups[pick_these]
-  skip_if_not(length(tstsetups) > 0)
-  for (tstsetup in tstsetups) {
-    args_vs_i <- args_vs[[tstsetup]]
-    if (identical(args_vs_i$nterms_max, unname(ntermss[args_vs_i$mod_nm])) &&
-        any(grepl("\\|", labels(terms(
-          args_fit[[args_vs_i$tstsetup_fit]]$formula
-        ))))) {
-      warn_expected <- "the projection onto the full model can be instable"
-    } else {
-      warn_expected <- NA
-    }
-    args_vs_i$refit_prj <- FALSE
-    expect_warning(
-      vs_tmp <- do.call(varsel, c(
-        list(object = refmods[[args_vs_i$tstsetup_ref]]),
-        excl_nonargs(args_vs_i)
-      )),
-      warn_expected,
-      info = tstsetup
-    )
-  }
-  options(warn_instable_orig)
 })
 
 ## validate_search --------------------------------------------------------

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1105,11 +1105,9 @@ test_that("invalid `method` fails", {
 
 test_that("invalid `cv_method` fails", {
   for (tstsetup in names(refmods)) {
-    expect_error(
-      suppressWarnings(cv_varsel(refmods[[tstsetup]], cv_method = "k-fold")),
-      "^Unknown `cv_method`\\.$",
-      info = tstsetup
-    )
+    expect_error(cv_varsel(refmods[[tstsetup]], cv_method = "k-fold"),
+                 "^Unknown `cv_method`\\.$",
+                 info = tstsetup)
   }
 })
 
@@ -1128,10 +1126,10 @@ test_that("`seed` works (and restores the RNG state afterwards)", {
     cvvs_orig <- cvvss[[tstsetup]]
     rand_orig <- runif(1) # Just to advance `.Random.seed[2]`.
     .Random.seed_repr1 <- .Random.seed
-    cvvs_repr <- suppressWarnings(do.call(cv_varsel, c(
+    cvvs_repr <- do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]]),
       excl_nonargs(args_cvvs_i)
-    )))
+    ))
     .Random.seed_repr2 <- .Random.seed
     rand_new <- runif(1) # Just to advance `.Random.seed[2]`.
     # Expected equality:
@@ -1154,10 +1152,10 @@ test_that("`refit_prj` works", {
   for (tstsetup in tstsetups) {
     args_cvvs_i <- args_cvvs[[tstsetup]]
     args_cvvs_i$refit_prj <- FALSE
-    cvvs_reuse <- suppressWarnings(do.call(cv_varsel, c(
+    cvvs_reuse <- do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]]),
       excl_nonargs(args_cvvs_i)
-    )))
+    ))
     mod_crr <- args_cvvs_i$mod_nm
     fam_crr <- args_cvvs_i$fam_nm
     prj_crr <- args_cvvs_i$prj_nm
@@ -1187,9 +1185,7 @@ test_that("`refit_prj` works", {
 
 test_that("invalid `nloo` fails", {
   for (tstsetup in names(refmods)) {
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
-    expect_error(suppressWarnings(cv_varsel(refmods[[tstsetup]], nloo = -1)),
+    expect_error(cv_varsel(refmods[[tstsetup]], nloo = -1),
                  "^nloo must be at least 1$",
                  info = tstsetup)
   }
@@ -1205,13 +1201,11 @@ test_that(paste(
                     value = TRUE)
   for (tstsetup in tstsetups) {
     args_cvvs_i <- args_cvvs[[tstsetup]]
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
-    cvvs_nloo <- suppressWarnings(do.call(cv_varsel, c(
+    cvvs_nloo <- do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]],
            nloo = nloo_tst),
       excl_nonargs(args_cvvs_i)
-    )))
+    ))
     expect_equal(cvvs_nloo, cvvss[[tstsetup]], info = tstsetup)
   }
 })
@@ -1232,14 +1226,11 @@ test_that("setting `nloo` smaller than the number of observations works", {
       meth_exp_crr <- ifelse(mod_crr == "glm" && prj_crr != "augdat",
                              "L1", "forward")
     }
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics and also because of the warning concerning subsampled PSIS-LOO
-    # CV (see issue #94):
-    cvvs_nloo <- suppressWarnings(do.call(cv_varsel, c(
+    cvvs_nloo <- do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]],
            nloo = nloo_tst),
       excl_nonargs(args_cvvs_i)
-    )))
+    ))
     vsel_tester(
       cvvs_nloo,
       with_cv = TRUE,
@@ -1293,13 +1284,11 @@ test_that("`validate_search` works", {
       meth_exp_crr <- ifelse(mod_crr == "glm" && prj_crr != "augdat",
                              "L1", "forward")
     }
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
-    cvvs_valsearch <- suppressWarnings(do.call(cv_varsel, c(
+    cvvs_valsearch <- do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]],
            validate_search = FALSE),
       excl_nonargs(args_cvvs_i)
-    )))
+    ))
     vsel_tester(
       cvvs_valsearch,
       with_cv = TRUE,

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1269,6 +1269,47 @@ test_that("setting `nloo` smaller than the number of observations works", {
   }
 })
 
+## Warning for full Gaussian multilevel models ----------------------------
+
+test_that(paste(
+  "the warning for full Gaussian multilevel models is thrown correctly"
+), {
+  skip_if_not(run_more)
+  skip_if_not(run_vs)
+  warn_instable_orig <- options(projpred.warn_instable_projections = NULL)
+  tstsetups <- names(vss)
+  pick_these <- sapply(tstsetups, function(tstsetup) {
+    refmod_i <- refmods[[args_vs[[tstsetup]]$tstsetup_ref]]
+    return(
+      (refmod_i$family$family == "gaussian" || refmod_i$family$for_latent) &&
+        is.null(args_vs[[tstsetup]]$search_terms)
+    )
+  })
+  tstsetups <- tstsetups[pick_these]
+  skip_if_not(length(tstsetups) > 0)
+  for (tstsetup in tstsetups) {
+    args_vs_i <- args_vs[[tstsetup]]
+    if (identical(args_vs_i$nterms_max, unname(ntermss[args_vs_i$mod_nm])) &&
+        any(grepl("\\|", labels(terms(
+          args_fit[[args_vs_i$tstsetup_fit]]$formula
+        ))))) {
+      warn_expected <- "the projection onto the full model can be instable"
+    } else {
+      warn_expected <- NA
+    }
+    args_vs_i$refit_prj <- FALSE
+    expect_warning(
+      vs_tmp <- do.call(varsel, c(
+        list(object = refmods[[args_vs_i$tstsetup_ref]]),
+        excl_nonargs(args_vs_i)
+      )),
+      warn_expected,
+      info = tstsetup
+    )
+  }
+  options(warn_instable_orig)
+})
+
 ## validate_search --------------------------------------------------------
 
 test_that("`validate_search` works", {

--- a/vignettes/projpred.Rmd
+++ b/vignettes/projpred.Rmd
@@ -139,7 +139,7 @@ cvvs_fast <- cv_varsel(
   ### 
 )
 ```
-In this case, we ignore the Pareto-$k$ warning due to the reduced values for `chains` and `iter` in the reference model fit.
+In this case, we ignore the Pareto $\hat{k}$ warning due to the reduced values for `chains` and `iter` in the reference model fit.
 
 To find a suitable value for `nterms_max` in subsequent `cv_varsel()` runs, we take a look at a plot of at least one predictive performance statistic in dependence of the submodel size.
 Here, we choose the mean log predictive density (MLPD; see the documentation for argument `stats` of `summary.vsel()` for details) as the only performance statistic.


### PR DESCRIPTION
This PR improves the Pareto k-value warnings by suppressing the original warnings from the loo package and throwing customized warnings instead (thank you, @n-kall, for the suggestion). 

While implementing this, I realized that if the projected draws used for the performance evaluation in the `validate_search = FALSE` case have different weights, then `loo::sis()` needs to be used instead of `loo::psis()` (because the weights would need to be taken into account when performing the Pareto smoothing). Hence, this fallback to `loo::sis()` is implemented here as well (and apart from that, we now use `loo::sis()` explicitly if `loo::psis()` would not perform the Pareto smoothing due to a small number of draws, but this is merely a safety measure, see the inline comments added in the code).

In order to differentiate between different warnings in the unit tests, other warnings are now thrown conditionally on their own "hidden" global options.

Some enhancements for `capture.output()` usage in `fit_cumul()` and `fit_cumul_mlvl()` are included as well (found when starting to use `capture.output()` in `loo_varsel()`).

Also added is a unit test that the warning for full Gaussian multilevel models is thrown correctly (this test required the differentiation between different warnings, so it is included here).