### PR TITLE
`plot.vsel()`: Add title and subtitle

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 ## Minor changes
 
 * In `as.matrix.projection()`, `nm_scheme = "auto"` is deprecated. Please use `nm_scheme = NULL` instead.
+* The plot produced by `plot.vsel()` now includes a title and a subtitle, with the subtitle mentioning the nominal coverage as well as the type of the confidence intervals explicitly. (GitHub: #468)
 
 ## Bug fixes
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -998,11 +998,21 @@ plot.vsel <- function(
     #                        direction = 1)
     ###
   }
+  if (all(stats %in% c("rmse", "auc"))) {
+    ci_type <- "bootstrap "
+  } else if (all(!stats %in% c("rmse", "auc"))) {
+    ci_type <- "normal approximation "
+  } else {
+    ci_type <- ""
+  }
   pp <- pp +
     scale_x_continuous(breaks = breaks, minor_breaks = minor_breaks,
                        limits = c(min(breaks), max(breaks)),
                        labels = tick_labs_x) +
-    labs(x = xlab, y = ylab) +
+    labs(x = xlab, y = ylab, title = "Predictive performance",
+         subtitle = paste0("Vertical bars indicate ",
+                           round(100 * (1 - alpha), 1), "% ", ci_type,
+                           "confidence intervals")) +
     theme(axis.text.x = element_text(angle = text_angle, hjust = 0.5,
                                      vjust = 0.5)) +
     facet_grid(statistic ~ ., scales = "free_y")


### PR DESCRIPTION
This adds a title and a subtitle to the plot produced by `plot.vsel()`, with the subtitle mentioning the nominal coverage as well as the type of the confidence intervals (CIs) explicitly.

The hope is that there will be less confusion about these CIs (in particular, whether these are "+/- 1 SE" or "+/- 2 SE" CIs; in general, they are neither of these two: only in case of the normal approximation, we can say that the default (due to `alpha = 2 * pnorm(-1)`) are "+/- 1 SE" CIs).

Illustration:
```r
data("df_gaussian", package = "projpred")
dat <- data.frame(y = df_gaussian$y, df_gaussian$x)
library(rstanarm)
rfit <- stan_glm(y ~ X1 + X2 + X3 + X4 + X5,
                 data = dat,
                 chains = 1,
                 iter = 500,
                 seed = 1140350788,
                 refresh = 0)
devtools::load_all(".")
vs <- varsel(rfit,
             nclusters = 3,
             nclusters_pred = 5,
             nterms_max = 4,
             seed = 46782345)
plot(vs)
plot(vs, alpha = 0.05)
plot(vs, alpha = 0.05, stats = "rmse")
plot(vs, alpha = 0.05, stats = c("mlpd", "rmse"))

```
produces the following plots (in this order):

![vs](https://github.com/stan-dev/projpred/assets/55132727/2990422c-b73a-4f02-80c6-70d3ee0ef6da)
![vs95](https://github.com/stan-dev/projpred/assets/55132727/f2ef4aab-e683-4600-9c4d-1b52369e3be9)
![vs95_rmse](https://github.com/stan-dev/projpred/assets/55132727/68e979c3-997e-47dd-85e6-65c6be992bea)
![vs_mlpd_rmse](https://github.com/stan-dev/projpred/assets/55132727/3499aaa7-0bd1-41bd-a1ff-ddabd7582e50)
