### PR TITLE
Fix performance summary bugs for subsampled PSIS-LOO CV

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 * Fixed a bug sometimes causing `plot.vsel()` to produce extra ("empty") ticks on the x-axis. (GitHub: #462)
 * Fixed a bug in `summary.vsel()` and `plot.vsel()` causing bootstrap results (i.e., standard error and confidence interval for RMSE and AUC) to be incorrect if `deltas = TRUE`. (GitHub: #474)
+* Fixed several bugs in `summary.vsel()` and `plot.vsel()` sometimes causing incorrect predictive performance results in case of subsampled PSIS-LOO CV (an experimental feature controlled by argument `nloo` of `cv_varsel()`). (GitHub: #475)
 
 # projpred 2.7.0
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -64,8 +64,8 @@ auc <- function(x) {
   resp <- x[, 1]
   pred <- x[, 2]
   wcv <- x[, 3]
-  n <- nrow(x)
-  ord <- order(pred, decreasing = TRUE)
+  ord <- order(pred, decreasing = TRUE, na.last = NA)
+  n <- length(ord)
   resp <- resp[ord]
   pred <- pred[ord]
   wcv <- wcv[ord]

--- a/R/misc.R
+++ b/R/misc.R
@@ -22,6 +22,9 @@ weighted.sd <- function(x, w, na.rm = FALSE) {
     n <- length(x)
     ind <- rep(TRUE, n)
   }
+  if (n %in% c(0, 1)) {
+    return(NA_real_)
+  }
   w <- w / sum(w[ind])
   m <- sum(x[ind] * w[ind])
   sqrt(n / (n - 1) * sum(w[ind] * (x[ind] - m)^2))

--- a/R/misc.R
+++ b/R/misc.R
@@ -80,6 +80,7 @@ auc <- function(x) {
   wcv <- wcv[ord]
 
   w0 <- w1 <- wcv
+  # CAUTION: The following check also ensures that `resp` does not have `NA`s:
   stopifnot(all(resp %in% c(0, 1)))
   w0[resp == 1] <- 0 # for calculating the false positive rate (fpr)
   w1[resp == 0] <- 0 # for calculating the true positive rate (tpr)

--- a/R/misc.R
+++ b/R/misc.R
@@ -64,11 +64,18 @@ auc <- function(x) {
   resp <- x[, 1]
   pred <- x[, 2]
   wcv <- x[, 3]
+
+  # Make it explicit that `x` should not be used anymore (due to the possibility
+  # of `NA`s, but also due to the re-ordering):
+  rm(x)
+
   ord <- order(pred, decreasing = TRUE, na.last = NA)
   n <- length(ord)
+
   resp <- resp[ord]
   pred <- pred[ord]
   wcv <- wcv[ord]
+
   w0 <- w1 <- wcv
   stopifnot(all(resp %in% c(0, 1)))
   w0[resp == 1] <- 0 # for calculating the false positive rate (fpr)

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -346,8 +346,8 @@ get_stat <- function(mu, lppd, y_wobs_test, stat, mu.bs = NULL, lppd.bs = NULL,
       if (!is.null(mu.bs)) {
         # Compute the RMSEs using only those observations for which both `mu`
         # and `mu.bs` are not `NA`:
-        mu.bs[is.na(mu)] <- NA
         mu[is.na(mu.bs)] <- NA
+        mu.bs[is.na(mu)] <- NA
         value <- sqrt(mean(wcv * (mu - y)^2, na.rm = TRUE)) -
           sqrt(mean(wcv * (mu.bs - y)^2, na.rm = TRUE))
         diffvalue.bootstrap <- bootstrap(
@@ -426,8 +426,8 @@ get_stat <- function(mu, lppd, y_wobs_test, stat, mu.bs = NULL, lppd.bs = NULL,
       if (!is.null(mu.bs)) {
         # Compute the AUCs using only those observations for which both `mu` and
         # `mu.bs` are not `NA`:
-        mu.bs[is.na(mu)] <- NA
         mu[is.na(mu.bs)] <- NA
+        mu.bs[is.na(mu)] <- NA
         auc.data.bs <- cbind(y, mu.bs, wcv)
         value <- auc(auc.data) - auc(auc.data.bs)
         idxs_cols <- seq_len(ncol(auc.data))

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -225,7 +225,9 @@ weighted_summary_means <- function(y_wobs_test, family, wdraws, mu, dis, cl_ref,
           # confidence interval bounds as well as for the standard error.
           warning("Lower and upper confidence interval bounds of performance ",
                   "statistic `", stat, "` are based on a normal ",
-                  "approximation, not the bootstrap.")
+                  "approximation, not the bootstrap. The standard error of ",
+                  "performance statistic `", stat, "` is also not based on a ",
+                  "bootstrap.")
         }
         lq <- qnorm(alpha / 2, mean = val, sd = val.se)
         uq <- qnorm(1 - alpha / 2, mean = val, sd = val.se)

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -344,8 +344,10 @@ get_stat <- function(mu, lppd, y_wobs_test, stat, mu.bs = NULL, lppd.bs = NULL,
       }
     } else if (stat == "rmse") {
       if (!is.null(mu.bs)) {
-        mu.bs[is.na(mu)] <- NA # compute the RMSEs using only those points
-        mu[is.na(mu.bs)] <- NA # for which both mu and mu.bs are non-NA
+        # Compute the RMSEs using only those observations for which both `mu`
+        # and `mu.bs` are not `NA`:
+        mu.bs[is.na(mu)] <- NA
+        mu[is.na(mu.bs)] <- NA
         value <- sqrt(mean(wcv * (mu - y)^2, na.rm = TRUE)) -
           sqrt(mean(wcv * (mu.bs - y)^2, na.rm = TRUE))
         diffvalue.bootstrap <- bootstrap(
@@ -422,8 +424,10 @@ get_stat <- function(mu, lppd, y_wobs_test, stat, mu.bs = NULL, lppd.bs = NULL,
     } else if (stat == "auc") {
       auc.data <- cbind(y, mu, wcv)
       if (!is.null(mu.bs)) {
-        mu.bs[is.na(mu)] <- NA # compute the AUCs using only those points
-        mu[is.na(mu.bs)] <- NA # for which both mu and mu.bs are non-NA
+        # Compute the AUCs using only those observations for which both `mu` and
+        # `mu.bs` are not `NA`:
+        mu.bs[is.na(mu)] <- NA
+        mu[is.na(mu.bs)] <- NA
         auc.data.bs <- cbind(y, mu.bs, wcv)
         value <- auc(auc.data) - auc(auc.data.bs)
         idxs_cols <- seq_len(ncol(auc.data))

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -422,12 +422,12 @@ get_stat <- function(mu, lppd, y_wobs_test, stat, mu.bs = NULL, lppd.bs = NULL,
         value.se <- weighted.sd(crrct, wcv, na.rm = TRUE) / sqrt(n_notna)
       }
     } else if (stat == "auc") {
-      auc.data <- cbind(y, mu, wcv)
       if (!is.null(mu.bs)) {
         # Compute the AUCs using only those observations for which both `mu` and
         # `mu.bs` are not `NA`:
         mu[is.na(mu.bs)] <- NA
         mu.bs[is.na(mu)] <- NA
+        auc.data <- cbind(y, mu, wcv)
         auc.data.bs <- cbind(y, mu.bs, wcv)
         value <- auc(auc.data) - auc(auc.data.bs)
         idxs_cols <- seq_len(ncol(auc.data))
@@ -446,6 +446,7 @@ get_stat <- function(mu, lppd, y_wobs_test, stat, mu.bs = NULL, lppd.bs = NULL,
                           probs = c(alpha_half, one_minus_alpha_half),
                           names = FALSE, na.rm = TRUE)
       } else {
+        auc.data <- cbind(y, mu, wcv)
         value <- auc(auc.data)
         value.bootstrap <- bootstrap(auc.data, auc, ...)
         value.se <- sd(value.bootstrap, na.rm = TRUE)

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -192,13 +192,8 @@ weighted_summary_means <- function(y_wobs_test, family, wdraws, mu, dis, cl_ref,
 
     ## reference model statistics
     summ <- summ_ref
-    # TODO (subsampled PSIS-LOO CV): Should `summ_ref$wcv` be non-`NULL` (see
-    # <https://github.com/stan-dev/projpred/issues/94#issuecomment-1195207164>)?
-    # If it is OK that `summ_ref$wcv` is always `NULL`, it is probably better to
-    # replace `summ$wcv` by `NULL` explicitly or to omit argument `wcv` so that
-    # `NULL` is used as its default:
     res <- get_stat(summ$mu, summ$lppd, varsel$y_wobs_test, stat, mu.bs = mu.bs,
-                    lppd.bs = lppd.bs, wcv = summ$wcv, alpha = alpha, ...)
+                    lppd.bs = lppd.bs, alpha = alpha, ...)
     row <- data.frame(
       data = varsel$type_test, size = Inf, delta = delta, statistic = stat,
       value = res$value, lq = res$lq, uq = res$uq, se = res$se, diff = NA,
@@ -215,8 +210,8 @@ weighted_summary_means <- function(y_wobs_test, family, wdraws, mu, dis, cl_ref,
         ## results to get more accurate statistic fot the submodel on the actual
         ## scale
         res_ref <- get_stat(summ_ref$mu, summ_ref$lppd, varsel$y_wobs_test,
-                            stat, mu.bs = NULL, lppd.bs = NULL,
-                            wcv = summ_ref$wcv, alpha = alpha, ...)
+                            stat, mu.bs = NULL, lppd.bs = NULL, alpha = alpha,
+                            ...)
         res_diff <- get_stat(summ$mu, summ$lppd, varsel$y_wobs_test, stat,
                              mu.bs = summ_ref$mu, lppd.bs = summ_ref$lppd,
                              wcv = summ$wcv, alpha = alpha, ...)

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -216,10 +216,13 @@ weighted_summary_means <- function(y_wobs_test, family, wdraws, mu, dis, cl_ref,
                              mu.bs = summ_ref$mu, lppd.bs = summ_ref$lppd,
                              wcv = summ$wcv, alpha = alpha, ...)
         val <- res_ref$value + res_diff$value
+        # TODO (subsampled PSIS-LOO CV): Is `val.se` really computed correctly
+        # or do we need to take into account that `res_ref$se` and `res_diff$se`
+        # might be stochastically dependent?
         val.se <- sqrt(res_ref$se^2 + res_diff$se^2)
         if (stat %in% c("rmse", "auc")) {
           # TODO (subsampled PSIS-LOO CV): Use bootstrap for lower and upper
-          # confidence interval bounds.
+          # confidence interval bounds as well as for the standard error.
           warning("Lower and upper confidence interval bounds of performance ",
                   "statistic `", stat, "` are based on a normal ",
                   "approximation, not the bootstrap.")

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -192,6 +192,11 @@ weighted_summary_means <- function(y_wobs_test, family, wdraws, mu, dis, cl_ref,
 
     ## reference model statistics
     summ <- summ_ref
+    # TODO (subsampled PSIS-LOO CV): Should `summ_ref$wcv` be non-`NULL` (see
+    # <https://github.com/stan-dev/projpred/issues/94#issuecomment-1195207164>)?
+    # If it is OK that `summ_ref$wcv` is always `NULL`, it is probably better to
+    # replace `summ$wcv` by `NULL` explicitly or to omit argument `wcv` so that
+    # `NULL` is used as its default:
     res <- get_stat(summ$mu, summ$lppd, varsel$y_wobs_test, stat, mu.bs = mu.bs,
                     lppd.bs = lppd.bs, wcv = summ$wcv, alpha = alpha, ...)
     row <- data.frame(

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -297,14 +297,15 @@ get_stat <- function(mu, lppd, y_wobs_test, stat, mu.bs = NULL, lppd.bs = NULL,
     n_notna <- sum(!is.na(lppd))
     n <- length(lppd)
   } else {
+    hasNA_y <- is.na(y_wobs_test$y_prop %||% y_wobs_test$y)
     if (!is.null(mu.bs)) {
       # Compute the performance statistics using only those observations for
       # which both `mu` and `mu.bs` are not `NA`:
       mu[is.na(mu.bs)] <- NA
       mu.bs[is.na(mu)] <- NA
-      n_notna.bs <- sum(!is.na(mu.bs))
+      n_notna.bs <- sum(!is.na(mu.bs) & !hasNA_y)
     }
-    n_notna <- sum(!is.na(mu) & !is.na(y_wobs_test$y_prop %||% y_wobs_test$y))
+    n_notna <- sum(!is.na(mu) & !hasNA_y)
     n <- length(mu)
   }
   if (!is.null(n_notna.bs) && getOption("projpred.additional_checks", FALSE)) {
@@ -339,11 +340,7 @@ get_stat <- function(mu, lppd, y_wobs_test, stat, mu.bs = NULL, lppd.bs = NULL,
       value.se <- value.se / n_notna
     }
   } else if (stat %in% c("mse", "rmse")) {
-    if (is.null(y_wobs_test$y_prop)) {
-      y <- y_wobs_test$y
-    } else {
-      y <- y_wobs_test$y_prop
-    }
+    y <- y_wobs_test$y_prop %||% y_wobs_test$y
     if (!all(y_wobs_test$wobs == 1)) {
       wcv <- wcv * y_wobs_test$wobs
       wcv <- n_notna * wcv / sum(wcv)

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -269,6 +269,14 @@ varsel.refmodel <- function(object, d_test = NULL, method = "forward",
     d_test <- d_test[nms_d_test()]
     invisible(lapply(setNames(nm = setdiff(nms_d_test(), c("y", "y_oscale"))),
                      function(d_nm) na.fail(d_test[[d_nm]])))
+    hasNA_y_test <- is.na(d_test[["y"]])
+    if (any(hasNA_y_test)) {
+      stopifnot(all(hasNA_y_test))
+    }
+    hasNA_y_oscale_test <- is.na(d_test[["y_oscale"]])
+    if (any(hasNA_y_oscale_test)) {
+      stopifnot(all(hasNA_y_oscale_test))
+    }
     if (refmodel$family$for_augdat) {
       d_test$y <- as.factor(d_test$y)
       if (!all(levels(d_test$y) %in% refmodel$family$cats)) {


### PR DESCRIPTION
This fixes several bugs (mainly in `get_stat()`) that were sometimes causing incorrect predictive performance results (i.e., point estimate, standard error, confidence interval) in case of subsampled PSIS-LOO CV. For details, see the commit messages.