### PR TITLE
Create `get_refdist()` output only if necessary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Function `do_call()` is deprecated and will be removed in a future release. Where possible, please use direct function calls instead. If this is not possible, please use `do.call()` instead.
 * Improved handling of PSIS-LOO CV warnings. (GitHub: #438)
 * Reduced peak memory usage during forward search. A global option `projpred.run_gc` has also been added, see the general package documentation (available [online](https://mc-stan.org/projpred/reference/projpred-package.html) or by typing `` ?`projpred-package` ``). (GitHub: #442)
+* Slightly improved efficiency in K-fold CV, especially in case of a large number of observations. If `refit_prj` is `FALSE`, `nclusters` is internally greater than `1` (which requires forward search), and `nclusters_pred` is not `NULL`, this change might affect the results, due to a different pseudorandom number generator (PRNG) state in folds other than the first one. (GitHub: #446)
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,7 +25,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Function `do_call()` is deprecated and will be removed in a future release. Where possible, please use direct function calls instead. If this is not possible, please use `do.call()` instead.
 * Improved handling of PSIS-LOO CV warnings. (GitHub: #438)
 * Reduced peak memory usage during forward search. A global option `projpred.run_gc` has also been added, see the general package documentation (available [online](https://mc-stan.org/projpred/reference/projpred-package.html) or by typing `` ?`projpred-package` ``). (GitHub: #442)
-* Slightly improved efficiency in K-fold CV, especially in case of a large number of observations. If `refit_prj` is `FALSE`, `nclusters` is internally greater than `1` (which requires forward search), and `nclusters_pred` is not `NULL`, this change might affect the results, due to a different pseudorandom number generator (PRNG) state in folds other than the first one. (GitHub: #446)
+* Slightly improved efficiency in K-fold and PSIS-LOO CV, especially in case of a large number of observations. If `refit_prj` is `FALSE`, `nclusters` is internally greater than `1` (which requires forward search), and `nclusters_pred` is not `NULL`, this change might affect K-fold CV results, due to a different pseudorandom number generator (PRNG) state in folds other than the first one. Likewise, the PRNG state for LOO subsampling (see argument `nloo`) is affected if `refit_prj` is `FALSE` and `nclusters_pred` is not `NULL`. (GitHub: #446)
 
 ## Bug fixes
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -1027,7 +1027,9 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
     # For performance evaluation: Re-project (using the training data of the
     # current fold) along the predictor ranking (or fetch the projections from
     # the search output) of the current fold:
-    p_pred <- get_refdist(fold$refmodel, ndraws_pred, nclusters_pred)
+    if (refit_prj) {
+      p_pred <- get_refdist(fold$refmodel, ndraws_pred, nclusters_pred)
+    }
     submodls <- get_submodls(
       search_path = search_path,
       nterms = c(0, seq_along(search_path$solution_terms)),

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -350,12 +350,14 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   # `validate_search = TRUE`, only `cl_sel` is used later, not `p_sel` itself):
   p_sel <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)
   cl_sel <- p_sel$cl
-  # Clustering or thinning for the performance evaluation (note that in case of
-  # `validate_search = TRUE`, only `cl_pred` is used later, not `p_pred`
-  # itself):
-  p_pred <- get_refdist(refmodel, ndraws = ndraws_pred,
-                        nclusters = nclusters_pred)
-  cl_pred <- p_pred$cl
+  if (refit_prj) {
+    # Clustering or thinning for the performance evaluation (note that in case
+    # of `validate_search = TRUE`, only `cl_pred` is used later, not `p_pred`
+    # itself):
+    p_pred <- get_refdist(refmodel, ndraws = ndraws_pred,
+                          nclusters = nclusters_pred)
+    cl_pred <- p_pred$cl
+  }
 
   if (inherits(refmodel, "datafit")) {
     stop("LOO can be performed only if the reference model is a genuine ",
@@ -748,11 +750,13 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
         mu_offs = refmodel$mu_offs, dis = refmodel$dis, wdraws = exp(lw[, i]),
         cl = cl_sel
       )
-      p_pred <- get_p_clust(
-        family = refmodel$family, eta = refmodel$eta, mu = refmodel$mu,
-        mu_offs = refmodel$mu_offs, dis = refmodel$dis, wdraws = exp(lw[, i]),
-        cl = cl_pred
-      )
+      if (refit_prj) {
+        p_pred <- get_p_clust(
+          family = refmodel$family, eta = refmodel$eta, mu = refmodel$mu,
+          mu_offs = refmodel$mu_offs, dis = refmodel$dis, wdraws = exp(lw[, i]),
+          cl = cl_pred
+        )
+      }
 
       # Run the search with the reweighted clusters (or thinned draws) (so the
       # *reweighted* fitted response values from the reference model act as


### PR DESCRIPTION
This slightly improves efficiency in K-fold and PSIS-LOO CV, especially in case of a large number of observations. See the updated `NEWS.md` for details.