### PR TITLE
Reduce memory usage by moving `get_refdist()` calls to `select()` and `get_submodls()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Reduced peak memory usage during forward search. A global option `projpred.run_gc` has also been added, see the general package documentation (available [online](https://mc-stan.org/projpred/reference/projpred-package.html) or by typing `` ?`projpred-package` ``). (GitHub: #442)
 * Slightly improved efficiency in K-fold and PSIS-LOO CV, especially in case of a large number of observations. If `refit_prj` is `FALSE`, `nclusters` is internally greater than `1` (which requires forward search), and `nclusters_pred` is not `NULL`, this change might affect K-fold CV results, due to a different pseudorandom number generator (PRNG) state in folds other than the first one. Likewise, the PRNG state for LOO subsampling (see argument `nloo`) is affected if `refit_prj` is `FALSE` and `nclusters_pred` is not `NULL`. (GitHub: #446)
 * Slightly improved efficiency at the end of `cv_varsel()`, especially in case of a large number of observations. (GitHub: #447)
+* Slightly improved memory usage in `varsel()`, `cv_varsel()`, and `project()`. In case of LOO subsampling (see argument `nloo`), this change may lead to slightly different results due to a different PRNG state when clustering the reference model's posterior draws. (GitHub: #448)
 
 ## Bug fixes
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -207,9 +207,9 @@ cv_varsel.refmodel <- function(
     verb_out("-----\nRunning the search using the full dataset ...",
              verbose = verbose)
     search_path_full_data <- select(
-      method = method, refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
-      nterms_max = nterms_max, penalty = penalty, verbose = verbose, opt = opt,
-      search_terms = search_terms, ...
+      refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
+      method = method, nterms_max = nterms_max, penalty = penalty,
+      verbose = verbose, opt = opt, search_terms = search_terms, ...
     )
     verb_out("-----", verbose = verbose)
     ce_out <- rep(NA_real_, length(search_path_full_data$solution_terms) + 1L)
@@ -512,9 +512,9 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     verb_out("-----\nRunning the search using the full dataset ...",
              verbose = verbose)
     search_path <- select(
-      method = method, refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
-      nterms_max = nterms_max, penalty = penalty, verbose = verbose, opt = opt,
-      search_terms = search_terms, ...
+      refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
+      method = method, nterms_max = nterms_max, penalty = penalty,
+      verbose = verbose, opt = opt, search_terms = search_terms, ...
     )
     verb_out("-----", verbose = verbose)
 
@@ -738,10 +738,10 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       # artifical response values in the projection (or L1-penalized
       # projection)):
       search_path <- select(
-        method = method, refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
-        wdraws_ref = exp(lw[, i]),
-        nterms_max = nterms_max, penalty = penalty, verbose = verbose_search,
-        opt = opt, search_terms = search_terms, ...
+        refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
+        wdraws_ref = exp(lw[, i]), method = method, nterms_max = nterms_max,
+        penalty = penalty, verbose = verbose_search, opt = opt,
+        search_terms = search_terms, ...
       )
 
       # Re-project along the solution path (or fetch the projections from the
@@ -1022,9 +1022,9 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
                        ...) {
     # Run the search for the current fold:
     search_path <- select(
-      method = method, refmodel = fold$refmodel, ndraws = ndraws, nclusters = nclusters,
-      nterms_max = nterms_max, penalty = penalty, verbose = verbose_search,
-      opt = opt, search_terms = search_terms, ...
+      refmodel = fold$refmodel, ndraws = ndraws, nclusters = nclusters,
+      method = method, nterms_max = nterms_max, penalty = penalty,
+      verbose = verbose_search, opt = opt, search_terms = search_terms, ...
     )
 
     # For performance evaluation: Re-project (using the training data of the

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -723,6 +723,12 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   } else {
     ## Case `validate_search = TRUE` ------------------------------------------
 
+    cl_sel <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)$cl
+    if (refit_prj) {
+      cl_pred <- get_refdist(refmodel, ndraws = ndraws_pred,
+                             nclusters = nclusters_pred)$cl
+    }
+
     verb_out("-----\nRunning the search and the performance evaluation for ",
              "each of the N = ", nloo, " LOO CV folds separately ...",
              verbose = verbose)
@@ -739,9 +745,9 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       # projection)):
       search_path <- select(
         refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
-        wdraws_ref = exp(lw[, i]), method = method, nterms_max = nterms_max,
-        penalty = penalty, verbose = verbose_search, opt = opt,
-        search_terms = search_terms, ...
+        reweighting_args = list(cl_ref = cl_sel, wdraws_ref = exp(lw[, i])),
+        method = method, nterms_max = nterms_max, penalty = penalty,
+        verbose = verbose_search, opt = opt, search_terms = search_terms, ...
       )
 
       # Re-project along the solution path (or fetch the projections from the
@@ -751,7 +757,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
         nterms = c(0, seq_along(search_path$solution_terms)),
         refmodel = refmodel, regul = opt$regul, refit_prj = refit_prj,
         ndraws = ndraws_pred, nclusters = nclusters_pred,
-        wdraws_ref = exp(lw[, i]), ...
+        reweighting_args = list(cl_ref = cl_pred, wdraws_ref = exp(lw[, i])),
+        ...
       )
       clust_used_eval <- element_unq(submodls, nm = "clust_used")
       nprjdraws_eval <- element_unq(submodls, nm = "nprjdraws")

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -749,8 +749,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       submodls <- get_submodls(
         search_path = search_path,
         nterms = c(0, seq_along(search_path$solution_terms)),
-        refmodel = refmodel, regul = opt$regul,
-        refit_prj = refit_prj, ndraws = ndraws_pred, nclusters = nclusters_pred,
+        refmodel = refmodel, regul = opt$regul, refit_prj = refit_prj,
+        ndraws = ndraws_pred, nclusters = nclusters_pred,
         wdraws_ref = exp(lw[, i]), ...
       )
       clust_used_eval <- element_unq(submodls, nm = "clust_used")
@@ -1033,9 +1033,8 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws,
     submodls <- get_submodls(
       search_path = search_path,
       nterms = c(0, seq_along(search_path$solution_terms)),
-      refmodel = fold$refmodel, regul = opt$regul,
-      refit_prj = refit_prj, ndraws = ndraws_pred, nclusters = nclusters_pred,
-      ...
+      refmodel = fold$refmodel, regul = opt$regul, refit_prj = refit_prj,
+      ndraws = ndraws_pred, nclusters = nclusters_pred, ...
     )
     clust_used_eval <- element_unq(submodls, nm = "clust_used")
     nprjdraws_eval <- element_unq(submodls, nm = "nprjdraws")

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -88,8 +88,8 @@ divmin <- function(formula, projpred_var, projpred_verbose = FALSE, ...) {
       projpred_formula_no_random_s = projpred_formulas_no_random,
       .export = c("sdivmin", "projpred_random", "dot_args"),
       .noexport = c(
-        "object", "p_sel", "p_pred", "search_path", "p_ref", "refmodel",
-        "formulas", "projpred_var", "projpred_formulas_no_random"
+        "object", "p_sel", "search_path", "p_ref", "refmodel", "formulas",
+        "projpred_var", "projpred_formulas_no_random"
       )
     ) %do_projpred% {
       do.call(
@@ -611,8 +611,8 @@ divmin_augdat <- function(formula, data, family, weights, projpred_var,
         "projpred_random", "dot_args"
       ),
       .noexport = c(
-        "object", "p_sel", "p_pred", "search_path", "p_ref", "refmodel",
-        "projpred_var", "projpred_ws_aug", "linkobjs"
+        "object", "p_sel", "search_path", "p_ref", "refmodel", "projpred_var",
+        "projpred_ws_aug", "linkobjs"
       )
     ) %do_projpred% {
       do.call(

--- a/R/project.R
+++ b/R/project.R
@@ -261,11 +261,6 @@ project <- function(object, nterms = NULL, solution_terms = NULL,
     )
   }
 
-  ## get the clustering or thinning
-  if (refit_prj) {
-    p_ref <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)
-  }
-
   ## project onto the submodels
   submodls <- get_submodls(
     search_path = nlist(
@@ -273,19 +268,14 @@ project <- function(object, nterms = NULL, solution_terms = NULL,
       p_sel = object$search_path$p_sel,
       outdmins = object$search_path$outdmins
     ),
-    nterms = nterms, p_ref = p_ref, refmodel = refmodel, regul = regul,
-    refit_prj = refit_prj, projpred_verbose = verbose, ...
+    nterms = nterms, refmodel = refmodel, regul = regul, refit_prj = refit_prj,
+    ndraws = ndraws, nclusters = nclusters, projpred_verbose = verbose, ...
   )
 
   # Output:
-  if (refit_prj) {
-    refdist_obj <- p_ref
-  } else {
-    refdist_obj <- object$search_path$p_sel
-  }
   projs <- lapply(submodls, function(submodl) {
     proj_k <- submodl
-    proj_k[["const_wdraws_prj"]] <- length(unique(refdist_obj$wdraws_prj)) == 1
+    proj_k[["const_wdraws_prj"]] <- length(unique(submodl$wdraws_prj)) == 1
     proj_k$refmodel <- refmodel
     class(proj_k) <- "projection"
     return(proj_k)

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -54,7 +54,7 @@ get_submodl_prj <- function(solution_terms, p_ref, refmodel, regul = 1e-4,
 # `submodl`.
 get_submodls <- function(search_path, nterms, refmodel, regul,
                          refit_prj = FALSE, ndraws, nclusters,
-                         wdraws_ref = NULL, return_p_ref = FALSE, ...) {
+                         reweighting_args = NULL, return_p_ref = FALSE, ...) {
   if (!refit_prj) {
     p_ref <- search_path$p_sel
     # In this case, simply fetch the already computed projections, so don't
@@ -76,13 +76,14 @@ get_submodls <- function(search_path, nterms, refmodel, regul,
     }
   } else {
     # In this case, project again.
-    p_ref <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)
-    if (!is.null(wdraws_ref)) {
+    if (is.null(reweighting_args)) {
+      p_ref <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)
+    } else {
       # Reweight the clusters (or thinned draws) according to the PSIS weights:
       p_ref <- get_p_clust(
         family = refmodel$family, eta = refmodel$eta, mu = refmodel$mu,
-        mu_offs = refmodel$mu_offs, dis = refmodel$dis, wdraws = wdraws_ref,
-        cl = p_ref$cl
+        mu_offs = refmodel$mu_offs, dis = refmodel$dis,
+        wdraws = reweighting_args$wdraws_ref, cl = reweighting_args$cl_ref
       )
     }
     fetch_submodl <- function(nterms, ...) {

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -412,14 +412,12 @@ select <- function(refmodel, ndraws, nclusters, wdraws_ref = NULL, method,
   }
   if (method == "L1") {
     search_path <- search_L1(p_sel, refmodel, nterms_max, penalty, opt)
-    search_path$p_sel <- p_sel
-    return(search_path)
   } else if (method == "forward") {
     search_path <- search_forward(p_sel, refmodel, nterms_max, verbose, opt,
                                   search_terms = search_terms, ...)
-    search_path$p_sel <- p_sel
-    return(search_path)
   }
+  search_path$p_sel <- p_sel
+  return(search_path)
 }
 
 # Auxiliary function for parsing the arguments of varsel()

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -392,21 +392,27 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
 
 # Workhorse function for the search
 #
-# For the arguments, see the documentation of varsel().
+# @param reweighting_args If the projected draws (i.e., those obtained from
+#   clustering or thinning) should be re-weighted (usually according to PSIS
+#   weights), then this needs to be a `list` with elements `wdraws_ref` and
+#   `cl_ref`. For these two elements, see the (internal) documentation of
+#   weighted_summary_means().
+# For all other arguments, see the documentation of varsel().
 #
 # @return A list with elements `solution_terms` (the solution path), `outdmins`
 #   (the submodel fits along the solution path, with the number of fits per
 #   model size being equal to the number of projected draws), and `p_sel` (the
 #   output from get_refdist() for the search).
-select <- function(refmodel, ndraws, nclusters, wdraws_ref = NULL, method,
+select <- function(refmodel, ndraws, nclusters, reweighting_args = NULL, method,
                    nterms_max, penalty, verbose, opt, search_terms, ...) {
-  p_sel <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)
-  if (!is.null(wdraws_ref)) {
+  if (is.null(reweighting_args)) {
+    p_sel <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)
+  } else {
     # Reweight the clusters (or thinned draws) according to the PSIS weights:
     p_sel <- get_p_clust(
       family = refmodel$family, eta = refmodel$eta, mu = refmodel$mu,
-      mu_offs = refmodel$mu_offs, dis = refmodel$dis, wdraws = wdraws_ref,
-      cl = p_sel$cl
+      mu_offs = refmodel$mu_offs, dis = refmodel$dis,
+      wdraws = reweighting_args$wdraws_ref, cl = reweighting_args$cl_ref
     )
   }
   if (method == "L1") {

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -295,8 +295,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
     search_path = search_path,
     nterms = c(0, seq_along(search_path$solution_terms)),
     refmodel = refmodel, regul = regul, refit_prj = refit_prj,
-    ndraws = ndraws_pred, nclusters = nclusters_pred,
-    ...
+    ndraws = ndraws_pred, nclusters = nclusters_pred, ...
   )
   clust_used_eval <- element_unq(submodls, nm = "clust_used")
   nprjdraws_eval <- element_unq(submodls, nm = "nprjdraws")

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -411,10 +411,15 @@ select <- function(refmodel, ndraws, nclusters, wdraws_ref = NULL, method,
     )
   }
   if (method == "L1") {
-    search_path <- search_L1(p_sel, refmodel, nterms_max, penalty, opt)
+    search_path <- search_L1(
+      p_ref = p_sel, refmodel = refmodel, nterms_max = nterms_max,
+      penalty = penalty, opt = opt
+    )
   } else if (method == "forward") {
-    search_path <- search_forward(p_sel, refmodel, nterms_max, verbose, opt,
-                                  search_terms = search_terms, ...)
+    search_path <- search_forward(
+      p_ref = p_sel, refmodel = refmodel, nterms_max = nterms_max,
+      verbose = verbose, opt = opt, search_terms = search_terms, ...
+    )
   }
   search_path$p_sel <- p_sel
   return(search_path)

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -280,9 +280,9 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
   opt <- nlist(lambda_min_ratio, nlambda, thresh, regul)
   verb_out("-----\nRunning the search ...", verbose = verbose)
   search_path <- select(
-    method = method, refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
-    nterms_max = nterms_max, penalty = penalty, verbose = verbose, opt = opt,
-    search_terms = search_terms, ...
+    refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
+    method = method, nterms_max = nterms_max, penalty = penalty,
+    verbose = verbose, opt = opt, search_terms = search_terms, ...
   )
   verb_out("-----", verbose = verbose)
 
@@ -399,7 +399,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = NULL,
 #   (the submodel fits along the solution path, with the number of fits per
 #   model size being equal to the number of projected draws), and `p_sel` (the
 #   output from get_refdist() for the search).
-select <- function(method, refmodel, ndraws, nclusters, wdraws_ref = NULL,
+select <- function(refmodel, ndraws, nclusters, wdraws_ref = NULL, method,
                    nterms_max, penalty, verbose, opt, search_terms, ...) {
   p_sel <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)
   if (!is.null(wdraws_ref)) {

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1227,12 +1227,21 @@ test_that("`refit_prj` works", {
 ## nloo -------------------------------------------------------------------
 
 test_that("invalid `nloo` fails", {
-  for (tstsetup in names(refmods)) {
+  tstsetups_nonkfold <- grep("\\.kfold", names(cvvss), value = TRUE,
+                             invert = TRUE)
+  for (tstsetup in head(tstsetups_nonkfold, 1)) {
+    args_cvvs_i <- args_cvvs[[tstsetup]]
     # Use suppressWarnings() because of occasional warnings concerning Pareto k
     # diagnostics:
-    expect_error(suppressWarnings(cv_varsel(refmods[[tstsetup]], nloo = -1)),
-                 "^nloo must be at least 1$",
-                 info = tstsetup)
+    expect_error(
+      suppressWarnings(do.call(cv_varsel, c(
+        list(object = refmods[[args_cvvs_i$tstsetup_ref]],
+             nloo = -1),
+        excl_nonargs(args_cvvs_i)
+      ))),
+      "^nloo must be at least 1$",
+      info = tstsetup
+    )
   }
 })
 


### PR DESCRIPTION
Where possible, this moves `get_refdist()` calls to `select()` and `get_submodls()`, which provides an efficiency improvement (in terms of memory used) because in case of a large number of observations, the `get_refdist()` output can be large.

See the newly added `NEWS.md` entry and the commit messages for details.