### PR TITLE
Avoid dummy `get_refdist()` call

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Improved handling of PSIS-LOO CV warnings. (GitHub: #438)
 * Reduced peak memory usage during forward search. A global option `projpred.run_gc` has also been added, see the general package documentation (available [online](https://mc-stan.org/projpred/reference/projpred-package.html) or by typing `` ?`projpred-package` ``). (GitHub: #442)
 * Slightly improved efficiency in K-fold and PSIS-LOO CV, especially in case of a large number of observations. If `refit_prj` is `FALSE`, `nclusters` is internally greater than `1` (which requires forward search), and `nclusters_pred` is not `NULL`, this change might affect K-fold CV results, due to a different pseudorandom number generator (PRNG) state in folds other than the first one. Likewise, the PRNG state for LOO subsampling (see argument `nloo`) is affected if `refit_prj` is `FALSE` and `nclusters_pred` is not `NULL`. (GitHub: #446)
+* Slightly improved efficiency at the end of `cv_varsel()`, especially in case of a large number of observations. (GitHub: #447)
 
 ## Bug fixes
 

--- a/R/augdat.R
+++ b/R/augdat.R
@@ -121,7 +121,7 @@ t.augvec <- function(x) {
   nobs_orig_x <- attr(x, "nobs_orig")
   stopifnot(!is.null(nobs_orig_x))
   n_discr <- nrow(x) / nobs_orig_x
-  if (isTRUE(getOption("projpred.subset_aug_checks", FALSE))) {
+  if (isTRUE(getOption("projpred.additional_checks", FALSE))) {
     # This check is not run by default because it could require custom str() and
     # print() (or even more) methods for `augmat` objects and because there
     # could be a high risk of false positive alarms if external functions like
@@ -137,7 +137,7 @@ t.augvec <- function(x) {
   } else {
     nobs_orig_x_out <- nrow(x_out) / n_discr
   }
-  if (isTRUE(getOption("projpred.subset_aug_checks", FALSE))) {
+  if (isTRUE(getOption("projpred.additional_checks", FALSE))) {
     # See above for why this check is not run by default (in this case, we
     # indeed had a false alarm at least once).
     stopifnot(is_wholenumber(nobs_orig_x_out))
@@ -162,14 +162,14 @@ t.augvec <- function(x) {
   nobs_orig_x <- attr(x, "nobs_orig")
   stopifnot(!is.null(nobs_orig_x))
   n_discr <- length(x) / nobs_orig_x
-  if (isTRUE(getOption("projpred.subset_aug_checks", FALSE))) {
+  if (isTRUE(getOption("projpred.additional_checks", FALSE))) {
     # See `[.augmat` for why this check is not run by default (in this case, we
     # indeed had a false alarm at least once).
     stopifnot(is_wholenumber(n_discr))
   }
   n_discr <- as.integer(round(n_discr))
   nobs_orig_x_out <- length(x_out) / n_discr
-  if (isTRUE(getOption("projpred.subset_aug_checks", FALSE))) {
+  if (isTRUE(getOption("projpred.additional_checks", FALSE))) {
     # See `[.augmat` for why this check is not run by default (in this case, we
     # indeed had a false alarm at least once).
     stopifnot(is_wholenumber(nobs_orig_x_out))

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -539,10 +539,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       nterms = c(0, seq_along(search_path$solution_terms)), p_ref = p_pred,
       refmodel = refmodel, regul = opt$regul, refit_prj = refit_prj, ...
     )
-    clust_used_eval <- unique(unlist(lapply(submodls, "[[", "clust_used")))
-    stopifnot(length(clust_used_eval) == 1)
-    nprjdraws_eval <- unique(unlist(lapply(submodls, "[[", "nprjdraws")))
-    stopifnot(length(nprjdraws_eval) == 1)
+    clust_used_eval <- element_unq(submodls, nm = "clust_used")
+    nprjdraws_eval <- element_unq(submodls, nm = "nprjdraws")
     verb_out("-----", verbose = verbose && refit_prj)
 
     verb_out("-----\nCalculating the full-data performance evaluation ",
@@ -782,10 +780,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
         p_ref = p_pred, refmodel = refmodel, regul = opt$regul,
         refit_prj = refit_prj, ...
       )
-      clust_used_eval <- unique(unlist(lapply(submodls, "[[", "clust_used")))
-      stopifnot(length(clust_used_eval) == 1)
-      nprjdraws_eval <- unique(unlist(lapply(submodls, "[[", "nprjdraws")))
-      stopifnot(length(nprjdraws_eval) == 1)
+      clust_used_eval <- element_unq(submodls, nm = "clust_used")
+      nprjdraws_eval <- element_unq(submodls, nm = "nprjdraws")
 
       # Predictive performance at the omitted observation:
       summaries_sub <- get_sub_summaries(submodls = submodls,
@@ -869,20 +865,20 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       rk_i <- res_cv[[run_index]][["predictor_ranking"]]
       if (is.null(prv_len_soltrms)) {
         prv_len_soltrms <- length(rk_i)
-      } else {
+      } else if (getOption("projpred.additional_checks", FALSE)) {
         stopifnot(identical(length(rk_i), prv_len_soltrms))
       }
       solution_terms_mat[i, seq_along(rk_i)] <- rk_i
 
       if (is.null(clust_used_eval)) {
         clust_used_eval <- res_cv[[run_index]][["clust_used_eval"]]
-      } else {
+      } else if (getOption("projpred.additional_checks", FALSE)) {
         stopifnot(identical(res_cv[[run_index]][["clust_used_eval"]],
                             clust_used_eval))
       }
       if (is.null(nprjdraws_eval)) {
         nprjdraws_eval <- res_cv[[run_index]][["nprjdraws_eval"]]
-      } else {
+      } else if (getOption("projpred.additional_checks", FALSE)) {
         stopifnot(identical(res_cv[[run_index]][["nprjdraws_eval"]],
                             nprjdraws_eval))
       }
@@ -1071,10 +1067,8 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
       p_ref = p_pred, refmodel = fold$refmodel, regul = opt$regul,
       refit_prj = refit_prj, ...
     )
-    clust_used_eval <- unique(unlist(lapply(submodls, "[[", "clust_used")))
-    stopifnot(length(clust_used_eval) == 1)
-    nprjdraws_eval <- unique(unlist(lapply(submodls, "[[", "nprjdraws")))
-    stopifnot(length(nprjdraws_eval) == 1)
+    clust_used_eval <- element_unq(submodls, nm = "clust_used")
+    nprjdraws_eval <- element_unq(submodls, nm = "nprjdraws")
 
     # Performance evaluation for the re-projected or fetched submodels of the
     # current fold:
@@ -1139,10 +1133,8 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
   }
   verb_out("-----", verbose = verbose)
   solution_terms_cv <- do.call(rbind, lapply(res_cv, "[[", "predictor_ranking"))
-  clust_used_eval <- unique(unlist(lapply(res_cv, "[[", "clust_used_eval")))
-  stopifnot(length(clust_used_eval) == 1)
-  nprjdraws_eval <- unique(unlist(lapply(res_cv, "[[", "nprjdraws_eval")))
-  stopifnot(length(nprjdraws_eval) == 1)
+  clust_used_eval <- element_unq(res_cv, nm = "clust_used_eval")
+  nprjdraws_eval <- element_unq(res_cv, nm = "nprjdraws_eval")
 
   # Handle the submodels' performance evaluation results:
   sub_foldwise <- lapply(res_cv, "[[", "summaries_sub")

--- a/R/misc.R
+++ b/R/misc.R
@@ -650,3 +650,15 @@ reorder_ias <- function(x, y) {
   }
   return(x)
 }
+
+# Retrieves an element (with name given in argument `nm`) that is duplicated
+# across the elements of a `list`, typically a `list` of `submodl`s:
+element_unq <- function(list_obj, nm) {
+  if (getOption("projpred.additional_checks", FALSE)) {
+    el_unq <- unique(unlist(lapply(list_obj, "[[", nm)))
+    stopifnot(length(el_unq) == 1)
+  } else {
+    el_unq <- list_obj[[1]][[nm]]
+  }
+  return(el_unq)
+}

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -145,7 +145,8 @@ init_submodl <- function(outdmin, p_ref, refmodel, solution_terms, wobs,
   )
   return(structure(
     nlist(dis, ce, wdraws_prj = wdraws_prj, solution_terms, outdmin,
-          cl_ref = p_ref$cl, wdraws_ref = p_ref$wdraws_orig),
+          cl_ref = p_ref$cl, wdraws_ref = p_ref$wdraws_orig,
+          clust_used = p_ref$clust_used, nprjdraws = NCOL(p_ref$mu)),
     class = "submodl"
   ))
 }

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -281,8 +281,6 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
   # Clustering or thinning for the performance evaluation:
   if (refit_prj) {
     p_pred <- get_refdist(refmodel, ndraws_pred, nclusters_pred)
-  } else {
-    p_pred <- p_sel
   }
 
   # Run the search:
@@ -306,6 +304,10 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
     p_ref = p_pred, refmodel = refmodel, regul = regul, refit_prj = refit_prj,
     ...
   )
+  clust_used_eval <- unique(unlist(lapply(submodls, "[[", "clust_used")))
+  stopifnot(length(clust_used_eval) == 1)
+  nprjdraws_eval <- unique(unlist(lapply(submodls, "[[", "nprjdraws")))
+  stopifnot(length(nprjdraws_eval) == 1)
   verb_out("-----", verbose = verbose && refit_prj)
   # The performance evaluation itself, i.e., the calculation of the predictive
   # performance statistic(s) for the submodels along the solution path:
@@ -388,9 +390,9 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
               K = NULL,
               validate_search = NULL,
               clust_used_search = p_sel$clust_used,
-              clust_used_eval = p_pred$clust_used,
+              clust_used_eval,
               nprjdraws_search = NCOL(p_sel$mu),
-              nprjdraws_eval = NCOL(p_pred$mu),
+              nprjdraws_eval,
               projpred_version = utils::packageVersion("projpred"))
   class(vs) <- "vsel"
 

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -304,10 +304,8 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
     p_ref = p_pred, refmodel = refmodel, regul = regul, refit_prj = refit_prj,
     ...
   )
-  clust_used_eval <- unique(unlist(lapply(submodls, "[[", "clust_used")))
-  stopifnot(length(clust_used_eval) == 1)
-  nprjdraws_eval <- unique(unlist(lapply(submodls, "[[", "nprjdraws")))
-  stopifnot(length(nprjdraws_eval) == 1)
+  clust_used_eval <- element_unq(submodls, nm = "clust_used")
+  nprjdraws_eval <- element_unq(submodls, nm = "nprjdraws")
   verb_out("-----", verbose = verbose && refit_prj)
   # The performance evaluation itself, i.e., the calculation of the predictive
   # performance statistic(s) for the submodels along the solution path:

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -1585,7 +1585,7 @@ projection_tester <- function(p,
   expect_named(
     p,
     c("dis", "ce", "wdraws_prj", "solution_terms", "outdmin", "cl_ref",
-      "wdraws_ref", "const_wdraws_prj", "refmodel"),
+      "wdraws_ref", "clust_used", "nprjdraws", "const_wdraws_prj", "refmodel"),
     info = info_str
   )
 
@@ -1726,6 +1726,12 @@ projection_tester <- function(p,
   # wdraws_ref
   expect_identical(p$wdraws_ref, rep(1, length(p$refmodel$wdraws_ref)),
                    info = info_str)
+
+  # clust_used
+  expect_identical(p$clust_used, with_clusters, info = info_str)
+
+  # nprjdraws
+  expect_identical(p$nprjdraws, nprjdraws_expected, info = info_str)
 
   # const_wdraws_prj
   expect_identical(p$const_wdraws_prj, const_wdraws_prj_expected,

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -879,9 +879,9 @@ options(projpred.warn_wobs_ppd = FALSE)
 options(projpred.verbose_project = FALSE)
 # Suppress instability warnings:
 options(projpred.warn_instable_projections = FALSE)
-# Run the check for attribute `nobs_orig` when subsetting `augmat` and `augvec`
-# objects:
-options(projpred.subset_aug_checks = TRUE)
+# Run additional checks, e.g., the check for attribute `nobs_orig` when
+# subsetting `augmat` and `augvec` objects:
+options(projpred.additional_checks = TRUE)
 
 search_trms_tst <- list(
   default_search_trms = list(),

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -341,7 +341,7 @@ test_that(paste(
           datafits[[args_prj_vs_datafit[[tstsetup]]$tstsetup_datafit]],
         solterms_expected = solterms_expected_crr,
         nprjdraws_expected = 1L,
-        with_clusters = TRUE,
+        with_clusters = FALSE,
         const_wdraws_prj_expected = TRUE,
         from_vsel_L1_search = with_L1,
         info_str = tstsetup
@@ -367,7 +367,7 @@ test_that(paste(
         refmod_expected =
           datafits[[args_prj_vs_datafit[[tstsetup]]$tstsetup_datafit]],
         nprjdraws_expected = 1L,
-        with_clusters = TRUE,
+        with_clusters = FALSE,
         const_wdraws_prj_expected = TRUE,
         prjdraw_weights_expected = prjs_vs_datafit[[tstsetup]][[1]]$wdraws_prj,
         from_vsel_L1_search = with_L1


### PR DESCRIPTION
This slightly improves efficiency at the end of `cv_varsel()`, especially in case of a large number of observations. See the commit messages for details.