### PR TITLE
Amend #461: Allow switching from `validate_search = TRUE` to `validate_search = FALSE` and partly prepare K-fold CV with `validate_search = FALSE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 ## Major changes
 
-* Search results generated in an earlier `varsel()` or `cv_varsel()` call can now be re-used by the help of the new `varsel.vsel()` and `cv_varsel.vsel()` methods (i.e., by applying `varsel()` or `cv_varsel()` to the output of the earlier `varsel()` or `cv_varsel()` call). This can save a lot of time when re-running the predictive performance evaluation part multiple times based on the same search results. An illustration may be found in the updated main vignette (section ["Preliminary `cv_varsel()` run"](https://mc-stan.org/projpred/articles/projpred.html#preliminary-cv_varsel-run); a more general description may also be found in section ["Speed"](https://mc-stan.org/projpred/articles/projpred.html#speed)). (GitHub: #461)
+* Search results generated in an earlier `varsel()` or `cv_varsel()` call can now be re-used by the help of the new `varsel.vsel()` and `cv_varsel.vsel()` methods (i.e., by applying `varsel()` or `cv_varsel()` to the output of the earlier `varsel()` or `cv_varsel()` call). This can save a lot of time when re-running the predictive performance evaluation part multiple times based on the same search results. An illustration may be found in the updated main vignette (section ["Preliminary `cv_varsel()` run"](https://mc-stan.org/projpred/articles/projpred.html#preliminary-cv_varsel-run); a more general description may also be found in section ["Speed"](https://mc-stan.org/projpred/articles/projpred.html#speed)). (GitHub: #461, #463)
 
 # projpred 2.7.0
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -151,14 +151,10 @@ cv_varsel.default <- function(object, ...) {
 
 #' @rdname cv_varsel
 #' @export
-cv_varsel.vsel <- function(
-    object,
-    cv_method = object[["cv_method"]] %||% "LOO",
-    K = object[["K"]],
-    cvfits = object[["cvfits"]],
-    validate_search = isTRUE(object[["validate_search"]]),
-    ...
-) {
+cv_varsel.vsel <- function(object, cv_method = object$cv_method %||% "LOO",
+                           K = object$K, cvfits = object$cvfits,
+                           validate_search = isTRUE(object$validate_search),
+                           ...) {
   if (validate_search) {
     if (!identical(cv_method, object[["cv_method"]])) {
       stop("In case of `validate_search = TRUE`, cv_varsel.vsel() requires ",

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -151,10 +151,14 @@ cv_varsel.default <- function(object, ...) {
 
 #' @rdname cv_varsel
 #' @export
-cv_varsel.vsel <- function(object, cv_method = object$cv_method %||% "LOO",
-                           K = object$K, cvfits = object$cvfits,
-                           validate_search = isTRUE(object$validate_search),
-                           ...) {
+cv_varsel.vsel <- function(
+    object,
+    cv_method = object$cv_method %||% "LOO",
+    K = object$K %||% if (!inherits(object, "datafit")) 5 else 10,
+    cvfits = object$cvfits,
+    validate_search = isTRUE(object$validate_search),
+    ...
+) {
   if (validate_search) {
     if (!identical(cv_method, object[["cv_method"]])) {
       stop("In case of `validate_search = TRUE`, cv_varsel.vsel() requires ",

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -363,9 +363,7 @@ cv_varsel.refmodel <- function(
               nloo,
               K,
               validate_search,
-              cvfits = if (is.null(cvfits_was_auto)) {
-                NULL
-              } else if (cvfits_was_missing || cvfits_was_auto) {
+              cvfits = if (cvfits_was_missing || cvfits_was_auto) {
                 "auto"
               } else {
                 cvfits
@@ -411,11 +409,11 @@ parse_args_cv_varsel <- function(refmodel, cv_method, K, cvfits,
     cv_method <- "kfold"
   }
 
+  cvfits_was_auto <- identical(cvfits, "auto")
+  if (cvfits_was_auto) {
+    cvfits <- refmodel[["cvfits"]]
+  }
   if (cv_method == "kfold") {
-    cvfits_was_auto <- identical(cvfits, "auto")
-    if (cvfits_was_auto) {
-      cvfits <- refmodel[["cvfits"]]
-    }
     if (!is.null(cvfits)) {
       if (identical(names(cvfits), "fits")) {
         warning(
@@ -441,10 +439,6 @@ parse_args_cv_varsel <- function(refmodel, cv_method, K, cvfits,
       stop("`cv_method = \"kfold\"` cannot be used with ",
            "`validate_search = FALSE`.")
     }
-  } else {
-    K <- NULL
-    cvfits <- NULL
-    cvfits_was_auto <- NULL
   }
 
   return(nlist(cv_method, K, cvfits, cvfits_was_auto))

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -151,7 +151,11 @@ cv_varsel.default <- function(object, ...) {
 
 #' @rdname cv_varsel
 #' @export
-cv_varsel.vsel <- function(object, ...) {
+cv_varsel.vsel <- function(
+    object,
+    validate_search = isTRUE(object[["validate_search"]]),
+    ...
+) {
   return(cv_varsel(
     object = get_refmodel(object),
     method = object[["args_search"]][["method"]],
@@ -167,7 +171,7 @@ cv_varsel.vsel <- function(object, ...) {
     nloo = object[["nloo"]],
     K = object[["K"]],
     cvfits = object[["cvfits"]],
-    validate_search = isTRUE(object[["validate_search"]]),
+    validate_search = validate_search,
     search_out = list(search_path = object[["search_path"]],
                       ranking = ranking(object)),
     ...

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -156,7 +156,7 @@ cv_varsel.vsel <- function(
     cv_method = object$cv_method %||% "LOO",
     K = object$K %||% if (!inherits(object, "datafit")) 5 else 10,
     cvfits = object$cvfits,
-    validate_search = isTRUE(object$validate_search),
+    validate_search = object$validate_search %||% TRUE,
     ...
 ) {
   if (validate_search) {

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -267,7 +267,6 @@ cv_varsel.refmodel <- function(
   search_terms <- args$search_terms
   search_terms_was_null <- args$search_terms_was_null
   # Parse arguments specific to cv_varsel():
-  cvfits_was_missing <- missing(cvfits)
   args <- parse_args_cv_varsel(
     refmodel = refmodel, cv_method = cv_method, K = K, cvfits = cvfits,
     validate_search = validate_search
@@ -275,7 +274,6 @@ cv_varsel.refmodel <- function(
   cv_method <- args$cv_method
   K <- args$K
   cvfits <- args$cvfits
-  cvfits_was_auto <- args$cvfits_was_auto
   # Arguments specific to the search:
   opt <- nlist(lambda_min_ratio, nlambda, thresh, regul)
 
@@ -363,11 +361,7 @@ cv_varsel.refmodel <- function(
               nloo,
               K,
               validate_search,
-              cvfits = if (cvfits_was_missing || cvfits_was_auto) {
-                "auto"
-              } else {
-                cvfits
-              },
+              cvfits,
               args_search = nlist(
                 method, ndraws, nclusters, nterms_max, lambda_min_ratio,
                 nlambda, thresh, penalty,
@@ -409,10 +403,6 @@ parse_args_cv_varsel <- function(refmodel, cv_method, K, cvfits,
     cv_method <- "kfold"
   }
 
-  cvfits_was_auto <- identical(cvfits, "auto")
-  if (cvfits_was_auto) {
-    cvfits <- refmodel[["cvfits"]]
-  }
   if (cv_method == "kfold") {
     if (!is.null(cvfits)) {
       if (identical(names(cvfits), "fits")) {
@@ -441,7 +431,7 @@ parse_args_cv_varsel <- function(refmodel, cv_method, K, cvfits,
     }
   }
 
-  return(nlist(cv_method, K, cvfits, cvfits_was_auto))
+  return(nlist(cv_method, K, cvfits))
 }
 
 # PSIS-LOO CV -------------------------------------------------------------

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -153,9 +153,26 @@ cv_varsel.default <- function(object, ...) {
 #' @export
 cv_varsel.vsel <- function(
     object,
+    cv_method = object[["cv_method"]] %||% "LOO",
+    K = object[["K"]],
+    cvfits = object[["cvfits"]],
     validate_search = isTRUE(object[["validate_search"]]),
     ...
 ) {
+  if (validate_search) {
+    if (!identical(cv_method, object[["cv_method"]])) {
+      stop("In case of `validate_search = TRUE`, cv_varsel.vsel() requires ",
+           "`cv_method` to be the same as `object$cv_method`.")
+    }
+    if (!identical(K, object[["K"]])) {
+      stop("In case of `validate_search = TRUE`, cv_varsel.vsel() requires ",
+           "`K` to be the same as `object$K`.")
+    }
+    if (!identical(cvfits, object[["cvfits"]])) {
+      stop("In case of `validate_search = TRUE`, cv_varsel.vsel() requires ",
+           "`cvfits` to be the same as `object$cvfits`.")
+    }
+  }
   return(cv_varsel(
     object = get_refmodel(object),
     method = object[["args_search"]][["method"]],
@@ -167,10 +184,10 @@ cv_varsel.vsel <- function(
     thresh = object[["args_search"]][["thresh"]],
     penalty = object[["args_search"]][["penalty"]],
     search_terms = object[["args_search"]][["search_terms"]],
-    cv_method = object[["cv_method"]] %||% "LOO",
+    cv_method = cv_method,
     nloo = object[["nloo"]],
-    K = object[["K"]],
-    cvfits = object[["cvfits"]],
+    K = K,
+    cvfits = cvfits,
     validate_search = validate_search,
     search_out = list(search_path = object[["search_path"]],
                       ranking = ranking(object)),

--- a/R/methods.R
+++ b/R/methods.R
@@ -1039,9 +1039,9 @@ plot.vsel <- function(
 #'   [cv_varsel()]).
 #' @param nterms_max Maximum submodel size (number of predictor terms) for which
 #'   the performance statistics are calculated. Using `NULL` is effectively the
-#'   same as `length(ranking(object)[["fulldata"]])`. Note that `nterms_max`
-#'   does not count the intercept, so use `nterms_max = 0` for the
-#'   intercept-only model. For [plot.vsel()], `nterms_max` must be at least `1`.
+#'   same as `length(ranking(object)$fulldata)`. Note that `nterms_max` does not
+#'   count the intercept, so use `nterms_max = 0` for the intercept-only model.
+#'   For [plot.vsel()], `nterms_max` must be at least `1`.
 #' @param stats One or more character strings determining which performance
 #'   statistics (i.e., utilities or losses) to estimate based on the
 #'   observations in the evaluation (or "test") set (in case of

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -406,7 +406,12 @@ varsel.refmodel <- function(object, d_test = NULL, method = "forward",
               nloo = NULL,
               K = NULL,
               validate_search = NULL,
-              cvfits = NULL,
+              ### Not set to `NULL` because in K-fold CV (relevant when using
+              ### cv_varsel.vsel() based on this `vsel` object), `cvfits = NULL`
+              ### would mean to use `cvfun`; instead, the default should be
+              ### element `cvfits` from `refmodel`, so:
+              cvfits = refmodel$cvfits,
+              ###
               args_search = nlist(
                 method, ndraws, nclusters, nterms_max, lambda_min_ratio,
                 nlambda, thresh, penalty,

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -16,7 +16,7 @@ cv_varsel(object, ...)
   cv_method = object$cv_method \%||\% "LOO",
   K = object$K \%||\% if (!inherits(object, "datafit")) 5 else 10,
   cvfits = object$cvfits,
-  validate_search = isTRUE(object$validate_search),
+  validate_search = object$validate_search \%||\% TRUE,
   ...
 )
 

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -14,7 +14,7 @@ cv_varsel(object, ...)
 \method{cv_varsel}{vsel}(
   object,
   cv_method = object$cv_method \%||\% "LOO",
-  K = object$K,
+  K = object$K \%||\% if (!inherits(object, "datafit")) 5 else 10,
   cvfits = object$cvfits,
   validate_search = isTRUE(object$validate_search),
   ...

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -11,7 +11,14 @@ cv_varsel(object, ...)
 
 \method{cv_varsel}{default}(object, ...)
 
-\method{cv_varsel}{vsel}(object, validate_search = isTRUE(object[["validate_search"]]), ...)
+\method{cv_varsel}{vsel}(
+  object,
+  cv_method = object[["cv_method"]] \%||\% "LOO",
+  K = object[["K"]],
+  cvfits = object[["cvfits"]],
+  validate_search = isTRUE(object[["validate_search"]]),
+  ...
+)
 
 \method{cv_varsel}{refmodel}(
   object,
@@ -51,6 +58,21 @@ to \code{\link[=cv_varsel.refmodel]{cv_varsel.refmodel()}}. For \code{\link[=cv_
 the divergence minimizer (during a forward search and also during the
 evaluation part, but the latter only if \code{refit_prj} is \code{TRUE}).}
 
+\item{cv_method}{The CV method, either \code{"LOO"} or \code{"kfold"}. In the \code{"LOO"}
+case, a Pareto-smoothed importance sampling leave-one-out CV (PSIS-LOO CV)
+is performed, which avoids refitting the reference model \code{nloo} times (in
+contrast to a standard LOO CV). In the \code{"kfold"} case, a \eqn{K}-fold CV is
+performed. See also section "Note" below.}
+
+\item{K}{Only relevant if \code{cv_method = "kfold"} and if \code{cvfits} is \code{NULL}
+(which is the case for reference model objects created by
+\code{\link[=get_refmodel.stanreg]{get_refmodel.stanreg()}} or \code{\link[brms:get_refmodel.brmsfit]{brms::get_refmodel.brmsfit()}}). Number of
+folds in \eqn{K}-fold CV.}
+
+\item{cvfits}{Only relevant if \code{cv_method = "kfold"}. The same as argument
+\code{cvfits} of \code{\link[=init_refmodel]{init_refmodel()}}, but repeated here so that output from
+\code{\link[=run_cvfun]{run_cvfun()}} can be inserted here straightforwardly.}
+
 \item{validate_search}{Only relevant if \code{cv_method = "LOO"}. A single logical
 value indicating whether to cross-validate also the search part, i.e.,
 whether to run the search separately for each CV fold (\code{TRUE}) or not
@@ -65,12 +87,6 @@ number of parameters introduced by the search).}
 \item{method}{The method for the search part. Possible options are
 \code{"forward"} for forward search and \code{"L1"} for L1 search. See also section
 "Details" below.}
-
-\item{cv_method}{The CV method, either \code{"LOO"} or \code{"kfold"}. In the \code{"LOO"}
-case, a Pareto-smoothed importance sampling leave-one-out CV (PSIS-LOO CV)
-is performed, which avoids refitting the reference model \code{nloo} times (in
-contrast to a standard LOO CV). In the \code{"kfold"} case, a \eqn{K}-fold CV is
-performed. See also section "Note" below.}
 
 \item{ndraws}{Number of posterior draws used in the search part. Ignored if
 \code{nclusters} is not \code{NULL} or in case of L1 search (because L1 search always
@@ -119,15 +135,6 @@ original number of observations). Smaller values lead to faster computation
 but higher uncertainty in the evaluation part. If \code{NULL}, all observations
 are used, but for faster experimentation, one can set this to a smaller
 value.}
-
-\item{K}{Only relevant if \code{cv_method = "kfold"} and if \code{cvfits} is \code{NULL}
-(which is the case for reference model objects created by
-\code{\link[=get_refmodel.stanreg]{get_refmodel.stanreg()}} or \code{\link[brms:get_refmodel.brmsfit]{brms::get_refmodel.brmsfit()}}). Number of
-folds in \eqn{K}-fold CV.}
-
-\item{cvfits}{Only relevant if \code{cv_method = "kfold"}. The same as argument
-\code{cvfits} of \code{\link[=init_refmodel]{init_refmodel()}}, but repeated here so that output from
-\code{\link[=run_cvfun]{run_cvfun()}} can be inserted here straightforwardly.}
 
 \item{lambda_min_ratio}{Only relevant for L1 search. Ratio between the
 smallest and largest lambda in the L1-penalized search. This parameter

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -11,7 +11,7 @@ cv_varsel(object, ...)
 
 \method{cv_varsel}{default}(object, ...)
 
-\method{cv_varsel}{vsel}(object, ...)
+\method{cv_varsel}{vsel}(object, validate_search = isTRUE(object[["validate_search"]]), ...)
 
 \method{cv_varsel}{refmodel}(
   object,
@@ -50,6 +50,17 @@ well as to \code{\link[=cv_varsel.refmodel]{cv_varsel.refmodel()}}. For \code{\l
 to \code{\link[=cv_varsel.refmodel]{cv_varsel.refmodel()}}. For \code{\link[=cv_varsel.refmodel]{cv_varsel.refmodel()}}: Arguments passed to
 the divergence minimizer (during a forward search and also during the
 evaluation part, but the latter only if \code{refit_prj} is \code{TRUE}).}
+
+\item{validate_search}{Only relevant if \code{cv_method = "LOO"}. A single logical
+value indicating whether to cross-validate also the search part, i.e.,
+whether to run the search separately for each CV fold (\code{TRUE}) or not
+(\code{FALSE}). We strongly do not recommend setting this to \code{FALSE}, because
+this is known to bias the predictive performance estimates of the selected
+submodels. However, setting this to \code{FALSE} can sometimes be useful because
+comparing the results to the case where this argument is \code{TRUE} gives an
+idea of how strongly the search is (over-)fitted to the data (the
+difference corresponds to the search degrees of freedom or the effective
+number of parameters introduced by the search).}
 
 \item{method}{The method for the search part. Possible options are
 \code{"forward"} for forward search and \code{"L1"} for L1 search. See also section
@@ -135,17 +146,6 @@ computing the L1 path. Usually, there is no need to change this.}
 projecting onto (i.e., fitting) submodels which are GLMs. Usually there is
 no need for regularization, but sometimes we need to add some
 regularization to avoid numerical problems.}
-
-\item{validate_search}{Only relevant if \code{cv_method = "LOO"}. A single logical
-value indicating whether to cross-validate also the search part, i.e.,
-whether to run the search separately for each CV fold (\code{TRUE}) or not
-(\code{FALSE}). We strongly do not recommend setting this to \code{FALSE}, because
-this is known to bias the predictive performance estimates of the selected
-submodels. However, setting this to \code{FALSE} can sometimes be useful because
-comparing the results to the case where this argument is \code{TRUE} gives an
-idea of how strongly the search is (over-)fitted to the data (the
-difference corresponds to the search degrees of freedom or the effective
-number of parameters introduced by the search).}
 
 \item{seed}{Pseudorandom number generation (PRNG) seed by which the same
 results can be obtained again if needed. Passed to argument \code{seed} of

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -13,10 +13,10 @@ cv_varsel(object, ...)
 
 \method{cv_varsel}{vsel}(
   object,
-  cv_method = object[["cv_method"]] \%||\% "LOO",
-  K = object[["K"]],
-  cvfits = object[["cvfits"]],
-  validate_search = isTRUE(object[["validate_search"]]),
+  cv_method = object$cv_method \%||\% "LOO",
+  K = object$K,
+  cvfits = object$cvfits,
+  validate_search = isTRUE(object$validate_search),
   ...
 )
 

--- a/man/plot.vsel.Rd
+++ b/man/plot.vsel.Rd
@@ -31,9 +31,9 @@
 
 \item{nterms_max}{Maximum submodel size (number of predictor terms) for which
 the performance statistics are calculated. Using \code{NULL} is effectively the
-same as \code{length(ranking(object)[["fulldata"]])}. Note that \code{nterms_max}
-does not count the intercept, so use \code{nterms_max = 0} for the
-intercept-only model. For \code{\link[=plot.vsel]{plot.vsel()}}, \code{nterms_max} must be at least \code{1}.}
+same as \code{length(ranking(object)$fulldata)}. Note that \code{nterms_max} does not
+count the intercept, so use \code{nterms_max = 0} for the intercept-only model.
+For \code{\link[=plot.vsel]{plot.vsel()}}, \code{nterms_max} must be at least \code{1}.}
 
 \item{stats}{One or more character strings determining which performance
 statistics (i.e., utilities or losses) to estimate based on the

--- a/man/summary.vsel.Rd
+++ b/man/summary.vsel.Rd
@@ -23,9 +23,9 @@
 
 \item{nterms_max}{Maximum submodel size (number of predictor terms) for which
 the performance statistics are calculated. Using \code{NULL} is effectively the
-same as \code{length(ranking(object)[["fulldata"]])}. Note that \code{nterms_max}
-does not count the intercept, so use \code{nterms_max = 0} for the
-intercept-only model. For \code{\link[=plot.vsel]{plot.vsel()}}, \code{nterms_max} must be at least \code{1}.}
+same as \code{length(ranking(object)$fulldata)}. Note that \code{nterms_max} does not
+count the intercept, so use \code{nterms_max = 0} for the intercept-only model.
+For \code{\link[=plot.vsel]{plot.vsel()}}, \code{nterms_max} must be at least \code{1}.}
 
 \item{stats}{One or more character strings determining which performance
 statistics (i.e., utilities or losses) to estimate based on the

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -1969,6 +1969,7 @@ vsel_tester <- function(
     },
     seed_expected = seed_tst,
     nloo_expected = NULL,
+    K_expected = NULL,
     penalty_expected = NULL,
     search_terms_expected = NULL,
     search_trms_empty_size = FALSE,
@@ -2382,8 +2383,12 @@ vsel_tester <- function(
   expect_identical(vs$nloo, nloo_expected_orig, info = info_str)
 
   # K
-  if (identical(cv_method_expected, "kfold")) {
+  if (!is.null(K_expected)) {
+    expect_identical(vs$K, K_expected, info = info_str)
+  } else if (identical(cv_method_expected, "kfold")) {
     expect_identical(vs$K, K_tst, info = info_str)
+  } else if (with_cv) {
+    expect_identical(vs$K, if (from_datafit) 10 else 5, info = info_str)
   } else {
     expect_null(vs$K, info = info_str)
   }
@@ -2392,14 +2397,10 @@ vsel_tester <- function(
   expect_identical(vs$validate_search, valsearch_expected, info = info_str)
 
   # cvfits
-  if (!identical(cv_method_expected, "kfold")) {
-    expect_null(vs$cvfits, info = info_str)
-  } else {
-    ### Currently, we are testing argument `cvfits` only implicitly via the
-    ### examples and via the main vignette:
-    expect_identical(vs$cvfits, "auto", info = info_str)
-    ###
-  }
+  ### Currently, we are testing argument `cvfits` only implicitly via the
+  ### examples and via the main vignette:
+  expect_identical(vs$cvfits, refmod_expected$cvfits, info = info_str)
+  ###
 
   # args_search
   expect_equal(

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1915,7 +1915,7 @@ vsel_nms <- c(
   "clust_used_eval", "nprjdraws_search", "nprjdraws_eval", "projpred_version"
 )
 # Output elements of `vsel` objects that may be influenced by `cvfits`:
-vsel_nms_cvfits <- c("refmodel", "summaries", "solution_terms_cv")
+vsel_nms_cvfits <- c("refmodel", "cvfits", "summaries", "solution_terms_cv")
 vsel_nms_cvfits_opt <- c("solution_terms_cv")
 # Sub-elements of `summaries`'s `sub` and `ref` elements:
 vsel_smmrs_sub_nms <- vsel_smmrs_ref_nms <- c("mu", "lppd")

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1891,7 +1891,7 @@ test_that(paste(
     # Use suppressWarnings() because of occasional warnings concerning Pareto k
     # diagnostics:
     cvvs_eval <- suppressWarnings(cv_varsel(
-      vss[[tstsetup]], refit_prj = refit_prj_crr,
+      vss[[tstsetup]], validate_search = FALSE, refit_prj = refit_prj_crr,
       nclusters_pred = nclusters_pred_crr, verbose = FALSE, seed = seed2_tst
     ))
     tstsetup_ref <- args_vs[[tstsetup]]$tstsetup_ref

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1869,8 +1869,8 @@ test_that("cv_varsel.vsel() works for `vsel` objects from cv_varsel()", {
 })
 
 test_that(paste(
-  "cv_varsel.vsel() (internally called with `validate_search = FALSE`) works",
-  "for `vsel` objects from varsel()"
+  "cv_varsel.vsel() (with `validate_search = FALSE`) works for `vsel` objects",
+  "from varsel()"
 ), {
   skip_if_not(run_vs)
   skip_if_not(run_cvvs)

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1971,6 +1971,7 @@ test_that(paste(
       cv_method_expected = "LOO",
       valsearch_expected = FALSE,
       refit_prj_expected = FALSE,
+      K_expected = args_cvvs[[tstsetup]]$K,
       search_terms_expected = args_cvvs[[tstsetup]]$search_terms,
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&


### PR DESCRIPTION
This amends #461 by allowing the user to switch from previous search results created with `validate_search = TRUE` to a `cv_varsel.vsel()` call with `validate_search = FALSE`. Furthermore, this PR makes some preparations for allowing K-fold CV with `validate_search = FALSE` later.