### PR TITLE
Interactions between grouping variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Fixed a bug introduced in version 2.6.0, causing an incompatibility of K-fold CV with R versions < 4.2.0. (GitHub: #423, #427)
 * Fixed a bug for the augmented-data projection in combination with subsampled PSIS-LOO CV. (GitHub: #433)
 * `cv_varsel()` with `validate_search = FALSE` used to call `loo::psis()` (for the submodel performance evaluation PSIS-LOO CV) even in case of draws with different (i.e., nonconstant) weights. In such cases, `loo::sis()` is called now (with a warning). (GitHub: #438)
+* Fixed a bug for **rstanarm** (and custom) multilevel reference models with interactions (`:` syntax) between grouping variables, caused by missing columns in the reference model's `data.frame` (for **brms** reference models, this was already done correctly). (GitHub: #445)
 
 # projpred 2.6.0
 

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -1228,14 +1228,24 @@ repair_re.merMod <- function(object, newdata) {
   lvls_list <- lapply(setNames(nm = vnms), function(vnm) {
     from_fit <- rownames(ranef_tmp[[vnm]])
     if (!vnm %in% names(newdata)) {
-      if (any(grepl("\\|.+/", labels(terms(formula(object)))))) {
-        stop("The `/` syntax for nested group-level terms is currently not ",
-             "supported. Please try to write out the interaction term implied ",
-             "by the `/` syntax (see Table 2 in lme4's vignette called ",
-             "\"Fitting Linear Mixed-Effects Models Using lme4\").")
-      } else {
-        stop("Could not find column `", vnm, "` in `newdata`.")
+      for (special_char in c("/", ":")) {
+        if (any(grepl(paste0("\\|.+", special_char),
+                      labels(terms(formula(object)))))) {
+          if (special_char == "/") {
+            add_hint <- paste0(
+              " implied by the `", special_char, "` syntax (see lme4 vignette ",
+              "\"Fitting Linear Mixed-Effects Models Using lme4\", Table 2)"
+            )
+          } else {
+            add_hint <- ""
+          }
+          stop("The `", special_char, "` syntax for grouping variables is ",
+               "currently not supported. Please write out (i.e., create ",
+               "corresponding columns in the dataset manually and then adapt ",
+               "the model formula) interaction terms", add_hint, ".")
+        }
       }
+      stop("Could not find column `", vnm, "` in `newdata`.")
     }
     from_new <- unique(newdata[, vnm])
     if (is.factor(from_new)) {
@@ -1314,14 +1324,24 @@ repair_re.clmm <- function(object, newdata) {
   lvls_list <- lapply(setNames(nm = vnms), function(vnm) {
     from_fit <- rownames(ranef_tmp[[vnm]])
     if (!vnm %in% names(newdata)) {
-      if (any(grepl("\\|.+/", labels(terms(formula(object)))))) {
-        stop("The `/` syntax for nested group-level terms is currently not ",
-             "supported. Please try to write out the interaction term implied ",
-             "by the `/` syntax (see Table 2 in lme4's vignette called ",
-             "\"Fitting Linear Mixed-Effects Models Using lme4\").")
-      } else {
-        stop("Could not find column `", vnm, "` in `newdata`.")
+      for (special_char in c("/", ":")) {
+        if (any(grepl(paste0("\\|.+", special_char),
+                      labels(terms(formula(object)))))) {
+          if (special_char == "/") {
+            add_hint <- paste0(
+              " implied by the `", special_char, "` syntax (see lme4 vignette ",
+              "\"Fitting Linear Mixed-Effects Models Using lme4\", Table 2)"
+            )
+          } else {
+            add_hint <- ""
+          }
+          stop("The `", special_char, "` syntax for grouping variables is ",
+               "currently not supported. Please write out (i.e., create ",
+               "corresponding columns in the dataset manually and then adapt ",
+               "the model formula) interaction terms", add_hint, ".")
+        }
       }
+      stop("Could not find column `", vnm, "` in `newdata`.")
     }
     from_new <- unique(newdata[, vnm])
     if (is.factor(from_new)) {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1058,7 +1058,9 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     response_name <- paste0(".", response_name[1])
   }
   formula <- update(formula, paste(response_name[1], "~ ."))
-  if (formula_contains_additive_terms(formula)) {
+  add_trms <- fml_extractions$additive_terms
+  grp_trms <- fml_extractions$group_terms
+  if (length(add_trms) > 0) {
     if (family$for_augdat) {
       stop("Currently, the augmented-data projection may not be combined with ",
            "additive models.")
@@ -1067,7 +1069,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
       warning("Support for additive models is still experimental.")
     }
   }
-  if (formula_contains_group_terms(formula) &&
+  if (length(grp_trms) > 0 &&
       getOption("projpred.warn_instable_projections", TRUE) &&
       !called_from_cvrefbuilder) {
     if (family$for_augdat) {
@@ -1428,7 +1430,6 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   # Needed for rstanarm (and possibly custom) multilevel models with `:` between
   # grouping variables (reason: repair_re() currently requires a corresponding
   # column in the `data.frame`; brms does this correctly):
-  grp_trms <- fml_extractions$group_terms
   if (length(grp_trms) > 0) {
     for (nm_IA in grep(":", grp_trms, value = TRUE)) {
       nm_IA <- sub(".*\\|[[:blank:]]*", "", nm_IA)

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -908,6 +908,20 @@ get_refmodel.stanreg <- function(object, latent = FALSE, dis = NULL, ...) {
     dis <- data.frame(object)[, "sigma"]
   }
 
+  # Needed for multilevel models with `:` between grouping variables because
+  # repair_re() currently requires a corresponding column in the `data.frame`:
+  grp_trms <- extract_terms_response(formula)$group_terms
+  if (length(grp_trms) > 0) {
+    for (nm_IA in grep(":", grp_trms, value = TRUE)) {
+      nm_IA <- sub(".*\\|[[:blank:]]*", "", nm_IA)
+      if (!nm_IA %in% names(data)) {
+        data[[nm_IA]] <- do.call(paste,
+                                 c(unname(data[strsplit(nm_IA, ":")[[1]]]),
+                                   list(sep = ":")))
+      }
+    }
+  }
+
   # Augmented-data projection -----------------------------------------------
 
   aug_data <- object$stan_function == "stan_polr" && !latent

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -908,20 +908,6 @@ get_refmodel.stanreg <- function(object, latent = FALSE, dis = NULL, ...) {
     dis <- data.frame(object)[, "sigma"]
   }
 
-  # Needed for multilevel models with `:` between grouping variables because
-  # repair_re() currently requires a corresponding column in the `data.frame`:
-  grp_trms <- extract_terms_response(formula)$group_terms
-  if (length(grp_trms) > 0) {
-    for (nm_IA in grep(":", grp_trms, value = TRUE)) {
-      nm_IA <- sub(".*\\|[[:blank:]]*", "", nm_IA)
-      if (!nm_IA %in% names(data)) {
-        data[[nm_IA]] <- do.call(paste,
-                                 c(unname(data[strsplit(nm_IA, ":")[[1]]]),
-                                   list(sep = ":")))
-      }
-    }
-  }
-
   # Augmented-data projection -----------------------------------------------
 
   aug_data <- object$stan_function == "stan_polr" && !latent
@@ -1437,6 +1423,21 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   })
   for (idx_col in which(has_contr)) {
     attr(data[[idx_col]], "contrasts") <- NULL
+  }
+
+  # Needed for rstanarm (and possibly custom) multilevel models with `:` between
+  # grouping variables (reason: repair_re() currently requires a corresponding
+  # column in the `data.frame`; brms does this correctly):
+  grp_trms <- fml_extractions$group_terms
+  if (length(grp_trms) > 0) {
+    for (nm_IA in grep(":", grp_trms, value = TRUE)) {
+      nm_IA <- sub(".*\\|[[:blank:]]*", "", nm_IA)
+      if (!nm_IA %in% names(data)) {
+        data[[nm_IA]] <- do.call(paste,
+                                 c(unname(data[strsplit(nm_IA, ":")[[1]]]),
+                                   list(sep = ":")))
+      }
+    }
   }
 
   # mu ----------------------------------------------------------------------


### PR DESCRIPTION
This fixes a bug for rstanarm (and custom) multilevel reference models with interactions (`:` syntax) between grouping variables, caused by missing columns in the reference model's `data.frame` (for brms reference models, this was already done correctly).

Illustration:
```r
# Data --------------------------------------------------------------------

data("df_gaussian", package = "projpred")
dat <- data.frame(y = df_gaussian$y, df_gaussian$x)
dat$group <- gl(n = 5, k = nrow(dat) %/% 5, length = nrow(dat),
                labels = paste0("gr", seq_len(5)))
dat$addgrp <- gl(n = 6, k = nrow(dat) %/% 6, length = nrow(dat),
                 labels = paste0("agr", seq_len(6)))
dat$thirdgrp <- gl(n = 3, k = nrow(dat) %/% 3, length = nrow(dat),
                   labels = paste0("tgr", seq_len(3)))
set.seed(457211)
dat$addgrp <- sample(dat$addgrp)
dat$thirdgrp <- sample(dat$thirdgrp)
group_icpts_truth <- rnorm(nlevels(dat$group), sd = 6)
group_X1_truth <- rnorm(nlevels(dat$group), sd = 6)
icpt <- -4.2
dat$y <- icpt +
  group_icpts_truth[dat$group] +
  group_X1_truth[dat$group] * dat$X1
dat$y <- rnorm(nrow(dat), mean = dat$y, sd = 4)
# Split up into training and test (hold-out) dataset:
idcs_test <- sample.int(nrow(dat), size = nrow(dat) %/% 3)
dat_train <- dat[-idcs_test, , drop = FALSE]
dat_test <- dat[idcs_test, , drop = FALSE]

# Reference model fit -----------------------------------------------------

suppressPackageStartupMessages(library(rstanarm))
rfit <- stan_glmer(
  y ~ X1 + X2 + X3 + (1 | group) + (1 | group:addgrp) + (1 | group:addgrp:thirdgrp),
  data = dat_train,
  chains = 1,
  iter = 500,
  refresh = 0,
  seed = 1140350788
)

# projpred ----------------------------------------------------------------

devtools::load_all()

refmodel_obj <- get_refmodel(rfit)

prj <- project(refmodel_obj,
               solution_terms = c("(1 | group)", "(1 | group:addgrp)"),
               nclusters = 1,
               seed = 457324)

dat_test$`group:addgrp` <- paste(dat_test$group,
                                 dat_test$addgrp,
                                 sep = ":")
dat_test$`group:addgrp:thirdgrp` <- paste(dat_test$group,
                                          dat_test$addgrp,
                                          dat_test$thirdgrp,
                                          sep = ":")
d_test_list <- list(
  data = dat_test[, names(dat_test) != "y"],
  offset = rep(0, nrow(dat_test)),
  weights = rep(1, nrow(dat_test)),
  y = dat_test[["y"]]
)
vs <- varsel(refmodel_obj,
             d_test = d_test_list,
             nclusters = 1,
             refit_prj = FALSE,
             seed = 46782345)

cvvs <- cv_varsel(refmodel_obj,
                  cv_method = "kfold",
                  nclusters = 1,
                  refit_prj = FALSE,
                  seed = 46782345)

```
These calls failed before this PR and succeed now.