### PR TITLE
Fix bootstrapping (`deltas = TRUE`)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 ## Bug fixes
 
 * Fixed a bug sometimes causing `plot.vsel()` to produce extra ("empty") ticks on the x-axis. (GitHub: #462)
+* Fixed a bug in `summary.vsel()` and `plot.vsel()` causing bootstrap results (i.e., standard error and confidence interval for RMSE and AUC) to be incorrect if `deltas = TRUE`. (GitHub: #474)
 
 # projpred 2.7.0
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -108,7 +108,7 @@ bootstrap <- function(x, fun = mean, B = 2000, seed = NA, ...) {
   bsstat <- rep(NA, B)
   for (i in 1:B) {
     bsind <- sample(seq_x, replace = TRUE)
-    bsstat[i] <- fun(if (is_vector) x[bsind] else x[bsind, ], ...)
+    bsstat[i] <- fun(if (is_vector) x[bsind] else x[bsind, , drop = FALSE], ...)
   }
   return(bsstat)
 }

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -429,7 +429,7 @@ get_stat <- function(mu, lppd, y_wobs_test, stat, mu.bs = NULL, lppd.bs = NULL,
         diffvalue.bootstrap <- bootstrap(
           cbind(auc.data, auc.data.bs),
           function(x) {
-            auc(x[, 1:3]) - auc(x[, 4:6])
+            auc(x[, 1:3, drop = FALSE]) - auc(x[, 4:6, drop = FALSE])
           },
           ...
         )

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -426,10 +426,14 @@ get_stat <- function(mu, lppd, y_wobs_test, stat, mu.bs = NULL, lppd.bs = NULL,
         mu[is.na(mu.bs)] <- NA # for which both mu and mu.bs are non-NA
         auc.data.bs <- cbind(y, mu.bs, wcv)
         value <- auc(auc.data) - auc(auc.data.bs)
+        idxs_cols <- seq_len(ncol(auc.data))
+        idxs_cols_bs <- setdiff(seq_len(ncol(auc.data) + ncol(auc.data.bs)),
+                                idxs_cols)
         diffvalue.bootstrap <- bootstrap(
           cbind(auc.data, auc.data.bs),
           function(x) {
-            auc(x[, 1:3, drop = FALSE]) - auc(x[, 4:6, drop = FALSE])
+            auc(x[, idxs_cols, drop = FALSE]) -
+              auc(x[, idxs_cols_bs, drop = FALSE])
           },
           ...
         )


### PR DESCRIPTION
This fixes a bug occurring for bootstrapped quantities (RMSE and AUC: standard error and confidence interval) if `deltas = TRUE`: In that case, we need to call `bootstrap()` only once (thereby making use of the matrix ability of `bootstrap()`'s `fun`) instead of twice, to ensure that the bootstrap samples are the same for the submodel (or reference model) and the baseline model (which is usually the reference model). The old behavior led to the strange result that the reference model's SE could be non-zero in case of `deltas = TRUE` when a seed was not set via argument `seed` (which gets passed to `bootstrap()`), see below.

Illustration:
```r
data("df_binom", package = "projpred")
dat <- data.frame(y = df_binom$y, df_binom$x)
rfit <- rstanarm::stan_glm(y ~ X1 + X2 + X3,
                           family = binomial(),
                           data = dat,
                           chains = 1,
                           iter = 500,
                           seed = 1140350788,
                           refresh = 0)

devtools::load_all()

vs <- varsel(rfit, method = "L1", nclusters_pred = 2, seed = 123)

set.seed(234)
summary(vs, deltas = TRUE, stats = "rmse")
summary(vs, deltas = TRUE, stats = "auc")
```
Previously, `rmse.se` was `0.02171921` and `auc.se` was `0.07552023`. With this PR, `rmse.se` and `auc.se` are both `0`, as expected.