### PR TITLE
Throw message when cutting off the search

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
     + An error is now thrown if a length-zero element `weights` or `offset` is returned by the function supplied to argument `extract_model_data` of `init_refmodel()` (before, a vector of ones or zeros was used silently for the observation weights and offsets, respectively).
 * Added the helper function `force_search_terms()` which allows to construct `search_terms` where certain predictor terms are forced to be included (i.e., they are forced to be selected first) whereas other predictor terms are optional (i.e., they are subject to the variable selection, but only after the inclusion of the "forced" terms). (GitHub: #346)
 * Reduced peak memory usage during performance evaluation (more precisely, during the re-projections done for the performance evaluation). This reduction is considerable especially for multilevel submodels, but possibly also for additive submodels. (GitHub: #440, #450)
+* A message is thrown now when cutting off the search at `nterms_max`'s internal default of (currently) `19`. (GitHub: #452)
 
 ## Bug fixes
 

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -495,6 +495,10 @@ parse_args_varsel <- function(refmodel, method, refit_prj, nterms_max,
   max_nv_possible <- count_terms_chosen(search_terms_unq) - 1L
   if (is.null(nterms_max)) {
     nterms_max <- 19
+    if (nterms_max < max_nv_possible &&
+        getOption("projpred.mssg_cut_search", TRUE)) {
+      message("Cutting off the search at size ", nterms_max, ".")
+    }
   }
   nterms_max <- min(max_nv_possible, nterms_max)
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -863,6 +863,9 @@ meth_tst <- list(
   L1 = list(method = "L1"),
   forward = list(method = "forward")
 )
+
+# Suppress the message when cutting off the search at `nterms_max = 19`:
+options(projpred.mssg_cut_search = FALSE)
 # Suppress the PSIS warnings:
 options(projpred.warn_psis = FALSE)
 # Suppress the subsampled PSIS-LOO CV warnings:

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -618,6 +618,50 @@ if (run_more) {
   })
 }
 
+## Message when cutting off the search ------------------------------------
+
+if (run_more) {
+  test_that("the message when cutting off the search is thrown correctly", {
+    skip_if_not(run_vs)
+    skip_if_not_installed("rstanarm")
+    mssg_cut_search_orig <- options(projpred.mssg_cut_search = NULL)
+    dat_gauss <- data.frame(y = df_gaussian$y, df_gaussian$x)
+    stopifnot(sum(grepl("^X", names(dat_gauss))) > 19)
+    fit_exceed <- suppressWarnings(rstanarm::stan_glm(
+      y ~ ., family = gaussian(), data = dat_gauss, QR = TRUE, chains = 1,
+      iter = 500, refresh = 0, seed = 9876
+    ))
+    fit_not_exceed <- suppressWarnings(rstanarm::stan_glm(
+      y ~ . - X20, family = gaussian(), data = dat_gauss, QR = TRUE, chains = 1,
+      iter = 500, refresh = 0, seed = 9876
+    ))
+    for (nterms_max_i in list(NULL, 0, 20)) {
+      if (is.null(nterms_max_i)) {
+        mssg_expected <- "Cutting off the search at size 19\\."
+      } else {
+        mssg_expected <- NA
+      }
+      expect_message(
+        vs_tmp <- varsel(
+          fit_exceed, method = "forward", nterms_max = nterms_max_i,
+          nclusters = 1, refit_prj = FALSE, seed = 5555, verbose = FALSE
+        ),
+        mssg_expected,
+        info = paste("fit_exceed, nterms_max =", nterms_max_i %||% "NULL")
+      )
+      expect_message(
+        vs_tmp <- varsel(
+          fit_not_exceed, method = "forward", nterms_max = nterms_max_i,
+          nclusters = 1, refit_prj = FALSE, seed = 5555, verbose = FALSE
+        ),
+        NA,
+        info = paste("fit_not_exceed, nterms_max =", nterms_max_i %||% "NULL")
+      )
+    }
+    options(mssg_cut_search_orig)
+  })
+}
+
 ## Regularization ---------------------------------------------------------
 
 # In fact, `regul` is already checked in `test_project.R`, so the `regul` tests
@@ -1224,6 +1268,52 @@ test_that("`refit_prj` works", {
     )
   }
 })
+
+## Message when cutting off the search ------------------------------------
+
+if (run_more) {
+  test_that("the message when cutting off the search is thrown correctly", {
+    skip_if_not(run_vs)
+    skip_if_not_installed("rstanarm")
+    mssg_cut_search_orig <- options(projpred.mssg_cut_search = NULL)
+    dat_gauss <- data.frame(y = df_gaussian$y, df_gaussian$x)
+    stopifnot(sum(grepl("^X", names(dat_gauss))) > 19)
+    fit_exceed <- suppressWarnings(rstanarm::stan_glm(
+      y ~ ., family = gaussian(), data = dat_gauss, QR = TRUE, chains = 1,
+      iter = 500, refresh = 0, seed = 9876
+    ))
+    fit_not_exceed <- suppressWarnings(rstanarm::stan_glm(
+      y ~ . - X20, family = gaussian(), data = dat_gauss, QR = TRUE, chains = 1,
+      iter = 500, refresh = 0, seed = 9876
+    ))
+    for (nterms_max_i in list(NULL, 0, 20)) {
+      if (is.null(nterms_max_i)) {
+        mssg_expected <- "Cutting off the search at size 19\\."
+      } else {
+        mssg_expected <- NA
+      }
+      expect_message(
+        vs_tmp <- suppressWarnings(cv_varsel(
+          fit_exceed, validate_search = FALSE, method = "forward",
+          nterms_max = nterms_max_i, nclusters = 2, refit_prj = FALSE,
+          seed = 5555, verbose = FALSE
+        )),
+        mssg_expected,
+        info = paste("fit_exceed, nterms_max =", nterms_max_i %||% "NULL")
+      )
+      expect_message(
+        vs_tmp <- suppressWarnings(cv_varsel(
+          fit_not_exceed, validate_search = FALSE, method = "forward",
+          nterms_max = nterms_max_i, nclusters = 2, refit_prj = FALSE,
+          seed = 5555, verbose = FALSE
+        )),
+        NA,
+        info = paste("fit_not_exceed, nterms_max =", nterms_max_i %||% "NULL")
+      )
+    }
+    options(mssg_cut_search_orig)
+  })
+}
 
 ## nloo -------------------------------------------------------------------
 


### PR DESCRIPTION
This PR throws a message when cutting off the search at `nterms_max`'s internal default of (currently) `19`.