### PR TITLE
Add `varsel.vsel()` and `cv_varsel.vsel()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 # projpred 2.7.0.9000
 
+## Major changes
+
+* Search results generated in an earlier `varsel()` or `cv_varsel()` call can now be re-used by the help of the new `varsel.vsel()` and `cv_varsel.vsel()` methods (i.e., by applying `varsel()` or `cv_varsel()` to the output of the earlier `varsel()` or `cv_varsel()` call). This can save a lot of time when re-running the predictive performance evaluation part multiple times based on the same search results. An illustration may be found in the updated main vignette (section ["Preliminary `cv_varsel()` run"](https://mc-stan.org/projpred/articles/projpred.html#preliminary-cv_varsel-run); a more general description may also be found in section ["Speed"](https://mc-stan.org/projpred/articles/projpred.html#speed)). (GitHub: #461)
 
 # projpred 2.7.0
 
@@ -42,7 +45,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Added the helper function `force_search_terms()` which allows to construct `search_terms` where certain predictor terms are forced to be included (i.e., they are forced to be selected first) whereas other predictor terms are optional (i.e., they are subject to the variable selection, but only after the inclusion of the "forced" terms). (GitHub: #346)
 * Reduced peak memory usage during performance evaluation (more precisely, during the re-projections done for the performance evaluation). This reduction is considerable especially for multilevel submodels, but possibly also for additive submodels. (GitHub: #440, #450)
 * A message is now thrown when cutting off the search at `nterms_max`'s internal default of (currently) `19`. (GitHub: #452)
-* Added sub-section "Speed" to the main vignette's ["Troubleshooting"](https://mc-stan.org/projpred/articles/projpred.html#troubleshooting) section. (GitHub: #455)
+* Added sub-section ["Speed"](https://mc-stan.org/projpred/articles/projpred.html#speed) to the main vignette's ["Troubleshooting"](https://mc-stan.org/projpred/articles/projpred.html#troubleshooting) section. (GitHub: #455)
 * In case of K-fold CV, the `list` passed to argument `cvfits` of `init_refmodel()` should not have a sub-`list` called `fits` anymore. Instead, the content of this former sub-`list` called `fits` should be moved one level up, i.e., should be placed directly in the `list` passed to `cvfits` (the empty element `fits` should then be removed). For some time, the old structure will continue to work, but this possibility is deprecated and will be removed in the future. (GitHub: #456)
 * In case of K-fold CV, the `K` reference model fits (i.e., the elements of the return value of the function passed to argument `cvfun` of `init_refmodel()` or the elements of the `list` supplied to argument `cvfits` of `init_refmodel()`) do not need to be `list`s anymore (see the documentation for argument `cvrefbuilder` of `init_refmodel()`). (GitHub: #457)
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -57,6 +57,11 @@
 #' @param parallel A single logical value indicating whether to run costly parts
 #'   of the CV in parallel (`TRUE`) or not (`FALSE`). See also section "Note"
 #'   below.
+#' @param ... For [cv_varsel.default()]: Arguments passed to [get_refmodel()] as
+#'   well as to [cv_varsel.refmodel()]. For [cv_varsel.vsel()]: Arguments passed
+#'   to [cv_varsel.refmodel()]. For [cv_varsel.refmodel()]: Arguments passed to
+#'   the divergence minimizer (during a forward search and also during the
+#'   evaluation part, but the latter only if `refit_prj` is `TRUE`).
 #'
 #' @inherit varsel details return
 #'

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -10,7 +10,9 @@
 #' [varsel()], [cv_varsel()] performs a cross-validation (CV) by running the
 #' search part with the training data of each CV fold separately (an exception
 #' is explained in section "Note" below) and by running the evaluation part on
-#' the corresponding test set of each CV fold.
+#' the corresponding test set of each CV fold. A special method is
+#' [cv_varsel.vsel()] because it re-uses the search results from an earlier
+#' [cv_varsel()] (or [varsel()]) run, as illustrated in the main vignette.
 #'
 #' @inheritParams varsel
 #' @param cv_method The CV method, either `"LOO"` or `"kfold"`. In the `"LOO"`
@@ -145,9 +147,33 @@ cv_varsel.default <- function(object, ...) {
 #' @rdname cv_varsel
 #' @export
 cv_varsel.vsel <- function(object, ...) {
-  stop("Purpose and content of cv_varsel.vsel() will be changed in a future ",
-       "release. Please use cv_varsel(get_refmodel(<vsel_object>), <...>) ",
-       "instead of cv_varsel(<vsel_object>, <...>).")
+  args <- list(
+    object = get_refmodel(object),
+    method = object[["args_search"]][["method"]],
+    ndraws = object[["args_search"]][["ndraws"]],
+    nclusters = object[["args_search"]][["nclusters"]],
+    nterms_max = object[["args_search"]][["nterms_max"]],
+    lambda_min_ratio = object[["args_search"]][["lambda_min_ratio"]],
+    nlambda = object[["args_search"]][["nlambda"]],
+    thresh = object[["args_search"]][["thresh"]],
+    penalty = object[["args_search"]][["penalty"]],
+    search_terms = if (object[["args_search"]][["search_terms_was_null"]]) {
+      NULL
+    } else {
+      object[["args_search"]][["search_terms"]]
+    },
+    cv_method = object[["cv_method"]] %||% "LOO",
+    nloo = object[["nloo"]],
+    K = object[["K"]],
+    validate_search = isTRUE(object[["validate_search"]]),
+    search_out = list(search_path = object[["search_path"]],
+                      ranking = ranking(object)),
+    ...
+  )
+  if (!is.null(object[["cvfits"]]) && !is.na(object[["cvfits"]])) {
+    args <- c(args, list(cvfits = object[["cvfits"]]))
+  }
+  return(do.call(cv_varsel, args))
 }
 
 #' @rdname cv_varsel
@@ -174,6 +200,7 @@ cv_varsel.refmodel <- function(
     validate_search = TRUE,
     seed = NA,
     search_terms = NULL,
+    search_out = NULL,
     parallel = getOption("projpred.prll_cv", FALSE),
     ...
 ) {
@@ -195,6 +222,28 @@ cv_varsel.refmodel <- function(
 
   refmodel <- object
   nterms_all <- count_terms_in_formula(refmodel$formula) - 1L
+
+  # Restrictions in case of old search results which should be re-used:
+  if (!is.null(search_out)) {
+    if (cv_method %in% c("loo", "LOO") && !is.null(nloo) &&
+        nloo != refmodel[["nobs"]]) {
+      stop("Currently, `nloo == n` is needed to re-use old search results.")
+    }
+    if (validate_search) {
+      # We will need the fold-wise predictor rankings later:
+      if (is.null(search_out[["ranking"]][["foldwise"]])) {
+        stop("For `validate_search = TRUE`, old search results can only be ",
+             "re-used if the old search was performed in a fold-wise manner.")
+      }
+      # For `refit_prj = FALSE`, we would need the fold-wise submodel fits
+      # (along the fold-wise predictor rankings), which are currently not
+      # available:
+      if (!refit_prj) {
+        stop("Currently, for `validate_search = TRUE`, old search results can ",
+             "only be re-used if `refit_prj` is `TRUE`.")
+      }
+    }
+  }
   # Parse arguments which also exist in varsel():
   args <- parse_args_varsel(
     refmodel = refmodel, method = method, refit_prj = refit_prj,
@@ -208,6 +257,7 @@ cv_varsel.refmodel <- function(
   search_terms <- args$search_terms
   search_terms_was_null <- args$search_terms_was_null
   # Parse arguments specific to cv_varsel():
+  cvfits_cust <- !missing(cvfits)
   args <- parse_args_cv_varsel(
     refmodel = refmodel, cv_method = cv_method, K = K, cvfits = cvfits,
     validate_search = validate_search
@@ -223,15 +273,19 @@ cv_varsel.refmodel <- function(
     # consistent PRNG states between the full-data search in the
     # `validate_search = FALSE` case and the full-data search in the
     # `validate_search = TRUE` case we are in here):
-    verb_out("-----\nRunning the search using the full dataset ...",
-             verbose = verbose)
-    search_path_full_data <- select(
-      refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
-      method = method, nterms_max = nterms_max, penalty = penalty,
-      verbose = verbose, opt = opt, search_terms = search_terms,
-      search_terms_was_null = search_terms_was_null, ...
-    )
-    verb_out("-----", verbose = verbose)
+    if (!is.null(search_out)) {
+      search_path_full_data <- search_out[["search_path"]]
+    } else {
+      verb_out("-----\nRunning the search using the full dataset ...",
+               verbose = verbose)
+      search_path_full_data <- select(
+        refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
+        method = method, nterms_max = nterms_max, penalty = penalty,
+        verbose = verbose, opt = opt, search_terms = search_terms,
+        search_terms_was_null = search_terms_was_null, ...
+      )
+      verb_out("-----", verbose = verbose)
+    }
     ce_out <- rep(NA_real_, length(search_path_full_data$solution_terms) + 1L)
   }
 
@@ -242,7 +296,8 @@ cv_varsel.refmodel <- function(
       nclusters_pred = nclusters_pred, refit_prj = refit_prj, penalty = penalty,
       verbose = verbose, opt = opt, nloo = nloo,
       validate_search = validate_search, search_terms = search_terms,
-      search_terms_was_null = search_terms_was_null, parallel = parallel, ...
+      search_terms_was_null = search_terms_was_null, search_out = search_out,
+      parallel = parallel, ...
     )
   } else if (cv_method == "kfold") {
     sel_cv <- kfold_varsel(
@@ -250,7 +305,9 @@ cv_varsel.refmodel <- function(
       ndraws = ndraws, nclusters = nclusters, ndraws_pred = ndraws_pred,
       nclusters_pred = nclusters_pred, refit_prj = refit_prj, penalty = penalty,
       verbose = verbose, opt = opt, K = K, cvfits = cvfits,
-      search_terms = search_terms, parallel = parallel, ...
+      search_terms = search_terms,
+      search_out_rk = search_out[["ranking"]][["foldwise"]],
+      parallel = parallel, ...
     )
   }
 
@@ -292,8 +349,14 @@ cv_varsel.refmodel <- function(
               nterms_max,
               method,
               cv_method,
-              K = K,
+              nloo,
+              K,
               validate_search,
+              cvfits = if (cvfits_cust) cvfits else NA,
+              args_search = nlist(
+                method, ndraws, nclusters, nterms_max, lambda_min_ratio,
+                nlambda, thresh, penalty, search_terms, search_terms_was_null
+              ),
               clust_used_search = refdist_info_search$clust_used,
               clust_used_eval = refdist_info_eval$clust_used,
               nprjdraws_search = refdist_info_search$nprjdraws,
@@ -374,7 +437,8 @@ parse_args_cv_varsel <- function(refmodel, cv_method, K, cvfits,
 loo_varsel <- function(refmodel, method, nterms_max, ndraws,
                        nclusters, ndraws_pred, nclusters_pred, refit_prj,
                        penalty, verbose, opt, nloo, validate_search,
-                       search_terms, search_terms_was_null, parallel, ...) {
+                       search_terms, search_terms_was_null, search_out,
+                       parallel, ...) {
   ## Pre-processing ---------------------------------------------------------
 
   has_grp <- formula_contains_group_terms(refmodel$formula)
@@ -546,15 +610,19 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   if (!validate_search) {
     ## Case `validate_search = FALSE` -----------------------------------------
 
-    verb_out("-----\nRunning the search using the full dataset ...",
-             verbose = verbose)
-    search_path <- select(
-      refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
-      method = method, nterms_max = nterms_max, penalty = penalty,
-      verbose = verbose, opt = opt, search_terms = search_terms,
-      search_terms_was_null = search_terms_was_null, ...
-    )
-    verb_out("-----", verbose = verbose)
+    if (!is.null(search_out)) {
+      search_path <- search_out[["search_path"]]
+    } else {
+      verb_out("-----\nRunning the search using the full dataset ...",
+               verbose = verbose)
+      search_path <- select(
+        refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
+        method = method, nterms_max = nterms_max, penalty = penalty,
+        verbose = verbose, opt = opt, search_terms = search_terms,
+        search_terms_was_null = search_terms_was_null, ...
+      )
+      verb_out("-----", verbose = verbose)
+    }
 
     verb_out("-----\nPerformance evaluation, step 1: Re-projecting (using the ",
              "full dataset) onto the submodels along the full-data solution ",
@@ -770,15 +838,27 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   } else {
     ## Case `validate_search = TRUE` ------------------------------------------
 
-    cl_sel <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)$cl
+    search_out_rk <- search_out[["ranking"]][["foldwise"]]
+    rm(search_out)
+
+    if (is.null(search_out_rk)) {
+      cl_sel <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)$cl
+    }
     if (refit_prj) {
       cl_pred <- get_refdist(refmodel, ndraws = ndraws_pred,
                              nclusters = nclusters_pred)$cl
     }
 
-    verb_out("-----\nRunning the search and the performance evaluation for ",
-             "each of the N = ", nloo, " LOO CV folds separately ...",
-             verbose = verbose)
+    if (verbose) {
+      verb_txt_start <- "-----\nRunning "
+      if (!is.null(search_out_rk)) {
+        verb_txt_mid <- ""
+      } else {
+        verb_txt_mid <- "the search and "
+      }
+      verb_out(verb_txt_start, verb_txt_mid, "the performance evaluation for ",
+               "each of the N = ", nloo, " LOO CV folds separately ...")
+    }
     one_obs <- function(run_index,
                         verbose_search = verbose &&
                           getOption("projpred.extra_verbose", FALSE),
@@ -790,13 +870,17 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       # *reweighted* fitted response values from the reference model act as
       # artifical response values in the projection (or L1-penalized
       # projection)):
-      search_path <- select(
-        refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
-        reweighting_args = list(cl_ref = cl_sel, wdraws_ref = exp(lw[, i])),
-        method = method, nterms_max = nterms_max, penalty = penalty,
-        verbose = verbose_search, opt = opt, search_terms = search_terms,
-        est_runtime = FALSE, ...
-      )
+      if (!is.null(search_out_rk)) {
+        search_path <- list(solution_terms = search_out_rk[run_index, ])
+      } else {
+        search_path <- select(
+          refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
+          reweighting_args = list(cl_ref = cl_sel, wdraws_ref = exp(lw[, i])),
+          method = method, nterms_max = nterms_max, penalty = penalty,
+          verbose = verbose_search, opt = opt, search_terms = search_terms,
+          est_runtime = FALSE, ...
+        )
+      }
 
       # Run the performance evaluation for the submodels along the predictor
       # ranking:
@@ -1059,16 +1143,27 @@ warn_pareto <- function(n07, n05, warn_txt_start, warn_txt_mid_common,
 # Needed to avoid a NOTE in `R CMD check`:
 if (getRversion() >= package_version("2.15.1")) {
   utils::globalVariables("list_cv_k")
+  utils::globalVariables("search_out_rk_k")
 }
 
 kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
                          ndraws_pred, nclusters_pred, refit_prj, penalty,
-                         verbose, opt, K, cvfits, search_terms, parallel, ...) {
+                         verbose, opt, K, cvfits, search_terms, search_out_rk,
+                         parallel, ...) {
   # Fetch the K reference model fits (or fit them now if not already done) and
   # create objects of class `refmodel` from them (and also store the `omitted`
   # indices):
   list_cv <- get_kfold(refmodel, K = K, cvfits = cvfits, verbose = verbose)
   K <- length(list_cv)
+
+  if (!is.null(search_out_rk)) {
+    stopifnot(nrow(search_out_rk) == K)
+    search_out_rk <- lapply(seq_len(K), function(row_idx) {
+      search_out_rk[row_idx, ]
+    })
+  } else {
+    search_out_rk <- replicate(K, NULL, simplify = FALSE)
+  }
 
   if (refmodel$family$for_latent) {
     # Need to set the latent response values in `refmodel$y` to `NA`s because
@@ -1080,19 +1175,32 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
   }
   y_wobs_test <- as.data.frame(refmodel[nms_y_wobs_test()])
 
-  verb_out("-----\nRunning the search and the performance evaluation for ",
-           "each of the K = ", K, " CV folds separately ...", verbose = verbose)
+  if (verbose) {
+    verb_txt_start <- "-----\nRunning "
+    if (!all(sapply(search_out_rk, is.null))) {
+      verb_txt_mid <- ""
+    } else {
+      verb_txt_mid <- "the search and "
+    }
+    verb_out(verb_txt_start, verb_txt_mid, "the performance evaluation for ",
+             "each of the K = ", K, " CV folds separately ...")
+  }
   one_fold <- function(fold,
+                       rk,
                        verbose_search = verbose &&
                          getOption("projpred.extra_verbose", FALSE),
                        ...) {
     # Run the search for the current fold:
-    search_path <- select(
-      refmodel = fold$refmodel, ndraws = ndraws, nclusters = nclusters,
-      method = method, nterms_max = nterms_max, penalty = penalty,
-      verbose = verbose_search, opt = opt, search_terms = search_terms,
-      est_runtime = FALSE, ...
-    )
+    if (!is.null(rk)) {
+      search_path <- list(solution_terms = rk)
+    } else {
+      search_path <- select(
+        refmodel = fold$refmodel, ndraws = ndraws, nclusters = nclusters,
+        method = method, nterms_max = nterms_max, penalty = penalty,
+        verbose = verbose_search, opt = opt, search_terms = search_terms,
+        est_runtime = FALSE, ...
+      )
+    }
 
     # Run the performance evaluation for the submodels along the predictor
     # ranking:
@@ -1135,7 +1243,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
       if (verbose) {
         on.exit(utils::setTxtProgressBar(pb, k))
       }
-      one_fold(list_cv[[k]], ...)
+      one_fold(fold = list_cv[[k]], rk = search_out_rk[[k]], ...)
     })
     if (verbose) {
       close(pb)
@@ -1152,10 +1260,12 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
     `%do_projpred%` <- doRNG::`%dorng%`
     res_cv <- foreach::foreach(
       list_cv_k = list_cv,
+      search_out_rk_k = search_out_rk,
       .export = c("one_fold", "dot_args"),
-      .noexport = c("list_cv")
+      .noexport = c("list_cv", "search_out_rk")
     ) %do_projpred% {
-      do.call(one_fold, c(list(fold = list_cv_k, verbose_search = FALSE),
+      do.call(one_fold, c(list(fold = list_cv_k, rk = search_out_rk_k,
+                               verbose_search = FALSE),
                           dot_args))
     }
   }

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -846,6 +846,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       }
     }
     verb_out("-----", verbose = verbose)
+    # Needed for cutting off post-processed results later:
+    prv_len_soltrms <- length(search_path$solution_terms)
   } else {
     ## Case `validate_search = TRUE` ------------------------------------------
 
@@ -948,8 +950,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     }
     # For storing the fold-wise solution paths:
     solution_terms_mat <- matrix(nrow = n, ncol = nterms_max)
-    # For checking that the length of the predictor ranking is the same across
-    # all CV folds (and also for cutting off `solution_terms_mat` later):
+    # Needed for checking that the length of the predictor ranking is the same
+    # across all CV folds and for cutting off post-processed results later:
     prv_len_soltrms <- NULL
     # For checking that `clust_used_eval` is the same across all CV folds (and
     # also for storing it):
@@ -1005,7 +1007,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   ## Post-processing --------------------------------------------------------
 
   # Submodel predictive performance:
-  summ_sub <- lapply(seq_len(nterms_max + 1L), function(k) {
+  summ_sub <- lapply(seq_len(prv_len_soltrms + 1L), function(k) {
     summ_k <- list(lppd = loo_sub[[k]], mu = mu_sub[[k]], wcv = validset$wcv)
     if (refmodel$family$for_latent) {
       summ_k$oscale <- list(lppd = loo_sub_oscale[[k]], mu = mu_sub_oscale[[k]],

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -610,11 +610,11 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   if (!validate_search) {
     ## Case `validate_search = FALSE` -----------------------------------------
 
+    # Run the search:
     if (!is.null(search_out)) {
       search_path <- search_out[["search_path"]]
     } else {
-      verb_out("-----\nRunning the search using the full dataset ...",
-               verbose = verbose)
+      verb_out("-----\nRunning the search ...", verbose = verbose)
       search_path <- select(
         refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
         method = method, nterms_max = nterms_max, penalty = penalty,
@@ -624,10 +624,12 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       verb_out("-----", verbose = verbose)
     }
 
-    verb_out("-----\nPerformance evaluation, step 1: Re-projecting (using the ",
-             "full dataset) onto the submodels along the full-data solution ",
-             "path and evaluating their predictive performance ...",
-             verbose = verbose && refit_prj)
+    # "Run" the performance evaluation for the submodels along the predictor
+    # ranking (in fact, we only prepare the performance evaluation by computing
+    # precursor quantities, but for users, this difference is not perceivable):
+    verb_out("-----\nRunning the performance evaluation ...", verbose = verbose)
+    # Step 1: Re-project (using the full dataset) onto the submodels along the
+    # full-data predictor ranking and evaluate their predictive performance.
     perf_eval_out <- perf_eval(
       search_path = search_path, refmodel = refmodel, regul = opt$regul,
       refit_prj = refit_prj, ndraws = ndraws_pred, nclusters = nclusters_pred,
@@ -636,11 +638,9 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     clust_used_eval <- perf_eval_out[["clust_used"]]
     nprjdraws_eval <- perf_eval_out[["nprjdraws"]]
     refdist_eval <- perf_eval_out[["p_ref"]]
-    verb_out("-----", verbose = verbose && refit_prj)
 
-    verb_out("-----\nPerformance evaluation, step 2: Weighting the full-data ",
-             "performance evaluation results according to the PSIS-LOO CV ",
-             "weights ...", verbose = verbose)
+    # Step 2: Weight the full-data performance evaluation results according to
+    # the PSIS-LOO CV weights.
     if (refmodel$family$for_latent) {
       refdist_eval_mu_offs_oscale <- refmodel$family$latent_ilink(
         t(refdist_eval$mu_offs), cl_ref = refdist_eval$cl,

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -333,8 +333,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = "forward",
   # "Run" the performance evaluation for the submodels along the predictor
   # ranking (in fact, we only prepare the performance evaluation by computing
   # precursor quantities, but for users, this difference is not perceivable):
-  verb_out("-----\nRunning the performance evaluation ...",
-           verbose = verbose && refit_prj)
+  verb_out("-----\nRunning the performance evaluation ...", verbose = verbose)
   perf_eval_out <- perf_eval(
     search_path = search_path, refmodel = refmodel, regul = regul,
     refit_prj = refit_prj, ndraws = ndraws_pred, nclusters = nclusters_pred,
@@ -342,7 +341,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = "forward",
     offset_test = d_test$offset, wobs_test = d_test$weights, y_test = d_test$y,
     y_oscale_test = d_test$y_oscale, ...
   )
-  verb_out("-----", verbose = verbose && refit_prj)
+  verb_out("-----", verbose = verbose)
 
   # Predictive performance of the reference model:
   if (inherits(refmodel, "datafit")) {

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -81,9 +81,11 @@
 #'   model's posterior draws (if `!is.null(nclusters)` or
 #'   `!is.null(nclusters_pred)`) and for drawing new group-level effects when
 #'   predicting from a multilevel submodel (however, not yet in case of a GAMM).
-#' @param ... Arguments passed to [get_refmodel()] as well as to the divergence
-#'   minimizer (during a forward search and also during the evaluation part, but
-#'   the latter only if `refit_prj` is `TRUE`).
+#' @param ... For [varsel.default()]: Arguments passed to [get_refmodel()] as
+#'   well as to [varsel.refmodel()]. For [varsel.vsel()]: Arguments passed to
+#'   [varsel.refmodel()]. For [varsel.refmodel()]: Arguments passed to the
+#'   divergence minimizer (during a forward search and also during the
+#'   evaluation part, but the latter only if `refit_prj` is `TRUE`).
 #'
 #' @details
 #'

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -202,7 +202,7 @@ varsel.default <- function(object, ...) {
 #' @rdname varsel
 #' @export
 varsel.vsel <- function(object, ...) {
-  return(do.call(varsel, list(
+  return(varsel(
     object = get_refmodel(object),
     method = object[["args_search"]][["method"]],
     ndraws = object[["args_search"]][["ndraws"]],
@@ -212,15 +212,11 @@ varsel.vsel <- function(object, ...) {
     nlambda = object[["args_search"]][["nlambda"]],
     thresh = object[["args_search"]][["thresh"]],
     penalty = object[["args_search"]][["penalty"]],
-    search_terms = if (object[["args_search"]][["search_terms_was_null"]]) {
-      NULL
-    } else {
-      object[["args_search"]][["search_terms"]]
-    },
+    search_terms = object[["args_search"]][["search_terms"]],
     search_out = list(search_path = object[["search_path"]],
                       ranking = ranking(object)),
     ...
-  )))
+  ))
 }
 
 #' @rdname varsel
@@ -418,7 +414,8 @@ varsel.refmodel <- function(object, d_test = NULL, method = "forward",
               cvfits = NULL,
               args_search = nlist(
                 method, ndraws, nclusters, nterms_max, lambda_min_ratio,
-                nlambda, thresh, penalty, search_terms, search_terms_was_null
+                nlambda, thresh, penalty,
+                search_terms = if (search_terms_was_null) NULL else search_terms
               ),
               clust_used_search = search_path$p_sel$clust_used,
               clust_used_eval = perf_eval_out[["clust_used"]],

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -35,6 +35,7 @@ cv_varsel(object, ...)
   validate_search = TRUE,
   seed = NA,
   search_terms = NULL,
+  search_out = NULL,
   parallel = getOption("projpred.prll_cv", FALSE),
   ...
 )
@@ -163,6 +164,8 @@ there's no difference between including it explicitly or omitting it. The
 default \code{search_terms} considers all the terms in the reference model's
 formula.}
 
+\item{search_out}{Intended for internal use.}
+
 \item{parallel}{A single logical value indicating whether to run costly parts
 of the CV in parallel (\code{TRUE}) or not (\code{FALSE}). See also section "Note"
 below.}
@@ -181,7 +184,9 @@ performance of the submodels along the predictor ranking. In contrast to
 \code{\link[=varsel]{varsel()}}, \code{\link[=cv_varsel]{cv_varsel()}} performs a cross-validation (CV) by running the
 search part with the training data of each CV fold separately (an exception
 is explained in section "Note" below) and by running the evaluation part on
-the corresponding test set of each CV fold.
+the corresponding test set of each CV fold. A special method is
+\code{\link[=cv_varsel.vsel]{cv_varsel.vsel()}} because it re-uses the search results from an earlier
+\code{\link[=cv_varsel]{cv_varsel()}} (or \code{\link[=varsel]{varsel()}}) run, as illustrated in the main vignette.
 }
 \details{
 Arguments \code{ndraws}, \code{nclusters}, \code{nclusters_pred}, and \code{ndraws_pred}

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -45,9 +45,11 @@ cv_varsel(object, ...)
 \code{\link[=init_refmodel]{init_refmodel()}}) or an object that can be passed to argument \code{object} of
 \code{\link[=get_refmodel]{get_refmodel()}}.}
 
-\item{...}{Arguments passed to \code{\link[=get_refmodel]{get_refmodel()}} as well as to the divergence
-minimizer (during a forward search and also during the evaluation part, but
-the latter only if \code{refit_prj} is \code{TRUE}).}
+\item{...}{For \code{\link[=cv_varsel.default]{cv_varsel.default()}}: Arguments passed to \code{\link[=get_refmodel]{get_refmodel()}} as
+well as to \code{\link[=cv_varsel.refmodel]{cv_varsel.refmodel()}}. For \code{\link[=cv_varsel.vsel]{cv_varsel.vsel()}}: Arguments passed
+to \code{\link[=cv_varsel.refmodel]{cv_varsel.refmodel()}}. For \code{\link[=cv_varsel.refmodel]{cv_varsel.refmodel()}}: Arguments passed to
+the divergence minimizer (during a forward search and also during the
+evaluation part, but the latter only if \code{refit_prj} is \code{TRUE}).}
 
 \item{method}{The method for the search part. Possible options are
 \code{"forward"} for forward search and \code{"L1"} for L1 search. See also section

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -30,6 +30,7 @@ varsel(object, ...)
   regul = 1e-04,
   penalty = NULL,
   search_terms = NULL,
+  search_out = NULL,
   seed = NA,
   ...
 )
@@ -119,6 +120,8 @@ there's no difference between including it explicitly or omitting it. The
 default \code{search_terms} considers all the terms in the reference model's
 formula.}
 
+\item{search_out}{Intended for internal use.}
+
 \item{seed}{Pseudorandom number generation (PRNG) seed by which the same
 results can be obtained again if needed. Passed to argument \code{seed} of
 \code{\link[=set.seed]{set.seed()}}, but can also be \code{NA} to not call \code{\link[=set.seed]{set.seed()}} at all. If not
@@ -138,7 +141,9 @@ Run the \emph{search} part and the \emph{evaluation} part for a projection predi
 variable selection. The search part determines the predictor ranking (also
 known as solution path), i.e., the best submodel for each submodel size
 (number of predictor terms). The evaluation part determines the predictive
-performance of the submodels along the predictor ranking.
+performance of the submodels along the predictor ranking. A special method is
+\code{\link[=varsel.vsel]{varsel.vsel()}} because it re-uses the search results from an earlier
+\code{\link[=varsel]{varsel()}} (or \code{\link[=cv_varsel]{cv_varsel()}}) run, as illustrated in the main vignette.
 }
 \details{
 Arguments \code{ndraws}, \code{nclusters}, \code{nclusters_pred}, and \code{ndraws_pred}

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -40,9 +40,11 @@ varsel(object, ...)
 \code{\link[=init_refmodel]{init_refmodel()}}) or an object that can be passed to argument \code{object} of
 \code{\link[=get_refmodel]{get_refmodel()}}.}
 
-\item{...}{Arguments passed to \code{\link[=get_refmodel]{get_refmodel()}} as well as to the divergence
-minimizer (during a forward search and also during the evaluation part, but
-the latter only if \code{refit_prj} is \code{TRUE}).}
+\item{...}{For \code{\link[=varsel.default]{varsel.default()}}: Arguments passed to \code{\link[=get_refmodel]{get_refmodel()}} as
+well as to \code{\link[=varsel.refmodel]{varsel.refmodel()}}. For \code{\link[=varsel.vsel]{varsel.vsel()}}: Arguments passed to
+\code{\link[=varsel.refmodel]{varsel.refmodel()}}. For \code{\link[=varsel.refmodel]{varsel.refmodel()}}: Arguments passed to the
+divergence minimizer (during a forward search and also during the
+evaluation part, but the latter only if \code{refit_prj} is \code{TRUE}).}
 
 \item{d_test}{A \code{list} of the structure outlined in section "Argument
 \code{d_test}" below, providing test data for evaluating the predictive

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -2366,12 +2366,12 @@ vsel_tester <- function(
   expect_identical(vs$validate_search, valsearch_expected, info = info_str)
 
   # cvfits
-  if (is.null(cv_method_expected)) {
+  if (!identical(cv_method_expected, "kfold")) {
     expect_null(vs$cvfits, info = info_str)
   } else {
     ### Currently, we are testing argument `cvfits` only implicitly via the
     ### examples and via the main vignette:
-    expect_identical(vs$cvfits, NA, info = info_str)
+    expect_identical(vs$cvfits, "auto", info = info_str)
     ###
   }
 
@@ -2392,12 +2392,10 @@ vsel_tester <- function(
       lambda_min_ratio = 1e-5, nlambda = 150, thresh = 1e-6,
       penalty = penalty_expected,
       search_terms = if (is.null(search_terms_expected)) {
-        union("1", split_formula(vs$refmodel$formula,
-                                 data = vs$refmodel$fetch_data()))
+        NULL
       } else {
         union("1", search_terms_expected)
-      },
-      search_terms_was_null = is.null(search_terms_expected)
+      }
     ),
     info = info_str
   )

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -1969,6 +1969,8 @@ vsel_tester <- function(
     },
     seed_expected = seed_tst,
     nloo_expected = NULL,
+    penalty_expected = NULL,
+    search_terms_expected = NULL,
     search_trms_empty_size = FALSE,
     extra_tol = 1.1,
     info_str = ""
@@ -1998,6 +2000,7 @@ vsel_tester <- function(
     # size (see issue #307):
     solterms_len_expected <- solterms_len_expected - 1L
   }
+  nloo_expected_orig <- nloo_expected
 
   # Test the general structure of the object:
   expect_s3_class(vs, "vsel")
@@ -2116,6 +2119,50 @@ vsel_tester <- function(
                  aug_expected = vs$refmodel$family$for_augdat,
                  fam_expected = vs$refmodel$family$family,
                  info_str = info_str)
+
+  # solution_terms
+  expect_type(vs$solution_terms, "character")
+  expect_length(vs$solution_terms, solterms_len_expected)
+  soltrms <- vs$solution_terms
+  for (soltrms_plus in grep("\\+", soltrms, value = TRUE)) {
+    soltrms <- setdiff(soltrms, soltrms_plus)
+    soltrms <- c(soltrms, labels(terms(as.formula(paste(". ~", soltrms_plus)))))
+  }
+  expect_true(all(soltrms %in% trms_universe_split), info = info_str)
+
+  # solution_terms_cv
+  if (with_cv && isTRUE(vs$validate_search)) {
+    expect_true(is.matrix(vs$solution_terms_cv), info = info_str)
+    expect_type(vs$solution_terms_cv, "character")
+    if (identical(cv_method_expected, "kfold")) {
+      n_folds <- K_tst
+    } else {
+      n_folds <- nobsv
+    }
+    expect_identical(dim(vs$solution_terms_cv),
+                     c(n_folds, solterms_len_expected),
+                     info = info_str)
+    # We need the addition of `NA_character_` because of subsampled PSIS-LOO CV:
+    expect_true(
+      all(vs$solution_terms_cv %in% c(trms_universe_split, NA_character_)),
+      info = info_str
+    )
+  } else {
+    expect_null(vs$solution_terms_cv, info = info_str)
+  }
+
+  # ce
+  if (with_cv && (valsearch_expected || cv_method_expected == "kfold")) {
+    expect_identical(vs$ce, rep(NA_real_, solterms_len_expected + 1))
+  } else {
+    expect_type(vs$ce, "double")
+    expect_length(vs$ce, solterms_len_expected + 1)
+    # Expected to be non-increasing for increasing model size:
+    expect_true(all(ifelse(sign(head(vs$ce, -1)) == 1,
+                           tail(vs$ce, -1) <= extra_tol * head(vs$ce, -1),
+                           tail(vs$ce, -1) <= 1 / extra_tol * head(vs$ce, -1))),
+                info = info_str)
+  }
 
   # type_test
   type_test_expected <- cv_method_expected
@@ -2287,49 +2334,10 @@ vsel_tester <- function(
     smmrs_ref_tester(vs$summaries$ref$oscale, tests_oscale = TRUE)
   }
 
-  # solution_terms
-  expect_type(vs$solution_terms, "character")
-  expect_length(vs$solution_terms, solterms_len_expected)
-  soltrms <- vs$solution_terms
-  for (soltrms_plus in grep("\\+", soltrms, value = TRUE)) {
-    soltrms <- setdiff(soltrms, soltrms_plus)
-    soltrms <- c(soltrms, labels(terms(as.formula(paste(". ~", soltrms_plus)))))
-  }
-  expect_true(all(soltrms %in% trms_universe_split), info = info_str)
-
-  # ce
-  if (with_cv && (valsearch_expected || cv_method_expected == "kfold")) {
-    expect_identical(vs$ce, rep(NA_real_, solterms_len_expected + 1))
-  } else {
-    expect_type(vs$ce, "double")
-    expect_length(vs$ce, solterms_len_expected + 1)
-    # Expected to be non-increasing for increasing model size:
-    expect_true(all(ifelse(sign(head(vs$ce, -1)) == 1,
-                           tail(vs$ce, -1) <= extra_tol * head(vs$ce, -1),
-                           tail(vs$ce, -1) <= 1 / extra_tol * head(vs$ce, -1))),
-                info = info_str)
-  }
-
-  # solution_terms_cv
-  if (with_cv && isTRUE(vs$validate_search)) {
-    expect_true(is.matrix(vs$solution_terms_cv), info = info_str)
-    expect_type(vs$solution_terms_cv, "character")
-    if (identical(cv_method_expected, "kfold")) {
-      n_folds <- K_tst
-    } else {
-      n_folds <- nobsv
-    }
-    expect_identical(dim(vs$solution_terms_cv),
-                     c(n_folds, solterms_len_expected),
-                     info = info_str)
-    # We need the addition of `NA_character_` because of subsampled PSIS-LOO CV:
-    expect_true(
-      all(vs$solution_terms_cv %in% c(trms_universe_split, NA_character_)),
-      info = info_str
-    )
-  } else {
-    expect_null(vs$solution_terms_cv, info = info_str)
-  }
+  # nterms_all
+  expect_identical(vs$nterms_all,
+                   count_terms_in_formula(vs$refmodel$formula) - 1L,
+                   info = info_str)
 
   # nterms_max
   nterms_max_expected <- solterms_len_expected
@@ -2338,16 +2346,14 @@ vsel_tester <- function(
   }
   expect_equal(vs$nterms_max, nterms_max_expected, info = info_str)
 
-  # nterms_all
-  expect_identical(vs$nterms_all,
-                   count_terms_in_formula(vs$refmodel$formula) - 1L,
-                   info = info_str)
-
   # method
   expect_identical(vs$method, method_expected, info = info_str)
 
   # cv_method
   expect_identical(vs$cv_method, cv_method_expected, info = info_str)
+
+  # nloo
+  expect_identical(vs$nloo, nloo_expected_orig, info = info_str)
 
   # K
   if (identical(cv_method_expected, "kfold")) {
@@ -2358,6 +2364,43 @@ vsel_tester <- function(
 
   # validate_search
   expect_identical(vs$validate_search, valsearch_expected, info = info_str)
+
+  # cvfits
+  if (is.null(cv_method_expected)) {
+    expect_null(vs$cvfits, info = info_str)
+  } else {
+    ### Currently, we are testing argument `cvfits` only implicitly via the
+    ### examples and via the main vignette:
+    expect_identical(vs$cvfits, NA, info = info_str)
+    ###
+  }
+
+  # args_search
+  expect_equal(
+    vs$args_search,
+    list(
+      method = method_expected,
+      ndraws = NULL,
+      nclusters = if (from_datafit && method_expected == "forward") {
+        20
+      } else if (cl_search_expected || from_datafit) {
+        nprjdraws_search_expected
+      } else {
+        NULL
+      },
+      nterms_max = vs$nterms_max,
+      lambda_min_ratio = 1e-5, nlambda = 150, thresh = 1e-6,
+      penalty = penalty_expected,
+      search_terms = if (is.null(search_terms_expected)) {
+        union("1", split_formula(vs$refmodel$formula,
+                                 data = vs$refmodel$fetch_data()))
+      } else {
+        union("1", search_terms_expected)
+      },
+      search_terms_was_null = is.null(search_terms_expected)
+    ),
+    info = info_str
+  )
 
   # clust_used_search
   expect_equal(vs$clust_used_search, cl_search_expected, info = info_str)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1908,26 +1908,18 @@ if (run_cvvs) {
 
 ## Output names -----------------------------------------------------------
 
+# Output elements of `vsel` objects:
 vsel_nms <- c(
   "refmodel", "nobs_train", "search_path", "solution_terms",
   "solution_terms_cv", "ce", "type_test", "y_wobs_test", "nobs_test",
-  "summaries", "nterms_all", "nterms_max", "method", "cv_method", "K",
-  "validate_search", "clust_used_search", "clust_used_eval", "nprjdraws_search",
-  "nprjdraws_eval", "projpred_version"
+  "summaries", "nterms_all", "nterms_max", "method", "cv_method", "nloo", "K",
+  "validate_search", "cvfits", "args_search", "clust_used_search",
+  "clust_used_eval", "nprjdraws_search", "nprjdraws_eval", "projpred_version"
 )
-# Related to prediction (in contrast to selection):
-vsel_nms_pred <- c("summaries", "solution_terms", "ce")
-vsel_nms_pred_opt <- c("solution_terms")
-# Related to `nloo`:
-vsel_nms_nloo <- c("summaries", "solution_terms_cv")
-vsel_nms_nloo_opt <- c("solution_terms_cv")
-# Related to `validate_search`:
-vsel_nms_valsearch <- c("validate_search", "summaries", "ce",
-                        "solution_terms_cv")
-vsel_nms_valsearch_opt <- character()
-# Related to `cvfits`:
+# Output elements of `vsel` objects that may be influenced by `cvfits`:
 vsel_nms_cvfits <- c("refmodel", "summaries", "solution_terms_cv")
 vsel_nms_cvfits_opt <- c("solution_terms_cv")
+# Sub-elements of `summaries`'s `sub` and `ref` elements:
 vsel_smmrs_sub_nms <- vsel_smmrs_ref_nms <- c("mu", "lppd")
 
 ## Defaults ---------------------------------------------------------------

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -241,6 +241,7 @@ test_that(paste(
         datafits[[args_vs_datafit[[tstsetup]]$tstsetup_datafit]],
       solterms_len_expected = args_vs_datafit[[tstsetup]]$nterms_max,
       method_expected = meth_exp_crr,
+      search_terms_expected = args_vs_datafit[[tstsetup]]$search_terms,
       search_trms_empty_size =
         length(args_vs_datafit[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs_datafit[[tstsetup]]$search_terms)),
@@ -268,6 +269,7 @@ test_that(paste(
       method_expected = meth_exp_crr,
       cv_method_expected = "kfold",
       valsearch_expected = args_cvvs_datafit[[tstsetup]]$validate_search,
+      search_terms_expected = args_cvvs_datafit[[tstsetup]]$search_terms,
       search_trms_empty_size =
         length(args_cvvs_datafit[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs_datafit[[tstsetup]]$search_terms)),

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -18,6 +18,7 @@ test_that(paste(
       refmod_expected = refmods[[tstsetup_ref]],
       solterms_len_expected = args_vs[[tstsetup]]$nterms_max,
       method_expected = meth_exp_crr,
+      search_terms_expected = args_vs[[tstsetup]]$search_terms,
       search_trms_empty_size =
         length(args_vs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs[[tstsetup]]$search_terms)),
@@ -157,6 +158,7 @@ test_that(paste(
       ),
       solterms_len_expected = args_vs_i$nterms_max,
       method_expected = meth_exp_crr,
+      search_terms_expected = args_vs_i$search_terms,
       search_trms_empty_size =
         length(args_vs_i$search_terms) &&
         all(grepl("\\+", args_vs_i$search_terms)),
@@ -283,6 +285,7 @@ test_that(paste(
       ),
       solterms_len_expected = args_vs_i$nterms_max,
       method_expected = meth_exp_crr,
+      search_terms_expected = args_vs_i$search_terms,
       search_trms_empty_size =
         length(args_vs_i$search_terms) &&
         all(grepl("\\+", args_vs_i$search_terms)),
@@ -551,6 +554,7 @@ test_that("`refit_prj` works", {
       solterms_len_expected = args_vs_i$nterms_max,
       method_expected = meth_exp_crr,
       refit_prj_expected = FALSE,
+      search_terms_expected = args_vs_i$search_terms,
       search_trms_empty_size =
         length(args_vs_i$search_terms) &&
         all(grepl("\\+", args_vs_i$search_terms)),
@@ -662,6 +666,10 @@ test_that(paste(
   regul_tst <- c(regul_default, 1e-1, 1e2)
   stopifnot(regul_tst[1] == regul_default)
   stopifnot(all(diff(regul_tst) > 0))
+  # Output elements of `vsel` objects that may be influenced by `regul`:
+  vsel_nms_regul <- c("summaries", "ce")
+  vsel_nms_regul_opt <- character()
+  # The setups that should be tested:
   tstsetups <- grep("\\.glm\\..*\\.L1\\.", names(vss), value = TRUE)
   for (tstsetup in tstsetups) {
     args_vs_i <- args_vs[[tstsetup]]
@@ -683,14 +691,13 @@ test_that(paste(
           method_expected = "L1",
           info_str = tstsetup
         )
-        # Expect equality for all components not related to prediction:
-        expect_equal(vs_regul[setdiff(vsel_nms, vsel_nms_pred)],
-                     vss[[tstsetup]][setdiff(vsel_nms, vsel_nms_pred)],
+        # Expect equality for all components not related to `regul`:
+        expect_equal(vs_regul[setdiff(vsel_nms, vsel_nms_regul)],
+                     vss[[tstsetup]][setdiff(vsel_nms, vsel_nms_regul)],
                      info = paste(tstsetup, j, sep = "__"))
-        # Expect inequality for the components related to prediction (but note
-        # that the components from `vsel_nms_pred_opt` can be, but don't need to
-        # be differing):
-        for (vsel_nm in setdiff(vsel_nms_pred, vsel_nms_pred_opt)) {
+        # Expect inequality for the elements related to `regul` (the elements
+        # from `vsel_nms_regul_opt` can be, but don't need to be differing):
+        for (vsel_nm in setdiff(vsel_nms_regul, vsel_nms_regul_opt)) {
           expect_false(isTRUE(all.equal(vs_regul[[vsel_nm]],
                                         vss[[tstsetup]][[vsel_nm]])),
                        info = paste(tstsetup, j, vsel_nm, sep = "__"))
@@ -766,6 +773,7 @@ test_that(paste(
           refmod_expected = refmods[[args_vs_i$tstsetup_ref]],
           solterms_len_expected = args_vs_i$nterms_max,
           method_expected = "forward",
+          search_terms_expected = args_vs_i$search_terms,
           search_trms_empty_size =
             length(args_vs_i$search_terms) &&
             all(grepl("\\+", args_vs_i$search_terms)),
@@ -906,6 +914,7 @@ test_that("for forward search, `penalty` has no effect", {
       )),
       warn_expected
     )
+    vs_penal$args_search["penalty"] <- list(NULL)
     expect_equal(vs_penal, vss[[tstsetup]], info = tstsetup)
   }
 })
@@ -954,6 +963,7 @@ test_that("for L1 search, `penalty` has an expected effect", {
       refmod_expected = refmods[[args_vs_i$tstsetup_ref]],
       solterms_len_expected = nterms_max_crr,
       method_expected = "L1",
+      penalty_expected = penal_crr,
       info_str = tstsetup
     )
     # Check that the variables with no cost are selected first and the ones
@@ -1051,7 +1061,9 @@ test_that(paste(
   for (tstsetup in tstsetups) {
     tstsetup_default <- sub("\\.alltrms", "\\.default_search_trms", tstsetup)
     if (!tstsetup_default %in% names(vss)) next
-    expect_identical(vss[[tstsetup]], vss[[tstsetup_default]], info = tstsetup)
+    vs_search_terms <- vss[[tstsetup]]
+    vs_search_terms$args_search$search_terms_was_null <- TRUE
+    expect_identical(vs_search_terms, vss[[tstsetup_default]], info = tstsetup)
   }
 })
 
@@ -1117,6 +1129,7 @@ test_that(paste(
       method_expected = meth_exp_crr,
       cv_method_expected = args_cvvs[[tstsetup]]$cv_method,
       valsearch_expected = args_cvvs[[tstsetup]]$validate_search,
+      search_terms_expected = args_cvvs[[tstsetup]]$search_terms,
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
@@ -1220,6 +1233,7 @@ test_that("`refit_prj` works", {
       refit_prj_expected = FALSE,
       cv_method_expected = args_cvvs_i$cv_method,
       valsearch_expected = args_cvvs_i$validate_search,
+      search_terms_expected = args_cvvs_i$search_terms,
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
         all(grepl("\\+", args_cvvs_i$search_terms)),
@@ -1313,6 +1327,7 @@ test_that(paste(
            nloo = nloo_tst),
       excl_nonargs(args_cvvs_i)
     )))
+    cvvs_nloo["nloo"] <- list(NULL)
     expect_equal(cvvs_nloo, cvvss[[tstsetup]], info = tstsetup)
   }
 })
@@ -1320,6 +1335,10 @@ test_that(paste(
 test_that("setting `nloo` smaller than the number of observations works", {
   skip_if_not(run_cvvs)
   nloo_tst <- nobsv %/% 5L
+  # Output elements of `vsel` objects that may be influenced by `nloo`:
+  vsel_nms_nloo <- c("summaries", "solution_terms_cv", "nloo")
+  vsel_nms_nloo_opt <- c("solution_terms_cv")
+  # The setups that should be tested:
   tstsetups <- grep("\\.glm\\.gauss\\..*\\.default_cvmeth", names(cvvss),
                     value = TRUE)
   for (tstsetup in tstsetups) {
@@ -1345,16 +1364,17 @@ test_that("setting `nloo` smaller than the number of observations works", {
       cv_method_expected = "LOO",
       valsearch_expected = args_cvvs_i$validate_search,
       nloo_expected = nloo_tst,
+      search_terms_expected = args_cvvs_i$search_terms,
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
         all(grepl("\\+", args_cvvs_i$search_terms)),
       info_str = tstsetup
     )
-    # Expected equality for most components with a few exceptions:
+    # Expected equality for most elements with a few exceptions:
     expect_equal(cvvs_nloo[setdiff(vsel_nms, vsel_nms_nloo)],
                  cvvss[[tstsetup]][setdiff(vsel_nms, vsel_nms_nloo)],
                  info = tstsetup)
-    # Expected inequality for the exceptions (but note that the components from
+    # Expected inequality for the exceptions (the elements from
     # `vsel_nms_nloo_opt` can be, but don't need to be differing):
     for (vsel_nm in setdiff(vsel_nms_nloo, vsel_nms_nloo_opt)) {
       expect_false(isTRUE(all.equal(cvvs_nloo[[vsel_nm]],
@@ -1368,6 +1388,12 @@ test_that("setting `nloo` smaller than the number of observations works", {
 
 test_that("`validate_search` works", {
   skip_if_not(run_cvvs)
+  # Output elements of `vsel` objects that may be influenced by
+  # `validate_search`:
+  vsel_nms_valsearch <- c("validate_search", "summaries", "ce",
+                          "solution_terms_cv")
+  vsel_nms_valsearch_opt <- character()
+  # The setups that should be tested:
   tstsetups <- grep("\\.default_cvmeth", names(cvvss), value = TRUE)
   if (!run_valsearch_always) {
     has_valsearch_true <- sapply(tstsetups, function(tstsetup_cvvs) {
@@ -1400,19 +1426,20 @@ test_that("`validate_search` works", {
       method_expected = meth_exp_crr,
       cv_method_expected = "LOO",
       valsearch_expected = FALSE,
+      search_terms_expected = args_cvvs_i$search_terms,
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
         all(grepl("\\+", args_cvvs_i$search_terms)),
       info_str = tstsetup
     )
-    # Expected equality for most components with a few exceptions:
+    # Expected equality for most elements with a few exceptions:
     expect_equal(cvvs_valsearch[setdiff(vsel_nms, vsel_nms_valsearch)],
                  cvvss[[tstsetup]][setdiff(vsel_nms, vsel_nms_valsearch)],
                  info = tstsetup)
     expect_identical(cvvs_valsearch$summaries$ref,
                      cvvss[[tstsetup]]$summaries$ref,
                      info = tstsetup)
-    # Expected inequality for the exceptions (but note that the components from
+    # Expected inequality for the exceptions (the elements from
     # `vsel_nms_valsearch_opt` can be, but don't need to be differing):
     for (vsel_nm in setdiff(vsel_nms_valsearch, vsel_nms_valsearch_opt)) {
       expect_false(isTRUE(all.equal(cvvs_valsearch[[vsel_nm]],
@@ -1544,12 +1571,13 @@ test_that(paste(
       method_expected = meth_exp_crr,
       cv_method_expected = "kfold",
       valsearch_expected = args_cvvs_i$validate_search,
+      search_terms_expected = args_cvvs_i$search_terms,
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
         all(grepl("\\+", args_cvvs_i$search_terms)),
       info_str = tstsetup
     )
-    # Expected equality for some components:
+    # Expected equality for most elements with a few exceptions:
     # TODO: Currently, `check.environment = FALSE` is needed. The reason is
     # probably that in the divergence minimizers, the projpred-extended family
     # is passed to argument `family` of the external model fitting functions
@@ -1559,9 +1587,8 @@ test_that(paste(
                  cvvss[[tstsetup]][setdiff(vsel_nms, vsel_nms_cvfits)],
                  check.environment = FALSE,
                  info = tstsetup)
-    # Expected inequality for the remaining components (but note that the
-    # components from `vsel_nms_cvfits_opt` can be, but don't need to be
-    # differing):
+    # Expected inequality for the exceptions (the elements from
+    # `vsel_nms_cvfits_opt` can be, but don't need to be differing):
     for (vsel_nm in setdiff(vsel_nms_cvfits, vsel_nms_cvfits_opt)) {
       expect_false(isTRUE(all.equal(cvvs_cvfits[[vsel_nm]],
                                     cvvss[[tstsetup]][[vsel_nm]])),
@@ -1670,12 +1697,13 @@ test_that(paste(
       method_expected = meth_exp_crr,
       cv_method_expected = "kfold",
       valsearch_expected = args_cvvs_i$validate_search,
+      search_terms_expected = args_cvvs_i$search_terms,
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
         all(grepl("\\+", args_cvvs_i$search_terms)),
       info_str = tstsetup
     )
-    # Expected equality for some components:
+    # Expected equality for most elements with a few exceptions:
     # TODO: Currently, `check.environment = FALSE` is needed. The reason is
     # probably that in the divergence minimizers, the projpred-extended family
     # is passed to argument `family` of the external model fitting functions
@@ -1685,9 +1713,8 @@ test_that(paste(
                  cvvss[[tstsetup]][setdiff(vsel_nms, vsel_nms_cvfits)],
                  check.environment = FALSE,
                  info = tstsetup)
-    # Expected inequality for the remaining components (but note that the
-    # components from `vsel_nms_cvfits_opt` can be, but don't need to be
-    # differing):
+    # Expected inequality for the exceptions (the elements from
+    # `vsel_nms_cvfits_opt` can be, but don't need to be differing):
     for (vsel_nm in setdiff(vsel_nms_cvfits, vsel_nms_cvfits_opt)) {
       expect_false(isTRUE(all.equal(cvvs_cvfits[[vsel_nm]],
                                     cvvss[[tstsetup]][[vsel_nm]])),

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1062,7 +1062,7 @@ test_that(paste(
     tstsetup_default <- sub("\\.alltrms", "\\.default_search_trms", tstsetup)
     if (!tstsetup_default %in% names(vss)) next
     vs_search_terms <- vss[[tstsetup]]
-    vs_search_terms$args_search$search_terms_was_null <- TRUE
+    vs_search_terms$args_search["search_terms"] <- list(NULL)
     expect_identical(vs_search_terms, vss[[tstsetup_default]], info = tstsetup)
   }
 })

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1123,6 +1123,15 @@ test_that("varsel.vsel() works for `vsel` objects from varsel()", {
     fam_crr <- args_vs[[tstsetup]]$fam_nm
     prj_crr <- args_vs[[tstsetup]]$prj_nm
     meth_exp_crr <- args_vs[[tstsetup]]$method %||% "forward"
+    extra_tol_crr <- 1.1
+    if (meth_exp_crr == "L1" &&
+        any(grepl(":", ranking(vs_eval)[["fulldata"]]))) {
+      ### Testing for non-increasing element `ce` (for increasing model size)
+      ### doesn't make sense if the ranking of predictors involved in
+      ### interactions has been changed, so we choose a higher `extra_tol`:
+      extra_tol_crr <- 1.2
+      ###
+    }
     vsel_tester(
       vs_eval,
       refmod_expected = refmods[[tstsetup_ref]],
@@ -1133,6 +1142,7 @@ test_that("varsel.vsel() works for `vsel` objects from varsel()", {
       search_trms_empty_size =
         length(args_vs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs[[tstsetup]]$search_terms)),
+      extra_tol = extra_tol_crr,
       info_str = tstsetup
     )
   }

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1858,9 +1858,6 @@ test_that(paste(
   "cv_varsel.vsel() (internally called with `validate_search = FALSE`) works",
   "for `vsel` objects from varsel()"
 ), {
-  ### TODO: Needs to be finished:
-  skip_if_not(FALSE)
-  ###
   skip_if_not(run_vs)
   skip_if_not(run_cvvs)
   tstsetup_counter <- 0L

--- a/vignettes/projpred.Rmd
+++ b/vignettes/projpred.Rmd
@@ -126,7 +126,7 @@ Nonetheless, a preliminary and comparatively fast run of `varsel()` or `cv_varse
 To illustrate a preliminary `cv_varsel()` run with `validate_search = FALSE`, we set `nterms_max` to the number of predictor terms in the full model, i.e., `nterms_max = 20`.
 To speed up the building of the vignette (this is not recommended in general), we choose the `"L1"` search `method`
 <!-- (in general, the default of forward search is more desirable, see `?varsel` or `?cv_varsel` for details) -->
-and set `nclusters_pred` to a comparatively low value of `20`.
+and set `refit_prj` to `FALSE`.
 ```{r cv_varsel_fast}
 # Preliminary cv_varsel() run:
 cvvs_fast <- cv_varsel(
@@ -134,7 +134,7 @@ cvvs_fast <- cv_varsel(
   validate_search = FALSE,
   ### Only for the sake of speed (not recommended in general):
   method = "L1",
-  nclusters_pred = 20,
+  refit_prj = FALSE,
   ###
   nterms_max = 20,
   ### In interactive use, we recommend not to deactivate the verbose mode:
@@ -151,10 +151,35 @@ Since we will be using the following plot only to determine `nterms_max` for sub
 ```{r plot_vsel_fast}
 plot(cvvs_fast, stats = "mlpd", ranking_nterms_max = NA)
 ```
-This plot (see `?plot.vsel` for a description) shows that the submodel MLPD does not change much after submodel size 8, so in our final `cv_varsel()` run, we set `nterms_max` to a value slightly higher than 8 (here: `nterms_max = 9`) to ensure that we see the MLPD leveling off.
+This plot (see `?plot.vsel` for a description) suggests that the submodel MLPD does not change much after submodel size 9, although it keeps slightly increasing even after submodel size 9.
+However, we used L1 search with `refit_prj = FALSE`, which means that the projections employed for the predictive performance evaluation are L1-penalized, which is usually undesired [@piironen_projective_2020, section 4].
+Thus, to investigate the impact of `refit_prj = FALSE`, we re-run `cv_varsel()`, but this time with the default of `refit_prj = TRUE` and re-using the search results (and also most of the arguments) from the former `cv_varsel()` call (this is done by applying `cv_varsel()` to `cvvs_fast` instead of `refm_fit` so that the `cv_varsel()` generic dispatches to the `cv_varsel.vsel()` method that has been introduced in **projpred** 2.8.0).
+To save time, we also set `nclusters_pred` to a comparatively low value of `20`:
+```{r cv_varsel_fast_refit}
+# Preliminary cv_varsel() run with `refit_prj = TRUE`:
+cvvs_fast_refit <- cv_varsel(
+  cvvs_fast,
+  ### Only for the sake of speed (not recommended in general):
+  nclusters_pred = 20,
+  ###
+  ### In interactive use, we recommend not to deactivate the verbose mode:
+  verbose = FALSE
+  ### 
+)
+```
+As explained above, we ignore the Pareto $\hat{k}$ warnings and also the warning that SIS is used instead of PSIS here.
+
+With the `refit_prj = TRUE` results, the predictive performance plot from above now looks as follows:
+```{r plot_vsel_fast_refit}
+plot(cvvs_fast_refit, stats = "mlpd", ranking_nterms_max = NA)
+```
+This refined plot shows that the submodel MLPD does not change much after submodel size 8, so in our final `cv_varsel()` run, we set `nterms_max` to a value slightly higher than 8 (here: `nterms_max = 9`) to ensure that we see the MLPD leveling off.
+The re-use of previous search results, achieved via `cv_varsel.vsel()`^[Analogous functionality exists for `varsel()`, implemented in `varsel.vsel()`.], could now be used again for investigating how much the results would change when increasing `nclusters_pred` or when using `ndraws_pred`.
+Here, we skip this for the sake of brevity and instead head over to the final `cv_varsel()` run.
 
 For this final `cv_varsel()` run, we use a $K$-fold CV with a small number of folds (`K = 2`) to make this vignette build faster.
 In practice, we recommend using either the default of `cv_method = "LOO"` (with `validate_search = TRUE`) or a larger value for `K` if this is possible in terms of computation time.
+<!-- For the sake of speed, we also set `nclusters_pred` to a comparatively low value of `20`. Furthermore, we illustrate -->
 We also illustrate how **projpred**'s CV can be parallelized, even though this is of little use here (we have only `K = 2` folds and the fold-wise searches and performance evaluations are quite fast, so the parallelization overhead eats up any runtime improvements).
 ```{r cv_varsel, message=FALSE}
 # For the CV parallelization (cv_varsel()'s argument `parallel`):
@@ -522,11 +547,12 @@ Some speed-up possibilities are:
 
 1.  Using L1 search (see argument `method` of `varsel()` or `cv_varsel()`) instead of forward search.
     Note that L1 search implies `nclusters = 1` and is not always supported.
+    <!-- Caution is also required when using L1 search in combination with `refit_prj = FALSE` because in that case, the projections used for the predictive performance evaluation are L1-penalized, which is usually undesired [@piironen_projective_2020, section 4]. -->
     In general, forward search is more accurate than L1 search and hence more desirable (see section "Details" in `?varsel` or `?cv_varsel` for a more detailed comparison of the two).
     The issue demonstrated in the Poisson example from the latent-projection vignette is related to this.
 
 1.  Setting argument `refit_prj` (of `varsel()` or `cv_varsel()`) to `FALSE`, which basically means to set `ndraws_pred = ndraws` and `nclusters_pred = nclusters`, but in a more efficient (i.e., faster) way.
-    In case of L1 search, this means that the L1-penalized projections of the regression coefficients are used for the predictive performance evaluation, which may be undesired [@piironen_projective_2020, section 4].
+    In case of L1 search, this means that the L1-penalized projections of the regression coefficients are used for the predictive performance evaluation, which is usually undesired [@piironen_projective_2020, section 4].
     In case of forward search, this issue does not exist.
 
 1.  Parallelizing costly parts of the CV implied by `cv_varsel()` (this was demonstrated in the example above; see argument `parallel` of `cv_varsel()`).

--- a/vignettes/projpred.Rmd
+++ b/vignettes/projpred.Rmd
@@ -90,7 +90,7 @@ ncores <- parallel::detectCores(logical = FALSE)
 ncores <- min(ncores, 2L)
 ###
 options(mc.cores = ncores)
-set.seed(507801)
+set.seed(5078022)
 refm_fit <- stan_glm(
   y ~ X1 + X2 + X3 + X4 + X5 + X6 + X7 + X8 + X9 + X10 + X11 + X12 + X13 + X14 +
     X15 + X16 + X17 + X18 + X19 + X20,
@@ -103,8 +103,8 @@ refm_fit <- stan_glm(
   QR = TRUE, refresh = 0
 )
 ```
-Usually, we would now have to check the convergence diagnostics (see, e.g., `?posterior::diagnostics` and `?posterior::default_convergence_measures`; the bulk-ESS warning already indicates a problem).
-However, due to the technical reasons for which we reduced `chains` and `iter`, we skip this step here (and hence ignore the bulk-ESS warning).
+Usually, we would now have to check the convergence diagnostics (see, e.g., `?posterior::diagnostics` and `?posterior::default_convergence_measures`; the tail-ESS warning already indicates a problem).
+However, due to the technical reasons for which we reduced `chains` and `iter`, we skip this step here (and hence ignore the tail-ESS warning).
 
 ## Variable selection {#variableselection}
 
@@ -122,6 +122,8 @@ In contrast to `varsel()`, `cv_varsel()` performs a cross-validation (CV). With 
 If `validate_search = FALSE` (which is currently only available for `cv_method = "LOO"`), the search is excluded from the CV so that only a single full-data search is run.
 Because of its most thorough protection against overfitting^[Currently, neither `varsel()` nor `cv_varsel()` (not even `cv_varsel()` with `validate_search = TRUE`) guard against overfitting in the selection of the submodel *size*. This is why we added "approximately" to "valid post-selection inference" in section ["Introduction"](#intro). Typically, however, the overfitting induced by the size selection should be comparatively small [@piironen_comparison_2017].], `cv_varsel()` with `validate_search = TRUE` is recommended over `varsel()` and `cv_varsel()` with `validate_search = FALSE`.
 Nonetheless, a preliminary and comparatively fast run of `varsel()` or `cv_varsel()` with `validate_search = FALSE` can give a rough idea of the performance of the submodels and can be used for finding a suitable value for argument `nterms_max` in subsequent runs (argument `nterms_max` imposes a limit on the submodel size up to which the search is continued and is thus able to reduce the runtime considerably).
+
+### Preliminary `cv_varsel()` run
 
 To illustrate a preliminary `cv_varsel()` run with `validate_search = FALSE`, we set `nterms_max` to the number of predictor terms in the full model, i.e., `nterms_max = 20`.
 To speed up the building of the vignette (this is not recommended in general), we choose the `"L1"` search `method`
@@ -143,7 +145,7 @@ cvvs_fast <- cv_varsel(
 )
 ```
 In this case, we ignore the Pareto $\hat{k}$ warnings due to the reduced values for `chains` and `iter` in the reference model fit.
-We also ignore the warning that SIS is used instead of PSIS (this is due to `nclusters_pred = 20` which we used only to speed up the building of the vignette).
+<!-- We also ignore the warning that SIS is used instead of PSIS (this is due to `nclusters_pred = 20` which we used only to speed up the building of the vignette). -->
 
 To find a suitable value for `nterms_max` in subsequent `cv_varsel()` runs, we take a look at a plot of at least one predictive performance statistic in dependence of the submodel size.
 Here, we choose the mean log predictive density (MLPD; see the documentation for argument `stats` of `summary.vsel()` for details) as the only performance statistic.
@@ -151,9 +153,9 @@ Since we will be using the following plot only to determine `nterms_max` for sub
 ```{r plot_vsel_fast}
 plot(cvvs_fast, stats = "mlpd", ranking_nterms_max = NA)
 ```
-This plot (see `?plot.vsel` for a description) suggests that the submodel MLPD does not change much after submodel size 9, although it keeps slightly increasing even after submodel size 9.
+This plot suggests that the submodel MLPD levels off for the first time from submodel size 9 to 10 and that it increases only slightly afterwards.
 However, we used L1 search with `refit_prj = FALSE`, which means that the projections employed for the predictive performance evaluation are L1-penalized, which is usually undesired [@piironen_projective_2020, section 4].
-Thus, to investigate the impact of `refit_prj = FALSE`, we re-run `cv_varsel()`, but this time with the default of `refit_prj = TRUE` and re-using the search results (and also most of the arguments) from the former `cv_varsel()` call (this is done by applying `cv_varsel()` to `cvvs_fast` instead of `refm_fit` so that the `cv_varsel()` generic dispatches to the `cv_varsel.vsel()` method that has been introduced in **projpred** 2.8.0).
+Thus, to investigate the impact of `refit_prj = FALSE`, we re-run `cv_varsel()`, but this time with the default of `refit_prj = TRUE` and re-using the search results (and also most of the arguments) from the former `cv_varsel()` call (this is done by applying `cv_varsel()` to `cvvs_fast` instead of `refm_fit` so that the `cv_varsel()` generic dispatches to the `cv_varsel.vsel()` method that was introduced in **projpred** 2.8.0^[Analogous functionality has been implemented for `varsel()`, namely in `varsel.vsel()`.]).
 To save time, we also set `nclusters_pred` to a comparatively low value of `20`:
 ```{r cv_varsel_fast_refit}
 # Preliminary cv_varsel() run with `refit_prj = TRUE`:
@@ -167,21 +169,26 @@ cvvs_fast_refit <- cv_varsel(
   ### 
 )
 ```
-As explained above, we ignore the Pareto $\hat{k}$ warnings and also the warning that SIS is used instead of PSIS here.
+As explained above, we ignore the Pareto $\hat{k}$ warnings
+<!-- and also the warning that SIS is used instead of PSIS -->
+here.
+We also ignore the warning that SIS is used instead of PSIS (this is due to `nclusters_pred = 20` which we used only to speed up the building of the vignette).
 
 With the `refit_prj = TRUE` results, the predictive performance plot from above now looks as follows:
 ```{r plot_vsel_fast_refit}
 plot(cvvs_fast_refit, stats = "mlpd", ranking_nterms_max = NA)
 ```
-This refined plot shows that the submodel MLPD does not change much after submodel size 8, so in our final `cv_varsel()` run, we set `nterms_max` to a value slightly higher than 8 (here: `nterms_max = 9`) to ensure that we see the MLPD leveling off.
-The re-use of previous search results, achieved via `cv_varsel.vsel()`^[Analogous functionality exists for `varsel()`, implemented in `varsel.vsel()`.], could now be used again for investigating how much the results would change when increasing `nclusters_pred` or when using `ndraws_pred`.
+This refined plot shows that the submodel MLPD does not change much after submodel size 8, so in our final `cv_varsel()` run, we set `nterms_max` to a value slightly higher than 8 (here: 9) to ensure that we see the MLPD leveling off.
+The search results from the initial `cvvs_fast` object could now be re-used again (via `cv_varsel.vsel()`) for investigating the sensitivity of the results to changes in `nclusters_pred` (or `ndraws_pred`).
 Here, we skip this for the sake of brevity and instead head over to the final `cv_varsel()` run.
+
+### Final `cv_varsel()` run
 
 For this final `cv_varsel()` run, we use a $K$-fold CV with a small number of folds (`K = 2`) to make this vignette build faster.
 In practice, we recommend using either the default of `cv_method = "LOO"` (with `validate_search = TRUE`) or a larger value for `K` if this is possible in terms of computation time.
 <!-- For the sake of speed, we also set `nclusters_pred` to a comparatively low value of `20`. Furthermore, we illustrate -->
 Here, we also perform the $K$ reference model refits outside of `cv_varsel()`.
-Although not strictly necessary here, this is helpful in practice because often, `cv_varsel()` needs to be re-run multiple times, trying out different argument settings.
+Although not strictly necessary here, this is helpful in practice because often, `cv_varsel()` needs to be re-run multiple times in order to try out different argument settings.
 We also illustrate how **projpred**'s CV (i.e., the CV comprising search and performance evaluation, after refitting the reference model $K$ times) can be parallelized, even though this is of little use here (we have only `K = 2` folds and the fold-wise searches and performance evaluations are quite fast, so the parallelization overhead eats up any runtime improvements).
 ```{r cv_varsel, message=FALSE}
 # Refit the reference model K times:
@@ -212,7 +219,7 @@ cvvs <- cv_varsel(
 doParallel::stopImplicitCluster()
 foreach::registerDoSEQ()
 ```
-Again, we ignore the bulk-ESS warnings due to the reduced values for `chains` and `iter` in the reference model fit.
+<!-- Again, we ignore the tail-ESS warnings due to the reduced values for `chains` and `iter` in the reference model fit. -->
 
 We can now select a final submodel size by looking at a predictive performance plot similar to the one created for the preliminary `cv_varsel()` run above.
 By default, the performance statistics are plotted on their original scale, but with `deltas = TRUE`, they are plotted as differences from a baseline model (which is the reference model by default, at least in the most common cases).
@@ -221,7 +228,9 @@ Since the differences and the (frequentist) uncertainty in their estimation are 
 plot(cvvs, stats = "mlpd", deltas = TRUE)
 ```
 
-Based on that plot, we decide for a submodel size.
+### Decision for final submodel size
+
+Based on that final predictive performance plot, we decide for a submodel size.
 Usually, the aim is to find the smallest submodel size where the predictive performance of the submodels levels off and is close enough to the reference model's predictive performance (the dashed red horizontal line).
 Sometimes (as here), the plot may be ambiguous because after reaching the reference model's performance, the submodels' performance may keep increasing (and hence become even better than the reference model's performance^[In general, only `cv_varsel()` with `validate_search = TRUE` (which we have here) allows to judge whether the submodels perform better than the reference model or not. Such a judgment is not possible with `varsel()` or `cv_varsel()` with `validate_search = FALSE` (in general).]).
 In that case, one has to find a suitable trade-off between predictive performance (accuracy) and model size (sparsity) in the context of subject-matter knowledge.
@@ -230,14 +239,16 @@ Hence, based on the plot, we decide for a submodel size of 6 because this is the
 ```{r size_man}
 size_decided <- 6
 ```
-If the focus of our predictive model had been accuracy (not sparsity), size 8 would have been a natural choice because at size 8, the submodel MLPD "levels off" (in fact, size 8 here even comes with the maximum submodel MLPD among all plotted sizes, but in general, this does not need to be the case).
-Further below, the predictor ranking and the (CV) ranking proportions that are shown in the plot (below the submodel sizes on the x-axis) are explained in detail---and also how they could have been incorporated into our decision for a submodel size.
+If the focus of our predictive model had been accuracy (not sparsity), size 7 (or even 8) would have been a natural choice because at size 7 (at the latest at size 8), the submodel MLPD can be considered to "level off".
+Further down, the predictor ranking and the (CV) ranking proportions that are shown in the plot (below the submodel sizes on the x-axis) are explained in detail---and also how they could have been incorporated into our decision for a submodel size.
 
 The `suggest_size()` function offered by **projpred** may help in the decision for a submodel size, but this is a rather heuristic method and needs to be interpreted with caution (see `?suggest_size`):
 ```{r size_sgg}
 suggest_size(cvvs, stat = "mlpd")
 ```
 With this heuristic, we would get the same final submodel size (`6`) as by our manual (sparsity-based) decision.
+
+### `summary()` method for `vsel` objects
 
 A tabular representation of the plot created by `plot.vsel()` can be achieved via `summary.vsel()`.
 For the output of `summary.vsel()`, there is a sophisticated `print()` method (`print.vselsummary()`) which is also called by the shortcut method `print.vsel()`^[`print.vsel()` is the method that is called when simply printing an object resulting from `varsel()` or `cv_varsel()`.].
@@ -248,7 +259,9 @@ smmry <- summary(cvvs, stats = "mlpd", type = c("mean", "lower", "upper"),
 print(smmry, digits = 1)
 ```
 
-As highlighted by the message above, the predictor ranking from column `solution_terms` is based on the full-data search.
+### Predictor ranking(s) and identification of the selected submodel
+
+As highlighted by the message thrown by `summary.vsel()`, the predictor ranking from column `solution_terms` is based on the full-data search.
 In case of `cv_varsel()` with `validate_search = TRUE`, there is not only the full-data search, but also fold-wise searches, implying that there are also fold-wise predictor rankings.
 All of these predictor rankings (the full-data one and---if available---the fold-wise ones) can be retrieved via `ranking()`:
 ```{r ranking}
@@ -262,8 +275,8 @@ To compute these ranking proportions, we use `cv_proportions()`:
 ( pr_rk <- cv_proportions(rk) )
 ```
 Here, the ranking proportions are of little use as we have used `K = 2` (in the final `cv_varsel()` call above) for the sake of speed.
-Nevertheless, we can see that the two CV folds agree on the set of the two most relevant predictor terms (`X1` and `X14`) as well as on their order.
-Since the column names of the matrix returned by `cv_proportions()` follow the full-data predictor ranking, we can infer that `X1` and `X14` are also the two most relevant predictor terms in the full-data predictor ranking.
+Nevertheless, we can see that the two CV folds agree on the most relevant predictor term (`X1`).
+Since the column names of the matrix returned by `cv_proportions()` follow the full-data predictor ranking, we can infer that `X1` is also the most relevant predictor term in the full-data predictor ranking.
 To see this more explicitly, we can access element `fulldata` of the `ranking()` output:
 ```{r ranking_fulldata}
 rk[["fulldata"]]
@@ -287,13 +300,11 @@ At this place, it is again helpful to take the ranking proportions into account,
 ```{r plot_cv_proportions_cumul}
 plot(cv_proportions(rk, cumulate = TRUE))
 ```
-This plot confirms (from a slightly different perspective) that the two fold-wise searches (as well as the full-data search, whose predictor ranking determines the order of the predictors on the y-axis) agree on the *set* of the two most relevant predictors (`X1` and `X14`): When looking at `<=2` on the x-axis, all tiles above and including the second main diagonal element are at 100&nbsp;%.
-Similarly, the two CV folds agree on the *sets* of the six and nine most relevant predictors (and also on the set of the most relevant predictor, which is a singleton).
-<!-- Looking at `<=6` on the x-axis, we see that for our chosen submodel size of 6, both CV folds have most terms from `predictors_final` included among the first 6 terms of their predictor ranking, except for `X6`. -->
-<!-- Only one of the two CV folds includes `X6` among the first 6 terms, but the other CV fold includes it shortly after that (at size 7, see also the `plot(pr_rk)` call above), which indicates that `X6` might indeed be a helpful term. -->
+This plot shows that the two fold-wise searches (as well as the full-data search, whose predictor ranking determines the order of the predictors on the y-axis) agree on the *set* of the 6 most relevant predictors: When looking at `<=6` on the x-axis, all tiles above and including the 6^th^ main diagonal element are at 100&nbsp;%.
+Similarly, the two CV folds agree on the *set* of the 7 most relevant predictors (and also on the set of the most relevant predictor, which is a singleton).
 
 Although not demonstrated here, the cumulated ranking proportions could also have guided the decision for a submodel size (if we had not been willing to follow a strict rule based on accuracy or sparsity):
-From their plot, we can see that size 9 might have been an unfortunate choice because `X10` (which---by cutting off the full-data predictor ranking at size 9---would then have been selected as the ninth predictor in the final submodel) is not included among the first 9 terms by any CV fold.
+From their plot, we can see that size 9 might have been an unfortunate choice because `X10` (which---by cutting off the full-data predictor ranking at size 9---would then have been selected as the 9^th^ predictor in the final submodel) is not included among the first 9 terms by any CV fold.
 However, since `K = 2` is too small for reliable statements regarding the variability of the predictor ranking, we did not take the cumulated ranking proportions into account when we made our decision for a submodel size above.
 
 In a real-world application, we might also be able to incorporate the full-data predictor ranking into our decision for a submodel size (usually, this requires to also take into account the variability of the predictor ranking, as reflected by the---possibly cumulated---ranking proportions).

--- a/vignettes/projpred.Rmd
+++ b/vignettes/projpred.Rmd
@@ -180,16 +180,25 @@ Here, we skip this for the sake of brevity and instead head over to the final `c
 For this final `cv_varsel()` run, we use a $K$-fold CV with a small number of folds (`K = 2`) to make this vignette build faster.
 In practice, we recommend using either the default of `cv_method = "LOO"` (with `validate_search = TRUE`) or a larger value for `K` if this is possible in terms of computation time.
 <!-- For the sake of speed, we also set `nclusters_pred` to a comparatively low value of `20`. Furthermore, we illustrate -->
-We also illustrate how **projpred**'s CV can be parallelized, even though this is of little use here (we have only `K = 2` folds and the fold-wise searches and performance evaluations are quite fast, so the parallelization overhead eats up any runtime improvements).
+Here, we also perform the $K$ reference model refits outside of `cv_varsel()`.
+Although not strictly necessary here, this is helpful in practice because often, `cv_varsel()` needs to be re-run multiple times, trying out different argument settings.
+We also illustrate how **projpred**'s CV (i.e., the CV comprising search and performance evaluation, after refitting the reference model $K$ times) can be parallelized, even though this is of little use here (we have only `K = 2` folds and the fold-wise searches and performance evaluations are quite fast, so the parallelization overhead eats up any runtime improvements).
 ```{r cv_varsel, message=FALSE}
-# For the CV parallelization (cv_varsel()'s argument `parallel`):
+# Refit the reference model K times:
+cv_fits <- run_cvfun(
+  refm_fit,
+  ### Only for the sake of speed (not recommended in general):
+  K = 2
+  ###
+)
+# For running projpred's CV in parallel (see cv_varsel()'s argument `parallel`):
 doParallel::registerDoParallel(ncores)
 # Final cv_varsel() run:
 cvvs <- cv_varsel(
   refm_fit,
   cv_method = "kfold",
+  cvfits = cv_fits,
   ### Only for the sake of speed (not recommended in general):
-  K = 2,
   method = "L1",
   nclusters_pred = 20,
   ###

--- a/vignettes/projpred.Rmd
+++ b/vignettes/projpred.Rmd
@@ -578,6 +578,12 @@ Some speed-up possibilities are:
 1.  Parallelizing costly parts of the CV implied by `cv_varsel()` (this was demonstrated in the example above; see argument `parallel` of `cv_varsel()`).
     When using `project()`, parallelizing the projection might also help (see the general package documentation available [online](https://mc-stan.org/projpred/reference/projpred-package.html) or by typing `` ?`projpred-package` ``).
 
+1.  Using `varsel.vsel()` or `cv_varsel.vsel()` to re-use previous search results for new performance evaluation(s).
+    This is helpful if the performance evaluation part is run multiple times based on the same search results (e.g., when only arguments `ndraws_pred` or `nclusters_pred` of `varsel()` or `cv_varsel()` are changed).
+    In the example above, this was illustrated when `cv_varsel()` was applied to `cvvs_fast` instead of `refm_fit` to yield `cvvs_fast_refit`.
+    In that example, search and performance evaluation were effectively run *separately* by the `cv_varsel()` calls yielding `cvvs_fast` and `cvvs_fast_refit`, respectively.
+    This is because `cv_varsel()` with `refit_prj = FALSE` (used for `cvvs_fast`) has almost only the computational cost of the search (the performance evaluation with `refit_prj = FALSE` has almost no computational cost) and `cv_varsel.vsel()` (used for `cvvs_fast_refit`) has almost only the computational cost of the performance evaluation (the search in `cv_varsel.vsel()` has no computational cost at all).
+
 1.  Using `run_cvfun()` in case of repeated $K$-fold CV with the same $K$ reference model refits.
     The output of `run_cvfun()` is typically used as input for argument `cvfits` of `cv_varsel.refmodel()` (so in order to have a speed improvement, the output of `run_cvfun()` needs to be assigned to an object which is then re-used in multiple `cv_varsel()` calls).
 


### PR DESCRIPTION
This adds new methods `varsel.vsel()` and `cv_varsel.vsel()` (in fact, these methods already existed before, but only as placeholders). With these methods, it is possible to re-use the search results from a previous `varsel()` or `cv_varsel()` run, which is an important feature of the (unfortunately hopelessly outdated) [`workflow`](https://github.com/stan-dev/projpred/tree/workflow) branch.

See the `NEWS.md` entry added here for some more information.