### PR TITLE
`plot.vsel()`: Allow omitting the CV ranking proportions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 * In `as.matrix.projection()`, `nm_scheme = "auto"` is deprecated. Please use `nm_scheme = NULL` instead.
 * The plot produced by `plot.vsel()` now includes a title and a subtitle, with the subtitle mentioning the nominal coverage as well as the type of the confidence intervals (CIs) explicitly. However, in case of a facetted plot (i.e., if multiple `stats` are specified) and some `stats` implying a different CI type than other `stats`, the CI type is omitted (because mentioning it would make the subtitle too complicated). (GitHub: #468)
+* `plot.vsel()` has gained a new argument `show_cv_proportions`, allowing to omit the CV ranking proportions. (GitHub: #470)
 
 ## Bug fixes
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -649,13 +649,17 @@ proj_predict_aux <- function(proj, newdata, offset, weights,
 #'   respectively.
 #' @param ranking_colored A single logical value indicating whether the points
 #'   and the uncertainty bars should be gradient-colored according to the CV
-#'   ranking proportions (`TRUE`) or not (`FALSE`). The CV ranking proportions
-#'   may be cumulated (see argument `cumulate`). Note that the point and the
+#'   ranking proportions (`TRUE`, currently only works if `show_cv_proportions`
+#'   is `TRUE` as well) or not (`FALSE`). The CV ranking proportions may be
+#'   cumulated (see argument `cumulate`). Note that the point and the
 #'   uncertainty bar at submodel size 0 (i.e., at the intercept-only model) are
 #'   always colored in gray because the intercept is forced to be selected
 #'   before any predictors are selected (in other words, the reason is that for
 #'   submodel size 0, the question of variability across CV folds is not
 #'   appropriate in the first place).
+#' @param show_cv_proportions A single logical value indicating whether the CV
+#'   ranking proportions (see [cv_proportions()]) should be displayed (`TRUE`)
+#'   or not (`FALSE`).
 #' @param cumulate Passed to argument `cumulate` of [cv_proportions()]. Affects
 #'   the ranking proportions given on the x-axis (below the full-data predictor
 #'   ranking).
@@ -720,6 +724,7 @@ plot.vsel <- function(
     ranking_repel = NULL,
     ranking_repel_args = list(),
     ranking_colored = FALSE,
+    show_cv_proportions = TRUE,
     cumulate = FALSE,
     text_angle = NULL,
     ...
@@ -837,6 +842,9 @@ plot.vsel <- function(
   if (!is.na(ranking_nterms_max)) {
     # Predictor ranking(s):
     rk <- ranking(object, nterms_max = ranking_nterms_max)
+    if (!show_cv_proportions) {
+      rk["foldwise"] <- list(NULL)
+    }
     if (!is.null(rk[["foldwise"]])) {
       pr_rk <- diag(cv_proportions(rk, cumulate = cumulate))
     } else {

--- a/man/plot.vsel.Rd
+++ b/man/plot.vsel.Rd
@@ -21,6 +21,7 @@
   ranking_repel = NULL,
   ranking_repel_args = list(),
   ranking_colored = FALSE,
+  show_cv_proportions = TRUE,
   cumulate = FALSE,
   text_angle = NULL,
   ...
@@ -124,13 +125,18 @@ respectively.}
 
 \item{ranking_colored}{A single logical value indicating whether the points
 and the uncertainty bars should be gradient-colored according to the CV
-ranking proportions (\code{TRUE}) or not (\code{FALSE}). The CV ranking proportions
-may be cumulated (see argument \code{cumulate}). Note that the point and the
+ranking proportions (\code{TRUE}, currently only works if \code{show_cv_proportions}
+is \code{TRUE} as well) or not (\code{FALSE}). The CV ranking proportions may be
+cumulated (see argument \code{cumulate}). Note that the point and the
 uncertainty bar at submodel size 0 (i.e., at the intercept-only model) are
 always colored in gray because the intercept is forced to be selected
 before any predictors are selected (in other words, the reason is that for
 submodel size 0, the question of variability across CV folds is not
 appropriate in the first place).}
+
+\item{show_cv_proportions}{A single logical value indicating whether the CV
+ranking proportions (see \code{\link[=cv_proportions]{cv_proportions()}}) should be displayed (\code{TRUE})
+or not (\code{FALSE}).}
 
 \item{cumulate}{Passed to argument \code{cumulate} of \code{\link[=cv_proportions]{cv_proportions()}}. Affects
 the ranking proportions given on the x-axis (below the full-data predictor


### PR DESCRIPTION
This adds an argument `show_cv_proportions` to `plot.vsel()`, allowing to omit the CV ranking proportions in the resulting plot.