### PR TITLE
Don't require `cvfits[[k]]` to be a `list`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,7 +38,8 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Reduced peak memory usage during performance evaluation (more precisely, during the re-projections done for the performance evaluation). This reduction is considerable especially for multilevel submodels, but possibly also for additive submodels. (GitHub: #440, #450)
 * A message is thrown now when cutting off the search at `nterms_max`'s internal default of (currently) `19`. (GitHub: #452)
 * Added sub-section "Speed" to the main vignette's ["Troubleshooting"](https://mc-stan.org/projpred/articles/projpred.html#troubleshooting) section. (GitHub: #455)
-* The `list` passed to argument `cvfits` of `init_refmodel()` should not have a sub-`list` called `fits` anymore. Instead, the content of this former sub-`list` called `fits` should be moved one level up, i.e., should be placed directly in the `list` passed to `cvfits` (the empty element `fits` should then be removed). For some time, the old structure will continue to work, but this possibility is deprecated and will be removed in the future. (GitHub: #456)
+* In case of K-fold CV, the `list` passed to argument `cvfits` of `init_refmodel()` should not have a sub-`list` called `fits` anymore. Instead, the content of this former sub-`list` called `fits` should be moved one level up, i.e., should be placed directly in the `list` passed to `cvfits` (the empty element `fits` should then be removed). For some time, the old structure will continue to work, but this possibility is deprecated and will be removed in the future. (GitHub: #456)
+* In case of K-fold CV, the `K` reference model fits (i.e., the elements of the return value of the function passed to argument `cvfun` of `init_refmodel()` or the elements of the `list` supplied to argument `cvfits` of `init_refmodel()`) do not need to be `list`s anymore (see the documentation for argument `cvrefbuilder` of `init_refmodel()`). (GitHub: #457)
 
 ## Bug fixes
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -1249,12 +1249,18 @@ get_kfold <- function(refmodel, K, verbose) {
   }
   return(lapply(seq_len(K), function(k) {
     cvfit <- cvfits[[k]]
-    # Add the omitted observation indices for this fold:
-    cvfit$omitted <- which(folds == k)
-    # Add the fold index:
-    cvfit$projpred_k <- k
+    # Add the omitted observation indices for this fold (and the fold index `k`
+    # itself):
+    omitted_idxs <- which(folds == k)
+    if (is.list(cvfit)) {
+      cvfit$omitted <- omitted_idxs
+      cvfit$projpred_k <- k
+    } else {
+      attr(cvfit, "omitted") <- omitted_idxs
+      attr(cvfit, "projpred_k") <- k
+    }
     return(list(refmodel = refmodel$cvrefbuilder(cvfit),
-                omitted = cvfit$omitted))
+                omitted = omitted_idxs))
   }))
 }
 

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -96,17 +96,18 @@
 #'   (for \eqn{K}-fold CV). Note that `cvfits` takes precedence over `cvfun`,
 #'   i.e., if both are provided, `cvfits` is used.
 #' @param cvrefbuilder For \eqn{K}-fold CV only. A function that, given a
-#'   reference model fit for fold \eqn{k \in \{1, ..., K\}}{k = 1, ..., K} (this
-#'   model fit is the \eqn{k}-th element of the return value of `cvfun` or the
-#'   \eqn{k}-th element of the `list` supplied to `cvfits`, extended by elements
-#'   `omitted` (containing the indices of the left-out observations in that
-#'   fold) and `projpred_k` (containing the integer \eqn{k}) if that \eqn{k}-th
-#'   element is a `list` itself (otherwise, `omitted` and `projpred_k` are
-#'   appended as attributes)), returns an object of the same type as
-#'   [init_refmodel()] does. Argument `cvrefbuilder` may be `NULL` for using an
-#'   internal default: [get_refmodel()] if `object` is not `NULL` and a function
-#'   calling [init_refmodel()] appropriately (with the assumption `dis = 0`) if
-#'   `object` is `NULL`.
+#'   reference model fit for fold \eqn{k \in \{1, ..., K\}}{k = 1, ..., K},
+#'   returns an object of the same type as [init_refmodel()] does. The reference
+#'   model fit for fold \eqn{k} is the \eqn{k}-th element of the return value of
+#'   `cvfun` or the \eqn{k}-th element of the `list` supplied to `cvfits`,
+#'   extended by elements `omitted` (containing the indices of the left-out
+#'   observations in that fold) and `projpred_k` (containing the integer
+#'   \eqn{k}) if that \eqn{k}-th element is a `list` itself (otherwise,
+#'   `omitted` and `projpred_k` are appended as attributes). Argument
+#'   `cvrefbuilder` may be `NULL` for using an internal default:
+#'   [get_refmodel()] if `object` is not `NULL` and a function calling
+#'   [init_refmodel()] appropriately (with the assumption `dis = 0`) if `object`
+#'   is `NULL`.
 #' @param called_from_cvrefbuilder A single logical value indicating whether
 #'   [init_refmodel()] is called from a `cvrefbuilder` function (`TRUE`) or not
 #'   (`FALSE`). Currently, `TRUE` only causes some warnings to be suppressed

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -84,11 +84,10 @@
 #' @param cvfits For \eqn{K}-fold CV only. A `list` containing the \eqn{K}
 #'   reference model fits from which reference model objects are created. This
 #'   `list` needs to have an attribute called `folds`, consisting of an integer
-#'   vector giving the fold indices (one fold index per observation). Each
-#'   element of this `list` (i.e., each of the \eqn{K} reference model fits)
-#'   needs to be a `list` itself. Only one of `cvfits` and `cvfun` needs to be
-#'   provided (for \eqn{K}-fold CV). Note that `cvfits` takes precedence over
-#'   `cvfun`, i.e., if both are provided, `cvfits` is used.
+#'   vector giving the fold indices (one fold index per observation). Only one
+#'   of `cvfits` and `cvfun` needs to be provided (for \eqn{K}-fold CV). Note
+#'   that `cvfits` takes precedence over `cvfun`, i.e., if both are provided,
+#'   `cvfits` is used.
 #' @param cvfun For \eqn{K}-fold CV only. A function that, given a fold indices
 #'   vector, fits the reference model separately for each fold and returns the
 #'   \eqn{K} model fits as a `list`. Each of the \eqn{K} model fits needs to be
@@ -101,11 +100,13 @@
 #'   model fit is the \eqn{k}-th element of the return value of `cvfun` or the
 #'   \eqn{k}-th element of the `list` supplied to `cvfits`, extended by elements
 #'   `omitted` (containing the indices of the left-out observations in that
-#'   fold) and `projpred_k` (containing the integer \eqn{k})), returns an object
-#'   of the same type as [init_refmodel()] does. Argument `cvrefbuilder` may be
-#'   `NULL` for using an internal default: [get_refmodel()] if `object` is not
-#'   `NULL` and a function calling [init_refmodel()] appropriately (with the
-#'   assumption `dis = 0`) if `object` is `NULL`.
+#'   fold) and `projpred_k` (containing the integer \eqn{k}) if that \eqn{k}-th
+#'   element is a `list` itself (otherwise, `omitted` and `projpred_k` are
+#'   appended as attributes)), returns an object of the same type as
+#'   [init_refmodel()] does. Argument `cvrefbuilder` may be `NULL` for using an
+#'   internal default: [get_refmodel()] if `object` is not `NULL` and a function
+#'   calling [init_refmodel()] appropriately (with the assumption `dis = 0`) if
+#'   `object` is `NULL`.
 #' @param called_from_cvrefbuilder A single logical value indicating whether
 #'   [init_refmodel()] is called from a `cvrefbuilder` function (`TRUE`) or not
 #'   (`FALSE`). Currently, `TRUE` only causes some warnings to be suppressed

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1370,6 +1370,10 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   }
 
   if (is.null(cvrefbuilder)) {
+    warning("`cvrefbuilder` was `NULL`, so using an internal default. ",
+            "However, this internal default might not take all arguments of ",
+            "get_refmodel() and init_refmodel() appropriately into account, ",
+            "so a custom `cvrefbuilder` is recommended.")
     if (proper_model) {
       cvrefbuilder <- function(cvfit) {
         get_refmodel(cvfit, called_from_cvrefbuilder = TRUE)

--- a/man/refmodel-init-get.Rd
+++ b/man/refmodel-init-get.Rd
@@ -135,17 +135,18 @@ that \code{cvfits} takes precedence over \code{cvfun}, i.e., if both are provide
 \code{cvfits} is used.}
 
 \item{cvrefbuilder}{For \eqn{K}-fold CV only. A function that, given a
-reference model fit for fold \eqn{k \in \{1, ..., K\}}{k = 1, ..., K} (this
-model fit is the \eqn{k}-th element of the return value of \code{cvfun} or the
-\eqn{k}-th element of the \code{list} supplied to \code{cvfits}, extended by elements
-\code{omitted} (containing the indices of the left-out observations in that
-fold) and \code{projpred_k} (containing the integer \eqn{k}) if that \eqn{k}-th
-element is a \code{list} itself (otherwise, \code{omitted} and \code{projpred_k} are
-appended as attributes)), returns an object of the same type as
-\code{\link[=init_refmodel]{init_refmodel()}} does. Argument \code{cvrefbuilder} may be \code{NULL} for using an
-internal default: \code{\link[=get_refmodel]{get_refmodel()}} if \code{object} is not \code{NULL} and a function
-calling \code{\link[=init_refmodel]{init_refmodel()}} appropriately (with the assumption \code{dis = 0}) if
-\code{object} is \code{NULL}.}
+reference model fit for fold \eqn{k \in \{1, ..., K\}}{k = 1, ..., K},
+returns an object of the same type as \code{\link[=init_refmodel]{init_refmodel()}} does. The reference
+model fit for fold \eqn{k} is the \eqn{k}-th element of the return value of
+\code{cvfun} or the \eqn{k}-th element of the \code{list} supplied to \code{cvfits},
+extended by elements \code{omitted} (containing the indices of the left-out
+observations in that fold) and \code{projpred_k} (containing the integer
+\eqn{k}) if that \eqn{k}-th element is a \code{list} itself (otherwise,
+\code{omitted} and \code{projpred_k} are appended as attributes). Argument
+\code{cvrefbuilder} may be \code{NULL} for using an internal default:
+\code{\link[=get_refmodel]{get_refmodel()}} if \code{object} is not \code{NULL} and a function calling
+\code{\link[=init_refmodel]{init_refmodel()}} appropriately (with the assumption \code{dis = 0}) if \code{object}
+is \code{NULL}.}
 
 \item{called_from_cvrefbuilder}{A single logical value indicating whether
 \code{\link[=init_refmodel]{init_refmodel()}} is called from a \code{cvrefbuilder} function (\code{TRUE}) or not

--- a/man/refmodel-init-get.Rd
+++ b/man/refmodel-init-get.Rd
@@ -129,22 +129,23 @@ i.e., if both are provided, \code{cvfits} is used.}
 \item{cvfits}{For \eqn{K}-fold CV only. A \code{list} containing the \eqn{K}
 reference model fits from which reference model objects are created. This
 \code{list} needs to have an attribute called \code{folds}, consisting of an integer
-vector giving the fold indices (one fold index per observation). Each
-element of this \code{list} (i.e., each of the \eqn{K} reference model fits)
-needs to be a \code{list} itself. Only one of \code{cvfits} and \code{cvfun} needs to be
-provided (for \eqn{K}-fold CV). Note that \code{cvfits} takes precedence over
-\code{cvfun}, i.e., if both are provided, \code{cvfits} is used.}
+vector giving the fold indices (one fold index per observation). Only one
+of \code{cvfits} and \code{cvfun} needs to be provided (for \eqn{K}-fold CV). Note
+that \code{cvfits} takes precedence over \code{cvfun}, i.e., if both are provided,
+\code{cvfits} is used.}
 
 \item{cvrefbuilder}{For \eqn{K}-fold CV only. A function that, given a
 reference model fit for fold \eqn{k \in \{1, ..., K\}}{k = 1, ..., K} (this
 model fit is the \eqn{k}-th element of the return value of \code{cvfun} or the
 \eqn{k}-th element of the \code{list} supplied to \code{cvfits}, extended by elements
 \code{omitted} (containing the indices of the left-out observations in that
-fold) and \code{projpred_k} (containing the integer \eqn{k})), returns an object
-of the same type as \code{\link[=init_refmodel]{init_refmodel()}} does. Argument \code{cvrefbuilder} may be
-\code{NULL} for using an internal default: \code{\link[=get_refmodel]{get_refmodel()}} if \code{object} is not
-\code{NULL} and a function calling \code{\link[=init_refmodel]{init_refmodel()}} appropriately (with the
-assumption \code{dis = 0}) if \code{object} is \code{NULL}.}
+fold) and \code{projpred_k} (containing the integer \eqn{k}) if that \eqn{k}-th
+element is a \code{list} itself (otherwise, \code{omitted} and \code{projpred_k} are
+appended as attributes)), returns an object of the same type as
+\code{\link[=init_refmodel]{init_refmodel()}} does. Argument \code{cvrefbuilder} may be \code{NULL} for using an
+internal default: \code{\link[=get_refmodel]{get_refmodel()}} if \code{object} is not \code{NULL} and a function
+calling \code{\link[=init_refmodel]{init_refmodel()}} appropriately (with the assumption \code{dis = 0}) if
+\code{object} is \code{NULL}.}
 
 \item{called_from_cvrefbuilder}{A single logical value indicating whether
 \code{\link[=init_refmodel]{init_refmodel()}} is called from a \code{cvrefbuilder} function (\code{TRUE}) or not


### PR DESCRIPTION
If `cvfits[[k]]` is not a `list`, then with this PR, objects `omitted` and `projpred_k` are appended as attributes (`list` elements would not work in such a case). Luckily, `stanreg`s from rstanarm and `brmsfit`s from brms are both `list`s, but in general, this was a quite restrictive assumption.