### PR TITLE
Simplify the required structure for `cvfits`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Reduced peak memory usage during performance evaluation (more precisely, during the re-projections done for the performance evaluation). This reduction is considerable especially for multilevel submodels, but possibly also for additive submodels. (GitHub: #440, #450)
 * A message is thrown now when cutting off the search at `nterms_max`'s internal default of (currently) `19`. (GitHub: #452)
 * Added sub-section "Speed" to the main vignette's ["Troubleshooting"](https://mc-stan.org/projpred/articles/projpred.html#troubleshooting) section. (GitHub: #455)
+* The `list` passed to argument `cvfits` of `init_refmodel()` should not have a sub-`list` called `fits` anymore. Instead, the content of this former sub-`list` called `fits` should be moved one level up, i.e., should be placed directly in the `list` passed to `cvfits` (the empty element `fits` should then be removed). For some time, the old structure will continue to work, but this possibility is deprecated and will be removed in the future. (GitHub: #456)
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 * Enhancements in the vignettes. In particular, the new functions `ranking()`, `cv_proportions()`, and `plot.cv_proportions()` (see "Major changes" above) are now illustrated in the main vignette. (GitHub: #407, #411)
 * Reduced the peak memory usage of `cv_varsel()` with `cv_method = "kfold"`. This may slightly change results from such a `cv_varsel()` run compared to older **projpred** versions due to different pseudorandom number generator (PRNG) states when clustering posterior draws. (GitHub: #419)
+* The `cvfits` list (see `init_refmodel()`) does not need to have an attribute called `K` anymore.
 
 ## Bug fixes
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -318,7 +318,19 @@ parse_args_cv_varsel <- function(refmodel, cv_method, K, validate_search) {
 
   if (cv_method == "kfold") {
     if (!is.null(refmodel$cvfits)) {
-      K <- length(refmodel$cvfits$fits)
+      cvfits_for_K <- refmodel$cvfits
+      if (identical(names(cvfits_for_K), "fits")) {
+        ### Not throwing this warning here because it is already thrown by
+        ### get_kfold() (where it makes more sense):
+        # warning(
+        #   "The content of `cvfits`'s sub-list called `fits` should be ",
+        #   "moved one level up (and element `fits` removed). The old ",
+        #   "structure will continue to work for a while, but is deprecated."
+        # )
+        ###
+        cvfits_for_K <- cvfits_for_K$fits
+      }
+      K <- length(cvfits_for_K)
     }
     stopifnot(!is.null(K))
     if (length(K) > 1 || !is.numeric(K) || !is_wholenumber(K)) {
@@ -1227,7 +1239,13 @@ get_kfold <- function(refmodel, K, verbose) {
     }
   } else {
     folds <- attr(refmodel$cvfits, "folds")
-    cvfits <- refmodel$cvfits$fits
+    cvfits <- refmodel$cvfits
+    if (identical(names(cvfits), "fits")) {
+      warning("The content of `cvfits`'s sub-list called `fits` should be ",
+              "moved one level up (and element `fits` removed). The old ",
+              "structure will continue to work for a while, but is deprecated.")
+      cvfits <- cvfits$fits
+    }
   }
   return(lapply(seq_len(K), function(k) {
     cvfit <- cvfits[[k]]

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -81,15 +81,14 @@
 #'   latent projection is an exception where `family` is not the family of the
 #'   submodels (in that case, the family of the submodels is the [gaussian()]
 #'   family).
-#' @param cvfits For \eqn{K}-fold CV only. A `list` containing a sub-`list`
-#'   called `fits` containing the \eqn{K} model fits from which reference model
-#'   objects are created. The `cvfits` `list` (i.e., the super-`list`) needs
-#'   to have an attribute called `folds`, consisting of an integer vector giving
-#'   the fold indices (one fold index per observation). Each element of
-#'   `cvfits$fits` (i.e., each of the \eqn{K} model fits) needs to be a list.
-#'   Only one of `cvfits` and `cvfun` needs to be provided (for \eqn{K}-fold
-#'   CV). Note that `cvfits` takes precedence over `cvfun`, i.e., if both are
-#'   provided, `cvfits` is used.
+#' @param cvfits For \eqn{K}-fold CV only. A `list` containing the \eqn{K}
+#'   reference model fits from which reference model objects are created. This
+#'   `list` needs to have an attribute called `folds`, consisting of an integer
+#'   vector giving the fold indices (one fold index per observation). Each
+#'   element of this `list` (i.e., each of the \eqn{K} reference model fits)
+#'   needs to be a `list` itself. Only one of `cvfits` and `cvfun` needs to be
+#'   provided (for \eqn{K}-fold CV). Note that `cvfits` takes precedence over
+#'   `cvfun`, i.e., if both are provided, `cvfits` is used.
 #' @param cvfun For \eqn{K}-fold CV only. A function that, given a fold indices
 #'   vector, fits the reference model separately for each fold and returns the
 #'   \eqn{K} model fits as a `list`. Each of the \eqn{K} model fits needs to be
@@ -100,13 +99,13 @@
 #' @param cvrefbuilder For \eqn{K}-fold CV only. A function that, given a
 #'   reference model fit for fold \eqn{k \in \{1, ..., K\}}{k = 1, ..., K} (this
 #'   model fit is the \eqn{k}-th element of the return value of `cvfun` or the
-#'   \eqn{k}-th element of `cvfits$fits`, extended by elements `omitted`
-#'   (containing the indices of the left-out observations in that fold) and
-#'   `projpred_k` (containing the integer \eqn{k})), returns an object of the
-#'   same type as [init_refmodel()] does. Argument `cvrefbuilder` may be `NULL`
-#'   for using an internal default: [get_refmodel()] if `object` is not `NULL`
-#'   and a function calling [init_refmodel()] appropriately (with the assumption
-#'   `dis = 0`) if `object` is `NULL`.
+#'   \eqn{k}-th element of the `list` supplied to `cvfits`, extended by elements
+#'   `omitted` (containing the indices of the left-out observations in that
+#'   fold) and `projpred_k` (containing the integer \eqn{k})), returns an object
+#'   of the same type as [init_refmodel()] does. Argument `cvrefbuilder` may be
+#'   `NULL` for using an internal default: [get_refmodel()] if `object` is not
+#'   `NULL` and a function calling [init_refmodel()] appropriately (with the
+#'   assumption `dis = 0`) if `object` is `NULL`.
 #' @param called_from_cvrefbuilder A single logical value indicating whether
 #'   [init_refmodel()] is called from a `cvrefbuilder` function (`TRUE`) or not
 #'   (`FALSE`). Currently, `TRUE` only causes some warnings to be suppressed

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -83,7 +83,7 @@
 #'   family).
 #' @param cvfits For \eqn{K}-fold CV only. A `list` containing a sub-`list`
 #'   called `fits` containing the \eqn{K} model fits from which reference model
-#'   structures are created. The `cvfits` `list` (i.e., the super-`list`) needs
+#'   objects are created. The `cvfits` `list` (i.e., the super-`list`) needs
 #'   to have an attribute called `folds`, consisting of an integer vector giving
 #'   the fold indices (one fold index per observation). Each element of
 #'   `cvfits$fits` (i.e., each of the \eqn{K} model fits) needs to be a list.

--- a/man/refmodel-init-get.Rd
+++ b/man/refmodel-init-get.Rd
@@ -128,7 +128,7 @@ i.e., if both are provided, \code{cvfits} is used.}
 
 \item{cvfits}{For \eqn{K}-fold CV only. A \code{list} containing a sub-\code{list}
 called \code{fits} containing the \eqn{K} model fits from which reference model
-structures are created. The \code{cvfits} \code{list} (i.e., the super-\code{list}) needs
+objects are created. The \code{cvfits} \code{list} (i.e., the super-\code{list}) needs
 to have an attribute called \code{folds}, consisting of an integer vector giving
 the fold indices (one fold index per observation). Each element of
 \code{cvfits$fits} (i.e., each of the \eqn{K} model fits) needs to be a list.

--- a/man/refmodel-init-get.Rd
+++ b/man/refmodel-init-get.Rd
@@ -126,26 +126,25 @@ internal default. Only one of \code{cvfits} and \code{cvfun} needs to be provide
 (for \eqn{K}-fold CV). Note that \code{cvfits} takes precedence over \code{cvfun},
 i.e., if both are provided, \code{cvfits} is used.}
 
-\item{cvfits}{For \eqn{K}-fold CV only. A \code{list} containing a sub-\code{list}
-called \code{fits} containing the \eqn{K} model fits from which reference model
-objects are created. The \code{cvfits} \code{list} (i.e., the super-\code{list}) needs
-to have an attribute called \code{folds}, consisting of an integer vector giving
-the fold indices (one fold index per observation). Each element of
-\code{cvfits$fits} (i.e., each of the \eqn{K} model fits) needs to be a list.
-Only one of \code{cvfits} and \code{cvfun} needs to be provided (for \eqn{K}-fold
-CV). Note that \code{cvfits} takes precedence over \code{cvfun}, i.e., if both are
-provided, \code{cvfits} is used.}
+\item{cvfits}{For \eqn{K}-fold CV only. A \code{list} containing the \eqn{K}
+reference model fits from which reference model objects are created. This
+\code{list} needs to have an attribute called \code{folds}, consisting of an integer
+vector giving the fold indices (one fold index per observation). Each
+element of this \code{list} (i.e., each of the \eqn{K} reference model fits)
+needs to be a \code{list} itself. Only one of \code{cvfits} and \code{cvfun} needs to be
+provided (for \eqn{K}-fold CV). Note that \code{cvfits} takes precedence over
+\code{cvfun}, i.e., if both are provided, \code{cvfits} is used.}
 
 \item{cvrefbuilder}{For \eqn{K}-fold CV only. A function that, given a
 reference model fit for fold \eqn{k \in \{1, ..., K\}}{k = 1, ..., K} (this
 model fit is the \eqn{k}-th element of the return value of \code{cvfun} or the
-\eqn{k}-th element of \code{cvfits$fits}, extended by elements \code{omitted}
-(containing the indices of the left-out observations in that fold) and
-\code{projpred_k} (containing the integer \eqn{k})), returns an object of the
-same type as \code{\link[=init_refmodel]{init_refmodel()}} does. Argument \code{cvrefbuilder} may be \code{NULL}
-for using an internal default: \code{\link[=get_refmodel]{get_refmodel()}} if \code{object} is not \code{NULL}
-and a function calling \code{\link[=init_refmodel]{init_refmodel()}} appropriately (with the assumption
-\code{dis = 0}) if \code{object} is \code{NULL}.}
+\eqn{k}-th element of the \code{list} supplied to \code{cvfits}, extended by elements
+\code{omitted} (containing the indices of the left-out observations in that
+fold) and \code{projpred_k} (containing the integer \eqn{k})), returns an object
+of the same type as \code{\link[=init_refmodel]{init_refmodel()}} does. Argument \code{cvrefbuilder} may be
+\code{NULL} for using an internal default: \code{\link[=get_refmodel]{get_refmodel()}} if \code{object} is not
+\code{NULL} and a function calling \code{\link[=init_refmodel]{init_refmodel()}} appropriately (with the
+assumption \code{dis = 0}) if \code{object} is \code{NULL}.}
 
 \item{called_from_cvrefbuilder}{A single logical value indicating whether
 \code{\link[=init_refmodel]{init_refmodel()}} is called from a \code{cvrefbuilder} function (\code{TRUE}) or not

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1520,9 +1520,7 @@ test_that(paste(
           attr(kfold_obj, "condition")$message, "\"\n", sep = "")
       next
     }
-    kfold_obj <- structure(list(fits = kfold_obj$fits[, "fit"]),
-                           K = K_crr,
-                           folds = folds_vec)
+    kfold_obj <- structure(kfold_obj$fits[, "fit"], folds = folds_vec)
 
     # Create `"refmodel"` object with `cvfits`:
     refmod_crr <- do.call(get_refmodel, c(
@@ -1621,9 +1619,7 @@ test_that(paste(
                        folds = folds_vec,
                        save_fits = TRUE,
                        seed = seed_fit)
-    kfold_obj <- structure(list(fits = kfold_obj$fits[, "fit"]),
-                           K = K_crr,
-                           folds = folds_vec)
+    kfold_obj <- structure(kfold_obj$fits[, "fit"], folds = folds_vec)
 
     # Create `"refmodel"` object with `cvfits`:
     refmod_crr <- do.call(get_refmodel, c(


### PR DESCRIPTION
This simplifies the required structure for the object passed to argument `cvfits` of `init_refmodel()` (see the `NEWS.md` entry added here for details). The reason for this change is that `loo::kfold()` output can't be used straightforwardly anyway:
```r
data("df_gaussian", package = "projpred")
dat <- data.frame(y = df_gaussian$y, df_gaussian$x)
n_strat <- 4L
dat$strat_fac <- gl(n = n_strat, k = floor(nrow(dat) / n_strat),
                    length = nrow(dat), labels = paste0("gr", seq_len(n_strat)))
library(rstanarm)
refm_fit <- stan_glm(y ~ X1 + X2 + X3 + X4 + X5,
                     data = dat,
                     chains = 1,
                     iter = 500,
                     seed = 1140350788,
                     refresh = 0)
set.seed(3424511)
refm_kfold <- kfold(
  refm_fit,
  folds = loo::kfold_split_stratified(K = 10, x = dat$strat_fac),
  save_fits = TRUE,
  cores = 1
)
cvfits_crr <- structure(
  list(fits = refm_kfold$fits[, "fit"]),
  folds = sapply(seq_len(nrow(dat)), function(ii) {
    which(sapply(refm_kfold$fits[, "omitted"], "%in%", x = ii))
  })
)
length(refm_kfold$fits)
## --> 20
length(cvfits_crr$fits)
## --> 10
lapply(refm_kfold$fits, class)
## --> First 10 are `stanreg`s, last 10 are `integer` vectors.
```
so having the K reference model refits in a sub-`list` called `fits` is not necessary and only complicates things.