### PR TITLE
Make K-fold CV with `validate_search = FALSE` possible

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 ## Major changes
 
 * Search results generated in an earlier `varsel()` or `cv_varsel()` call can now be re-used by the help of the new `varsel.vsel()` and `cv_varsel.vsel()` methods (i.e., by applying `varsel()` or `cv_varsel()` to the output of the earlier `varsel()` or `cv_varsel()` call). This can save a lot of time when re-running the predictive performance evaluation part multiple times based on the same search results. An illustration may be found in the updated main vignette (section ["Preliminary `cv_varsel()` run"](https://mc-stan.org/projpred/articles/projpred.html#preliminary-cv_varsel-run); a more general description may also be found in section ["Speed"](https://mc-stan.org/projpred/articles/projpred.html#speed)). (GitHub: #461, #463)
+* K-fold CV can now be combined with `validate_search = FALSE`. Related to this is an internal change which may cause LOO subsampling (see argument `nloo`) with clustered projection during the search (i.e., `1 < nclusters && nclusters < S`, where `S` denotes the number of posterior draws in the reference model) to yield slightly different results due to different internal pseudorandom number generator (PRNG) states. Furthermore, if `is.na(seed)`, then the PRNG state for code downstream of such a `cv_varsel()` call will be different due to this internal change. (GitHub: #464)
 
 # projpred 2.7.0
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -1173,7 +1173,8 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
   list_cv <- get_kfold(refmodel, K = K, cvfits = cvfits, verbose = verbose)
   K <- length(list_cv)
 
-  if (is.null(search_out_rk)) {
+  search_out_rk_was_null <- is.null(search_out_rk)
+  if (search_out_rk_was_null) {
     search_out_rk <- replicate(K, NULL, simplify = FALSE)
   }
 
@@ -1189,7 +1190,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
 
   if (verbose) {
     verb_txt_start <- "-----\nRunning "
-    if (!all(sapply(search_out_rk, is.null))) {
+    if (!search_out_rk_was_null) {
       verb_txt_mid <- ""
     } else {
       verb_txt_mid <- "the search and "

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -283,7 +283,7 @@ cv_varsel.refmodel <- function(
 
   # Full-data search:
   if (!is.null(search_out)) {
-    search_path_full_data <- search_out[["search_path"]]
+    search_path_fulldata <- search_out[["search_path"]]
   } else {
     verb_txt_search <- "-----\nRunning the search "
     if (validate_search) {
@@ -294,7 +294,7 @@ cv_varsel.refmodel <- function(
     }
     verb_txt_search <- paste0(verb_txt_search, "...")
     verb_out(verb_txt_search, verbose = verbose)
-    search_path_full_data <- select(
+    search_path_fulldata <- select(
       refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
       method = method, nterms_max = nterms_max, penalty = penalty,
       verbose = verbose, opt = opt, search_terms = search_terms,
@@ -323,12 +323,12 @@ cv_varsel.refmodel <- function(
       nclusters_pred = nclusters_pred, refit_prj = refit_prj, penalty = penalty,
       verbose = verbose, opt = opt, nloo = nloo,
       validate_search = validate_search,
-      search_path_full_data = if (validate_search) {
+      search_path_fulldata = if (validate_search) {
         # Not needed in this case, so for computational efficiency, avoiding
-        # passing the large object `search_path_full_data` to loo_varsel():
+        # passing the large object `search_path_fulldata` to loo_varsel():
         NULL
       } else {
-        search_path_full_data
+        search_path_fulldata
       },
       search_terms = search_terms,
       search_terms_was_null = search_terms_was_null,
@@ -346,7 +346,7 @@ cv_varsel.refmodel <- function(
   }
 
   if (validate_search) {
-    ce_out <- rep(NA_real_, length(search_path_full_data$solution_terms) + 1L)
+    ce_out <- rep(NA_real_, length(search_path_fulldata$solution_terms) + 1L)
   } else {
     ce_out <- sel_cv$ce
   }
@@ -356,8 +356,8 @@ cv_varsel.refmodel <- function(
 
   # Information about the clustering/thinning used for the search:
   refdist_info_search <- list(
-    clust_used = search_path_full_data$p_sel$clust_used,
-    nprjdraws = NCOL(search_path_full_data$p_sel$mu)
+    clust_used = search_path_fulldata$p_sel$clust_used,
+    nprjdraws = NCOL(search_path_fulldata$p_sel$mu)
   )
   # Information about the clustering/thinning used for the performance
   # evaluation:
@@ -370,8 +370,8 @@ cv_varsel.refmodel <- function(
   # The object to be returned:
   vs <- nlist(refmodel,
               nobs_train = refmodel$nobs,
-              search_path = search_path_full_data,
-              solution_terms = search_path_full_data$solution_terms,
+              search_path = search_path_fulldata,
+              solution_terms = search_path_fulldata$solution_terms,
               solution_terms_cv = sel_cv$solution_terms_cv,
               ce = ce_out,
               type_test = cv_method,
@@ -468,7 +468,7 @@ parse_args_cv_varsel <- function(refmodel, cv_method, K, cvfits,
 loo_varsel <- function(refmodel, method, nterms_max, ndraws,
                        nclusters, ndraws_pred, nclusters_pred, refit_prj,
                        penalty, verbose, opt, nloo, validate_search,
-                       search_path_full_data, search_terms,
+                       search_path_fulldata, search_terms,
                        search_terms_was_null, search_out_rk, parallel, ...) {
   ## Pre-processing ---------------------------------------------------------
 
@@ -648,7 +648,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     # Step 1: Re-project (using the full dataset) onto the submodels along the
     # full-data predictor ranking and evaluate their predictive performance.
     perf_eval_out <- perf_eval(
-      search_path = search_path_full_data, refmodel = refmodel,
+      search_path = search_path_fulldata, refmodel = refmodel,
       regul = opt$regul, refit_prj = refit_prj, ndraws = ndraws_pred,
       nclusters = nclusters_pred, return_p_ref = TRUE, return_preds = TRUE,
       indices_test = inds, ...
@@ -801,7 +801,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     # This re-weighting requires a re-normalization (as.array() is applied to
     # have stricter consistency checks, see `?sweep`):
     lw_sub <- sweep(lw_sub, 2, as.array(apply(lw_sub, 2, log_sum_exp)))
-    for (k in seq_len(1 + length(search_path_full_data$solution_terms))) {
+    for (k in seq_len(1 + length(search_path_fulldata$solution_terms))) {
       # TODO: For consistency, replace `k` in this `for` loop by `j`.
       mu_k <- perf_eval_out[["mu_by_size"]][[k]]
       log_lik_sub <- perf_eval_out[["lppd_by_size"]][[k]]
@@ -854,7 +854,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     }
     verb_out("-----", verbose = verbose)
     # Needed for cutting off post-processed results later:
-    prv_len_soltrms <- length(search_path_full_data$solution_terms)
+    prv_len_soltrms <- length(search_path_fulldata$solution_terms)
   } else {
     ## Case `validate_search = TRUE` ------------------------------------------
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -318,7 +318,13 @@ cv_varsel.refmodel <- function(
         search_path_full_data
       },
       search_terms = search_terms,
-      search_terms_was_null = search_terms_was_null, search_out = search_out,
+      search_terms_was_null = search_terms_was_null,
+      search_out_rk = if (validate_search) {
+        search_out[["ranking"]][["foldwise"]]
+      } else {
+        # Not needed in this case, so pass `NULL` to make this clear:
+        NULL
+      },
       parallel = parallel, ...
     )
   } else if (cv_method == "kfold") {
@@ -457,7 +463,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
                        nclusters, ndraws_pred, nclusters_pred, refit_prj,
                        penalty, verbose, opt, nloo, validate_search,
                        search_path_full_data, search_terms,
-                       search_terms_was_null, search_out, parallel, ...) {
+                       search_terms_was_null, search_out_rk, parallel, ...) {
   ## Pre-processing ---------------------------------------------------------
 
   has_grp <- formula_contains_group_terms(refmodel$formula)
@@ -845,9 +851,6 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     prv_len_soltrms <- length(search_path_full_data$solution_terms)
   } else {
     ## Case `validate_search = TRUE` ------------------------------------------
-
-    search_out_rk <- search_out[["ranking"]][["foldwise"]]
-    rm(search_out)
 
     if (is.null(search_out_rk)) {
       cl_sel <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)$cl

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -858,7 +858,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   } else {
     ## Case `validate_search = TRUE` ------------------------------------------
 
-    if (is.null(search_out_rk)) {
+    search_out_rk_was_null <- is.null(search_out_rk)
+    if (search_out_rk_was_null) {
       cl_sel <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)$cl
     }
     if (refit_prj) {
@@ -868,7 +869,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
 
     if (verbose) {
       verb_txt_start <- "-----\nRunning "
-      if (!is.null(search_out_rk)) {
+      if (!search_out_rk_was_null) {
         verb_txt_mid <- ""
       } else {
         verb_txt_mid <- "the search and "
@@ -887,7 +888,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       # *reweighted* fitted response values from the reference model act as
       # artifical response values in the projection (or L1-penalized
       # projection)):
-      if (!is.null(search_out_rk)) {
+      if (!search_out_rk_was_null) {
         search_path <- list(solution_terms = search_out_rk[[run_index]])
       } else {
         search_path <- select(
@@ -1204,7 +1205,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
                          getOption("projpred.extra_verbose", FALSE),
                        ...) {
     # Run the search for the current fold:
-    if (!is.null(rk)) {
+    if (!search_out_rk_was_null) {
       search_path <- list(solution_terms = rk)
     } else {
       search_path <- select(

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -73,16 +73,16 @@ folds in \eqn{K}-fold CV.}
 \code{cvfits} of \code{\link[=init_refmodel]{init_refmodel()}}, but repeated here so that output from
 \code{\link[=run_cvfun]{run_cvfun()}} can be inserted here straightforwardly.}
 
-\item{validate_search}{Only relevant if \code{cv_method = "LOO"}. A single logical
-value indicating whether to cross-validate also the search part, i.e.,
-whether to run the search separately for each CV fold (\code{TRUE}) or not
-(\code{FALSE}). We strongly do not recommend setting this to \code{FALSE}, because
-this is known to bias the predictive performance estimates of the selected
-submodels. However, setting this to \code{FALSE} can sometimes be useful because
-comparing the results to the case where this argument is \code{TRUE} gives an
-idea of how strongly the search is (over-)fitted to the data (the
-difference corresponds to the search degrees of freedom or the effective
-number of parameters introduced by the search).}
+\item{validate_search}{A single logical value indicating whether to
+cross-validate also the search part, i.e., whether to run the search
+separately for each CV fold (\code{TRUE}) or not (\code{FALSE}). We strongly do not
+recommend setting this to \code{FALSE}, because this is known to bias the
+predictive performance estimates of the selected submodels. However,
+setting this to \code{FALSE} can sometimes be useful because comparing the
+results to the case where this argument is \code{TRUE} gives an idea of how
+strongly the search is (over-)fitted to the data (the difference
+corresponds to the search degrees of freedom or the effective number of
+parameters introduced by the search).}
 
 \item{method}{The method for the search part. Possible options are
 \code{"forward"} for forward search and \code{"L1"} for L1 search. See also section

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -852,6 +852,11 @@ seed3_tst <- 1208499
 
 nclusters_tst <- 2L
 nclusters_pred_tst <- 3L
+### Later, we will subtract 1L and still wish to have `nclusters_pred >= 2` in
+### order to differentiate this from `nclusters_pred == 1` which is more or less
+### a special case:
+stopifnot(nclusters_pred_tst >= 3)
+###
 if (!run_more) {
   ndr_ncl_pred_tst <- list()
 } else {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1214,14 +1214,11 @@ if (run_cvvs) {
     }
     lapply(meth, function(meth_i) {
       lapply(cvmeth, function(cvmeth_i) {
-        if (!run_valsearch_always &&
+        if (!identical(meth_i$method, "L1") && !run_valsearch_always &&
             (!prj_crr %in% c("latent", "augdat", "trad_compare") ||
              (prj_crr %in% c("latent", "augdat", "trad_compare") &&
-              !run_valsearch_aug_lat)) &&
-            !identical(meth_i$method, "L1")) {
-          # These are cases with forward search and `!run_valsearch_always`
-          # where we want to save time by using `validate_search = FALSE`:
-          meth_i <- c(meth_i, list(validate_search = FALSE))
+              !run_valsearch_aug_lat))) {
+          cvmeth_i <- c(cvmeth_i, list(validate_search = FALSE))
         }
         search_trms <- search_trms_tst["default_search_trms"]
         lapply(search_trms, function(search_trms_i) {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1214,16 +1214,13 @@ if (run_cvvs) {
     }
     lapply(meth, function(meth_i) {
       lapply(cvmeth, function(cvmeth_i) {
-        if (!run_valsearch_always && !identical(cvmeth_i$cv_method, "kfold") &&
-            # Handle augmented-data and corresponding traditional projection:
+        if (!run_valsearch_always &&
             (!prj_crr %in% c("latent", "augdat", "trad_compare") ||
              (prj_crr %in% c("latent", "augdat", "trad_compare") &&
               !run_valsearch_aug_lat)) &&
-            # Forward search:
             !identical(meth_i$method, "L1")) {
-          # These are cases with forward search, LOO CV, and
-          # `!run_valsearch_always` where we want to save time by using
-          # `validate_search = FALSE`:
+          # These are cases with forward search and `!run_valsearch_always`
+          # where we want to save time by using `validate_search = FALSE`:
           meth_i <- c(meth_i, list(validate_search = FALSE))
         }
         search_trms <- search_trms_tst["default_search_trms"]

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1309,6 +1309,12 @@ test_that("`refit_prj` works", {
   }
   for (tstsetup in tstsetups) {
     args_cvvs_i <- args_cvvs[[tstsetup]]
+    if (identical(args_cvvs_i$cv_method, "kfold") &&
+        isFALSE(args_cvvs_i$validate_search)) {
+      # K-fold CV with `validate_search = FALSE` does not allow to specify
+      # `refit_prj = FALSE`:
+      next
+    }
     args_cvvs_i$refit_prj <- FALSE
     cvvs_reuse <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]]),

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1154,7 +1154,7 @@ test_that("varsel.vsel() works for `vsel` objects from cv_varsel()", {
       next
     } else if (run_more && tstsetup_counter > 0L) {
       refit_prj_crr <- TRUE
-      nclusters_pred_crr <- args_cvvs[[tstsetup]]$nclusters_pred + 1L
+      nclusters_pred_crr <- args_cvvs[[tstsetup]]$nclusters_pred - 1L
     } else {
       refit_prj_crr <- FALSE
       nclusters_pred_crr <- args_cvvs[[tstsetup]]$nclusters_pred
@@ -1828,7 +1828,7 @@ test_that("cv_varsel.vsel() works for `vsel` objects from cv_varsel()", {
   for (tstsetup in tstsetups) {
     refit_prj_crr <- !identical(args_cvvs[[tstsetup]]$validate_search, FALSE) ||
       identical(args_cvvs[[tstsetup]]$cv_method, "kfold")
-    nclusters_pred_crr <- nclusters_pred_tst + if (refit_prj_crr) 1L else 0L
+    nclusters_pred_crr <- nclusters_pred_tst - if (refit_prj_crr) 1L else 0L
     # Use suppressWarnings() because of occasional warnings concerning Pareto k
     # diagnostics:
     cvvs_eval <- suppressWarnings(cv_varsel(
@@ -1874,7 +1874,7 @@ test_that(paste(
       next
     } else if (run_more && tstsetup_counter > 0L) {
       refit_prj_crr <- TRUE
-      nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred + 1L
+      nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred - 1L
     } else {
       refit_prj_crr <- FALSE
       nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred
@@ -1936,7 +1936,7 @@ test_that(paste(
     if (!run_more && tstsetup_counter > 0L) {
       next
     } else if (run_more && tstsetup_counter > 0L) {
-      nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred + 1L
+      nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred - 1L
     } else {
       nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred
     }
@@ -2047,7 +2047,7 @@ test_that(paste(
       # rstanarm::stan_polr() fits, see rstanarm issue stan-dev/rstanarm#564:
       next
     }
-    nclusters_pred_crr <- args_cvvs[[tstsetup]]$nclusters_pred + 1L
+    nclusters_pred_crr <- args_cvvs[[tstsetup]]$nclusters_pred - 1L
     # Use suppressWarnings() because of occasional warnings concerning Pareto k
     # diagnostics:
     if (identical(args_cvvs[[tstsetup]]$cv_method, "kfold")) {

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1830,7 +1830,8 @@ test_that("cv_varsel.vsel() works for `vsel` objects from cv_varsel()", {
     tstsetups <- head(tstsetups, 1)
   }
   for (tstsetup in tstsetups) {
-    refit_prj_crr <- !identical(args_cvvs[[tstsetup]]$validate_search, FALSE)
+    refit_prj_crr <- !identical(args_cvvs[[tstsetup]]$validate_search, FALSE) ||
+      identical(args_cvvs[[tstsetup]]$cv_method, "kfold")
     nclusters_pred_crr <- nclusters_pred_tst + if (refit_prj_crr) 1L else 0L
     # Use suppressWarnings() because of occasional warnings concerning Pareto k
     # diagnostics:
@@ -1923,6 +1924,59 @@ test_that(paste(
 })
 
 test_that(paste(
+  "cv_varsel.vsel() with K-fold CV (and with `validate_search = FALSE`) works",
+  "for `vsel` objects from varsel()"
+), {
+  skip_if_not(run_vs)
+  skip_if_not(run_cvvs)
+  tstsetup_counter <- 0L
+  for (tstsetup in names(vss)) {
+    tstsetup_ref <- args_vs[[tstsetup]]$tstsetup_ref
+    if (grepl("\\.with_wobs", tstsetup_ref) &&
+        args_vs[[tstsetup]]$pkg_nm == "rstanarm") {
+      # Currently, rstanarm:::kfold.stanreg() doesn't support observation
+      # weights:
+      next
+    } else if (args_vs[[tstsetup]]$fam_nm == "cumul" &&
+               args_vs[[tstsetup]]$pkg_nm == "rstanarm") {
+      # Currently, rstanarm:::kfold.stanreg() doesn't work for
+      # rstanarm::stan_polr() fits, see rstanarm issue stan-dev/rstanarm#564:
+      next
+    }
+    if (!run_more && tstsetup_counter > 0L) {
+      next
+    } else if (run_more && tstsetup_counter > 0L) {
+      nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred + 1L
+    } else {
+      nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred
+    }
+    # Use suppressWarnings() because of occasional warnings concerning Pareto k
+    # diagnostics:
+    cvvs_eval <- suppressWarnings(cv_varsel(
+      vss[[tstsetup]], cv_method = "kfold", K = K_tst, validate_search = FALSE,
+      nclusters_pred = nclusters_pred_crr, verbose = FALSE, seed = seed2_tst
+    ))
+    meth_exp_crr <- args_vs[[tstsetup]]$method %||% "forward"
+    vsel_tester(
+      cvvs_eval,
+      with_cv = TRUE,
+      refmod_expected = refmods[[tstsetup_ref]],
+      solterms_len_expected = args_vs[[tstsetup]]$nterms_max,
+      method_expected = meth_exp_crr,
+      cv_method_expected = "kfold",
+      valsearch_expected = FALSE,
+      nprjdraws_eval_expected = nclusters_pred_crr,
+      search_terms_expected = args_vs[[tstsetup]]$search_terms,
+      search_trms_empty_size =
+        length(args_vs[[tstsetup]]$search_terms) &&
+        all(grepl("\\+", args_vs[[tstsetup]]$search_terms)),
+      info_str = tstsetup
+    )
+    tstsetup_counter <- tstsetup_counter + 1L
+  }
+})
+
+test_that(paste(
   "cv_varsel.vsel() with `validate_search = FALSE` and PSIS-LOO CV works for",
   "`vsel` objects from cv_varsel() created with `validate_search = TRUE`"
 ), {
@@ -1977,6 +2031,125 @@ test_that(paste(
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
       extra_tol = extra_tol_crr,
+      info_str = tstsetup
+    )
+  }
+})
+
+test_that(paste(
+  "cv_varsel.vsel() with `validate_search = FALSE` and K-fold CV works for",
+  "`vsel` objects from cv_varsel() created with `validate_search = TRUE`"
+), {
+  skip_if_not(run_cvvs)
+  tstsetups <- names(cvvss)
+  if (!run_more) {
+    tstsetups <- head(tstsetups, 1)
+  }
+  for (tstsetup in tstsetups) {
+    tstsetup_ref <- args_cvvs[[tstsetup]]$tstsetup_ref
+    if (isFALSE(args_cvvs[[tstsetup]]$validate_search)) {
+      next
+    } else if (grepl("\\.with_wobs", tstsetup_ref) &&
+               args_cvvs[[tstsetup]]$pkg_nm == "rstanarm") {
+      # Currently, rstanarm:::kfold.stanreg() doesn't support observation
+      # weights:
+      next
+    } else if (args_cvvs[[tstsetup]]$fam_nm == "cumul" &&
+               args_cvvs[[tstsetup]]$pkg_nm == "rstanarm") {
+      # Currently, rstanarm:::kfold.stanreg() doesn't work for
+      # rstanarm::stan_polr() fits, see rstanarm issue stan-dev/rstanarm#564:
+      next
+    }
+    nclusters_pred_crr <- args_cvvs[[tstsetup]]$nclusters_pred + 1L
+    # Use suppressWarnings() because of occasional warnings concerning Pareto k
+    # diagnostics:
+    if (identical(args_cvvs[[tstsetup]]$cv_method, "kfold")) {
+      cvvs_eval <- suppressWarnings(cv_varsel(
+        cvvss[[tstsetup]], validate_search = FALSE,
+        nclusters_pred = nclusters_pred_crr, verbose = FALSE, seed = seed2_tst
+      ))
+    } else {
+      cvvs_eval <- suppressWarnings(cv_varsel(
+        cvvss[[tstsetup]], cv_method = "kfold", K = K_tst,
+        validate_search = FALSE, nclusters_pred = nclusters_pred_crr,
+        verbose = FALSE, seed = seed2_tst
+      ))
+    }
+    meth_exp_crr <- args_cvvs[[tstsetup]]$method %||% "forward"
+    vsel_tester(
+      cvvs_eval,
+      with_cv = TRUE,
+      refmod_expected = refmods[[tstsetup_ref]],
+      solterms_len_expected = args_cvvs[[tstsetup]]$nterms_max,
+      method_expected = meth_exp_crr,
+      cv_method_expected = "kfold",
+      valsearch_expected = FALSE,
+      K_expected = K_tst,
+      nprjdraws_eval_expected = nclusters_pred_crr,
+      search_terms_expected = args_cvvs[[tstsetup]]$search_terms,
+      search_trms_empty_size =
+        length(args_cvvs[[tstsetup]]$search_terms) &&
+        all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
+      info_str = tstsetup
+    )
+  }
+})
+
+test_that(paste(
+  "switching the CV method in cv_varsel.vsel() works for `vsel` objects from",
+  "cv_varsel() created with `validate_search = FALSE`"
+), {
+  skip_if_not(run_cvvs)
+  tstsetups <- names(cvvss)
+  if (!run_more) {
+    tstsetups <- head(tstsetups, 1)
+  }
+  for (tstsetup in tstsetups) {
+    tstsetup_ref <- args_cvvs[[tstsetup]]$tstsetup_ref
+    if (!isFALSE(args_cvvs[[tstsetup]]$validate_search)) {
+      next
+    } else if (grepl("\\.with_wobs", tstsetup_ref) &&
+               args_cvvs[[tstsetup]]$pkg_nm == "rstanarm") {
+      # Currently, rstanarm:::kfold.stanreg() doesn't support observation
+      # weights:
+      next
+    } else if (args_cvvs[[tstsetup]]$fam_nm == "cumul" &&
+               args_cvvs[[tstsetup]]$pkg_nm == "rstanarm") {
+      # Currently, rstanarm:::kfold.stanreg() doesn't work for
+      # rstanarm::stan_polr() fits, see rstanarm issue stan-dev/rstanarm#564:
+      next
+    }
+    nclusters_pred_crr <- args_cvvs[[tstsetup]]$nclusters_pred - 1L
+    # Use suppressWarnings() because of occasional warnings concerning Pareto k
+    # diagnostics:
+    if (identical(args_cvvs[[tstsetup]]$cv_method, "kfold")) {
+      cv_meth_crr <- "LOO"
+      cvvs_eval <- suppressWarnings(cv_varsel(
+        cvvss[[tstsetup]], cv_method = cv_meth_crr,
+        nclusters_pred = nclusters_pred_crr, verbose = FALSE, seed = seed2_tst
+      ))
+    } else {
+      cv_meth_crr <- "kfold"
+      cvvs_eval <- suppressWarnings(cv_varsel(
+        cvvss[[tstsetup]], cv_method = cv_meth_crr, K = K_tst,
+        nclusters_pred = nclusters_pred_crr, verbose = FALSE, seed = seed2_tst
+      ))
+    }
+    meth_exp_crr <- args_cvvs[[tstsetup]]$method %||% "forward"
+    vsel_tester(
+      cvvs_eval,
+      with_cv = TRUE,
+      refmod_expected = refmods[[tstsetup_ref]],
+      solterms_len_expected = args_cvvs[[tstsetup]]$nterms_max,
+      method_expected = meth_exp_crr,
+      cv_method_expected = cv_meth_crr,
+      valsearch_expected = FALSE,
+      K_expected = if (cv_meth_crr == "LOO") K_tst else NULL,
+      nprjdraws_eval_expected = nclusters_pred_crr,
+      search_terms_expected = args_cvvs[[tstsetup]]$search_terms,
+      search_trms_empty_size =
+        length(args_cvvs[[tstsetup]]$search_terms) &&
+        all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
       info_str = tstsetup
     )
   }

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1119,9 +1119,6 @@ test_that("varsel.vsel() works for `vsel` objects from varsel()", {
     vs_eval <- varsel(vss[[tstsetup]], refit_prj = FALSE, verbose = FALSE,
                       seed = seed2_tst)
     tstsetup_ref <- args_vs[[tstsetup]]$tstsetup_ref
-    mod_crr <- args_vs[[tstsetup]]$mod_nm
-    fam_crr <- args_vs[[tstsetup]]$fam_nm
-    prj_crr <- args_vs[[tstsetup]]$prj_nm
     meth_exp_crr <- args_vs[[tstsetup]]$method %||% "forward"
     extra_tol_crr <- 1.1
     if (meth_exp_crr == "L1" &&
@@ -1162,7 +1159,6 @@ test_that("varsel.vsel() works for `vsel` objects from cv_varsel()", {
       refit_prj_crr <- FALSE
       nclusters_pred_crr <- args_cvvs[[tstsetup]]$nclusters_pred
     }
-    mod_crr <- args_cvvs[[tstsetup]]$mod_nm
     fam_crr <- args_cvvs[[tstsetup]]$fam_nm
     prj_crr <- args_cvvs[[tstsetup]]$prj_nm
     if (refit_prj_crr && prj_crr == "augdat" && fam_crr == "cumul") {
@@ -1840,9 +1836,6 @@ test_that("cv_varsel.vsel() works for `vsel` objects from cv_varsel()", {
       nclusters_pred = nclusters_pred_crr, verbose = FALSE, seed = seed2_tst
     ))
     tstsetup_ref <- args_cvvs[[tstsetup]]$tstsetup_ref
-    mod_crr <- args_cvvs[[tstsetup]]$mod_nm
-    fam_crr <- args_cvvs[[tstsetup]]$fam_nm
-    prj_crr <- args_cvvs[[tstsetup]]$prj_nm
     meth_exp_crr <- args_cvvs[[tstsetup]]$method %||% "forward"
     vsel_tester(
       cvvs_eval,
@@ -1886,9 +1879,6 @@ test_that(paste(
       refit_prj_crr <- FALSE
       nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred
     }
-    mod_crr <- args_vs[[tstsetup]]$mod_nm
-    fam_crr <- args_vs[[tstsetup]]$fam_nm
-    prj_crr <- args_vs[[tstsetup]]$prj_nm
     # Use suppressWarnings() because of occasional warnings concerning Pareto k
     # diagnostics:
     cvvs_eval <- suppressWarnings(cv_varsel(
@@ -2003,9 +1993,6 @@ test_that(paste(
       ))
     }
     tstsetup_ref <- args_cvvs[[tstsetup]]$tstsetup_ref
-    mod_crr <- args_cvvs[[tstsetup]]$mod_nm
-    fam_crr <- args_cvvs[[tstsetup]]$fam_nm
-    prj_crr <- args_cvvs[[tstsetup]]$prj_nm
     meth_exp_crr <- args_cvvs[[tstsetup]]$method %||% "forward"
     extra_tol_crr <- 1.1
     if (meth_exp_crr == "L1" &&

--- a/vignettes/projpred.Rmd
+++ b/vignettes/projpred.Rmd
@@ -119,7 +119,7 @@ The evaluation part determines the predictive performance of the increasingly co
 
 There are two functions for running the combination of search and evaluation: `varsel()` and `cv_varsel()`.
 In contrast to `varsel()`, `cv_varsel()` performs a cross-validation (CV). With `cv_method = "LOO"` (the default), `cv_varsel()` runs a Pareto-smoothed importance sampling leave-one-out CV [PSIS-LOO CV, see @vehtari_practical_2017; @vehtari_pareto_2022]. With `cv_method = "kfold"`, `cv_varsel()` runs a $K$-fold CV. The extent of the CV depends on `cv_varsel()`'s argument `validate_search`: If `validate_search = TRUE` (the default), the search part is run with the training data of each CV fold separately and the evaluation part is run with the corresponding test data of each CV fold.
-If `validate_search = FALSE` (which is currently only available for `cv_method = "LOO"`), the search is excluded from the CV so that only a single full-data search is run.
+If `validate_search = FALSE`, the search is excluded from the CV so that only a single full-data search is run.
 Because of its most thorough protection against overfitting^[Currently, neither `varsel()` nor `cv_varsel()` (not even `cv_varsel()` with `validate_search = TRUE`) guard against overfitting in the selection of the submodel *size*. This is why we added "approximately" to "valid post-selection inference" in section ["Introduction"](#intro). Typically, however, the overfitting induced by the size selection should be comparatively small [@piironen_comparison_2017].], `cv_varsel()` with `validate_search = TRUE` is recommended over `varsel()` and `cv_varsel()` with `validate_search = FALSE`.
 Nonetheless, a preliminary and comparatively fast run of `varsel()` or `cv_varsel()` with `validate_search = FALSE` can give a rough idea of the performance of the submodels and can be used for finding a suitable value for argument `nterms_max` in subsequent runs (argument `nterms_max` imposes a limit on the submodel size up to which the search is continued and is thus able to reduce the runtime considerably).
 
@@ -184,8 +184,8 @@ Here, we skip this for the sake of brevity and instead head over to the final `c
 
 ### Final `cv_varsel()` run
 
-For this final `cv_varsel()` run, we use a $K$-fold CV with a small number of folds (`K = 2`) to make this vignette build faster.
-In practice, we recommend using either the default of `cv_method = "LOO"` (with `validate_search = TRUE`) or a larger value for `K` if this is possible in terms of computation time.
+For this final `cv_varsel()` run (with `validate_search = TRUE`, as recommended), we use a $K$-fold CV with a small number of folds (`K = 2`) to make this vignette build faster.
+In practice, we recommend using either the default of `cv_method = "LOO"` or a larger value for `K` if this is possible in terms of computation time.
 <!-- For the sake of speed, we also set `nclusters_pred` to a comparatively low value of `20`. Furthermore, we illustrate -->
 Here, we also perform the $K$ reference model refits outside of `cv_varsel()`.
 Although not strictly necessary here, this is helpful in practice because often, `cv_varsel()` needs to be re-run multiple times in order to try out different argument settings.
@@ -544,11 +544,11 @@ According to the simulation-based case study from [#353](https://github.com/stan
 There are many ways to speed up **projpred**, but in general, such speed-ups lead to results that are less accurate and hence should only be considered as *preliminary* results.
 Some speed-up possibilities are:
 
-1.  Using `cv_varsel()` with `validate_search = FALSE` (which requires `cv_method = "LOO"`) instead of `validate_search = TRUE`.
-    This approach (`cv_varsel()` with `validate_search = FALSE`) has comparable runtime to `varsel()`, but accounts for some overfitting, namely that induced by `varsel()`'s in-sample predictions during the predictive performance evaluation.
+1.  Using `cv_varsel()` with `validate_search = FALSE` instead of `validate_search = TRUE`.
+    In case of `cv_method = "LOO"`^[In case of `cv_method = "kfold"`, the runtime advantage of `validate_search = FALSE` compared to `validate_search = TRUE` is not as large as in case of `cv_method = "LOO"`, but even for `cv_method = "kfold"`, such a runtime advantage still exists.], `cv_varsel()` with `validate_search = FALSE` has comparable runtime to `varsel()`, but accounts for some overfitting, namely that induced by `varsel()`'s in-sample predictions during the predictive performance evaluation.
     However, as explained in section ["Variable selection"](#variableselection) (see also section ["Overfitting"](#overfitting)), `cv_varsel()` with `validate_search = FALSE` is more prone to overfitting than `cv_varsel()` with `validate_search = TRUE`.
 
-1.  Using `cv_varsel()` with $K$-fold CV instead of PSIS-LOO CV (with `validate_search = TRUE`).
+1.  Using `cv_varsel()` with $K$-fold CV instead of PSIS-LOO CV.
     Whether this provides a speed improvement mainly depends on the number of observations and the complexity of the reference model.
     Note that PSIS-LOO CV is often more accurate than $K$-fold CV if argument `K` is (much) smaller than the number of observations.
 


### PR DESCRIPTION
This makes it possible to use K-fold CV with `validate_search = FALSE`. In order to implement this, it was easier to perform some refactoring first (commits be9b149dc9237ea0963f430ba6379aaf3e9a4c91 to 6a626c356cf7c8008de5c5e003b83d2d94e33b98) instead of relying on more "hacky" solutions.