### PR TITLE
Add GMPD

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Added a `print()` method for objects of class `refmodel`, mainly to avoid cluttering the console when printing such objects accidentally.
 * Argument `extract_model_data` of `init_refmodel()` is now allowed to be `NULL` for using an internal default.
 * `print.vselsummary()` (and hence also `print.vsel()`) now use a minimum number of significant digits of `2` by default. The previous behavior can be restored by setting `options(projpred.digits = getOption("digits"))`.
+* Added a new performance statistic, the geometric mean predictive density (GMPD). This is particularly useful for discrete outcomes because there, the GMPD is a geometric mean of probabilities and hence bounded by zero and one. For details, see argument `stats` of the `?summary.vsel` help. (GitHub: #476)
 
 ## Bug fixes
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -512,7 +512,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
   }
 
   # Log-likelihood values for the reference model (necessary for the PSIS-LOO CV
-  # weights, but also for performance statistics like ELPD and MLPD):
+  # weights, but also for performance statistics like ELPD, MLPD, and GMPD):
   if (refmodel$family$for_latent) {
     mu_offs_oscale <- refmodel$family$latent_ilink(
       t(refmodel$mu_offs), cl_ref = seq_along(refmodel$wdraws_ref),

--- a/R/misc.R
+++ b/R/misc.R
@@ -152,9 +152,10 @@ validate_vsel_object_stats <- function(object, stats, resp_oscale = TRUE) {
   }
   resp_oscale <- object$refmodel$family$for_latent && resp_oscale
 
-  trad_stats <- c("elpd", "mlpd", "mse", "rmse", "acc", "pctcorr", "auc")
+  trad_stats <- c("elpd", "mlpd", "gmpd", "mse", "rmse", "acc", "pctcorr",
+                  "auc")
   trad_stats_binom_only <- c("acc", "pctcorr", "auc")
-  augdat_stats <- c("elpd", "mlpd", "acc", "pctcorr")
+  augdat_stats <- c("elpd", "mlpd", "gmpd", "acc", "pctcorr")
   resp_oscale_stats_fac <- augdat_stats
 
   if (is.null(stats)) {
@@ -202,7 +203,7 @@ validate_baseline <- function(refmodel, baseline, deltas) {
   }
   if (baseline == "ref" && deltas == TRUE && inherits(refmodel, "datafit")) {
     # no reference model (or the results missing for some other reason),
-    # so cannot compute differences between the reference model and submodels
+    # so cannot compute differences (or ratios) vs. the reference model
     stop("Cannot use deltas = TRUE and baseline = 'ref' when there is no ",
          "reference model.")
   }

--- a/man/plot.vsel.Rd
+++ b/man/plot.vsel.Rd
@@ -50,6 +50,13 @@ density values (with each of these predictive density values being
 a---possibly weighted---average across the parameter draws).
 \item \code{"mlpd"}: mean log predictive density, that is, \code{"elpd"} divided by the
 number of observations.
+\item \code{"gmpd"}: geometric mean predictive density (GMPD), that is, \code{\link[=exp]{exp()}} of
+\code{"mlpd"}. The GMPD is especially helpful for discrete response families
+(because there, the GMPD is bounded by zero and one). For the corresponding
+standard error, the delta method is used. The corresponding confidence
+interval type is an "exponentiated normal approximation" because the
+confidence interval bounds are the exponentiated confidence interval bounds
+of the \code{"mlpd"}.
 \item \code{"mse"}: mean squared error (only available in the situations mentioned
 in section "Details" below).
 \item \code{"rmse"}: root mean squared error (only available in the situations
@@ -62,27 +69,30 @@ mentioned in section "Details" below). For the corresponding standard error
 and lower and upper confidence interval bounds, bootstrapping is used.
 }}
 
-\item{deltas}{If \code{TRUE}, the submodel statistics are estimated as differences
-from the baseline model (see argument \code{baseline}). With a "difference
-\emph{from} the baseline model", we mean to take the submodel statistic minus
-the baseline model statistic (not the other way round).}
+\item{deltas}{If \code{TRUE}, the submodel statistics are estimated relatively to
+the baseline model (see argument \code{baseline}). For the GMPD, the term
+"relatively" refers to the ratio vs. the baseline model (i.e., the submodel
+statistic divided by the baseline model statistic). For all other \code{stats},
+"relatively" refers to the difference from the baseline model (i.e., the
+submodel statistic minus the baseline model statistic).}
 
 \item{alpha}{A number determining the (nominal) coverage \code{1 - alpha} of the
-normal-approximation (or bootstrap; see argument \code{stats}) confidence
-intervals. For example, in case of the normal approximation, \code{alpha = 2 * pnorm(-1)} corresponds to a confidence interval stretching by one standard
-error on either side of the point estimate.}
+normal-approximation (or bootstrap or exponentiated normal-approximation;
+see argument \code{stats}) confidence intervals. For example, in case of the
+normal approximation, \code{alpha = 2 * pnorm(-1)} corresponds to a confidence
+interval stretching by one standard error on either side of the point
+estimate.}
 
 \item{baseline}{For \code{\link[=summary.vsel]{summary.vsel()}}: Only relevant if \code{deltas} is \code{TRUE}.
 For \code{\link[=plot.vsel]{plot.vsel()}}: Always relevant. Either \code{"ref"} or \code{"best"}, indicating
 whether the baseline is the reference model or the best submodel found (in
 terms of \code{stats[1]}), respectively.}
 
-\item{thres_elpd}{Only relevant if \code{any(stats \%in\% c("elpd", "mlpd"))}. The
-threshold for the ELPD difference (taking the submodel's ELPD minus the
-baseline model's ELPD) above which the submodel's ELPD is considered to be
-close enough to the baseline model's ELPD. An equivalent rule is applied in
-case of the MLPD. See \code{\link[=suggest_size]{suggest_size()}} for a formalization. Supplying \code{NA}
-deactivates this.}
+\item{thres_elpd}{Only relevant if \code{any(stats \%in\% c("elpd", "mlpd", "gmpd"))}. The threshold for the ELPD difference (taking the submodel's
+ELPD minus the baseline model's ELPD) above which the submodel's ELPD is
+considered to be close enough to the baseline model's ELPD. An equivalent
+rule is applied in case of the MLPD and the GMPD. See \code{\link[=suggest_size]{suggest_size()}} for
+a formalization. Supplying \code{NA} deactivates this.}
 
 \item{resp_oscale}{Only relevant for the latent projection. A single logical
 value indicating whether to calculate the performance statistics on the
@@ -200,11 +210,11 @@ latent projection with \code{resp_oscale = TRUE} in combination with
 As long as the reference model's performance is computable, it is always
 shown in the plot as a dashed red horizontal line. If \code{baseline = "best"},
 the baseline model's performance is shown as a dotted black horizontal line.
-If \code{!is.na(thres_elpd)} and \code{any(stats \%in\% c("elpd", "mlpd"))}, the value
-supplied to \code{thres_elpd} (which is automatically adapted internally in case
-of the MLPD or \code{deltas = FALSE}) is shown as a dot-dashed gray horizontal
-line for the reference model and, if \code{baseline = "best"}, as a long-dashed
-green horizontal line for the baseline model.
+If \code{!is.na(thres_elpd)} and \code{any(stats \%in\% c("elpd", "mlpd", "gmpd"))}, the
+value supplied to \code{thres_elpd} (which is automatically adapted internally in
+case of the MLPD or the GMPD or \code{deltas = FALSE}) is shown as a dot-dashed
+gray horizontal line for the reference model and, if \code{baseline = "best"}, as
+a long-dashed green horizontal line for the baseline model.
 }
 
 \examples{

--- a/man/suggest_size.Rd
+++ b/man/suggest_size.Rd
@@ -37,12 +37,12 @@ for more information.}
 based on the upper or lower confidence interval bound, respectively. See
 section "Details" below for more information.}
 
-\item{thres_elpd}{Only relevant if \code{stat \%in\% c("elpd", "mlpd")}. The
-threshold for the ELPD difference (taking the submodel's ELPD minus the
+\item{thres_elpd}{Only relevant if \verb{stat \%in\% c("elpd", "mlpd", "gmpd"))}.
+The threshold for the ELPD difference (taking the submodel's ELPD minus the
 baseline model's ELPD) above which the submodel's ELPD is considered to be
 close enough to the baseline model's ELPD. An equivalent rule is applied in
-case of the MLPD. See section "Details" for a formalization. Supplying \code{NA}
-deactivates this.}
+case of the MLPD and the GMPD. See section "Details" for a formalization.
+Supplying \code{NA} deactivates this.}
 
 \item{warnings}{Mainly for internal use. A single logical value indicating
 whether to throw warnings if automatic suggestion fails. Usually there is
@@ -68,11 +68,11 @@ In general (beware of special cases below), the suggested model
 size is the smallest model size \eqn{j \in \{0, 1, ...,
   \texttt{nterms\_max}\}}{{j = 0, 1, ..., nterms_max}} for which either the
 lower or upper bound (depending on argument \code{type}) of the
-normal-approximation (or bootstrap; see argument \code{stat}) confidence
-interval (with nominal coverage \code{1 - alpha}; see argument \code{alpha} of
-\code{\link[=summary.vsel]{summary.vsel()}}) for \eqn{U_j - U_{\mathrm{base}}}{U_j - U_base} (with
-\eqn{U_j} denoting the \eqn{j}-th submodel's true utility and
-\eqn{U_{\mathrm{base}}}{U_base} denoting the baseline model's true utility)
+normal-approximation (or bootstrap or exponentiated normal-approximation;
+see argument \code{stat}) confidence interval (with nominal coverage \code{1 - alpha}; see argument \code{alpha} of \code{\link[=summary.vsel]{summary.vsel()}}) for \eqn{U_j -
+  U_{\mathrm{base}}}{U_j - U_base} (with \eqn{U_j} denoting the \eqn{j}-th
+submodel's true utility and \eqn{U_{\mathrm{base}}}{U_base} denoting the
+baseline model's true utility)
 falls above (or is equal to) \deqn{\texttt{pct} \cdot (u_0 -
   u_{\mathrm{base}})}{pct * (u_0 - u_base)} where \eqn{u_0} denotes the null
 model's estimated utility and \eqn{u_{\mathrm{base}}}{u_base} the baseline
@@ -87,6 +87,22 @@ bound for the \emph{negative} RMSE or MSE exceeds (or is equal to) the cutoff
 MSE below---or equal to---the cutoff). This is done to make the
 interpretation of argument \code{type} the same regardless of argument \code{stat}.
 
+For the geometric mean predictive density (GMPD), the decision rule above
+is applied on \code{\link[=log]{log()}} scale. In other words, if the true GMPD is denoted by
+\eqn{U^\ast_j}{U^*_j} for the \eqn{j}-th submodel and
+\eqn{U^\ast_{\mathrm{base}}}{U^*_base} for the baseline model (so that
+\eqn{U_j} and \eqn{U_{\mathrm{base}}}{U_base} from above are given by
+\eqn{U_j = \log(U^\ast_j)}{U_j = log(U^*_j)} and
+\eqn{U_{\mathrm{base}} = \log(U^\ast_{\mathrm{base}})}{U_base =
+  log(U^*_base)}), then \code{\link[=suggest_size]{suggest_size()}} yields the smallest model size whose
+lower or upper (depending on argument \code{type}) confidence interval bound for
+\eqn{\frac{U^\ast_j}{U^\ast_{\mathrm{base}}}}{U^*_j / U^*_base} exceeds (or
+is equal to)
+\deqn{(\frac{u^\ast_0}{u^\ast_{\mathrm{base}}})^{\texttt{pct}}}{(u^*_0 /
+  u^*_base)^(pct)} where \eqn{u^\ast_0}{u^*_0} denotes the null
+model's estimated GMPD and \eqn{u^\ast_{\mathrm{base}}}{u^*_base} the
+baseline model's estimated GMPD.
+
 If \code{!is.na(thres_elpd)} and \code{stat = "elpd"}, the decision rule above is
 extended: The suggested model size is then the smallest model size \eqn{j}
 fulfilling the rule above \emph{or} \eqn{u_j - u_{\mathrm{base}} >
@@ -95,18 +111,24 @@ of \code{stat = "mlpd"} (and \code{!is.na(thres_elpd)}), the suggested model siz
 the smallest model size \eqn{j} fulfilling the rule above \emph{or} \eqn{u_j -
   u_{\mathrm{base}} > \frac{\texttt{thres\_elpd}}{N}}{u_j - u_base >
   thres_elpd / N} with \eqn{N} denoting the number of observations.
+Correspondingly, in case of \code{stat = "gmpd"} (and \code{!is.na(thres_elpd)}), the
+suggested model size is the smallest model size \eqn{j} fulfilling the rule
+above \emph{or} \eqn{\frac{u^\ast_j}{u^\ast_{\mathrm{base}}} >
+  \exp(\frac{\texttt{thres\_elpd}}{N})}{u^*_j / u^*_base > exp(thres_elpd /
+  N)}.
 
 For example (disregarding the special extensions in case of
-\code{!is.na(thres_elpd)} with \code{stat = "elpd"} or \code{stat = "mlpd"}),
-\code{alpha = 2 * pnorm(-1)}, \code{pct = 0}, and \code{type = "upper"} means that we
-select the smallest model size for which the upper bound of the
-\code{1 - 2 * pnorm(-1)} (approximately 68.3\%) confidence interval for
-\eqn{U_j - U_{\mathrm{base}}}{U_j - U_base} exceeds (or is equal to) zero,
-that is (if \code{stat} is a performance statistic for which the normal
-approximation is used, not the bootstrap), for which the submodel's utility
-estimate is at most one standard error smaller than the baseline model's
-utility estimate (with that standard error referring to the utility
-\emph{difference}).
+\code{!is.na(thres_elpd)} with \code{stat \%in\% c("elpd", "mlpd", "gmpd")}), \code{alpha = 2 * pnorm(-1)}, \code{pct = 0}, and \code{type = "upper"} means that we select the
+smallest model size for which the upper bound of the \code{1 - 2 * pnorm(-1)}
+(approximately 68.3\%) confidence interval for \eqn{U_j -
+  U_{\mathrm{base}}}{U_j - U_base}
+(\eqn{\frac{U^\ast_j}{U^\ast_{\mathrm{base}}}}{U^*_j / U^*_base} in case of
+the GMPD) exceeds (or is equal to) zero (one in case of the GMPD), that is
+(if \code{stat} is a performance statistic for which the normal approximation is
+used, not the bootstrap and not the exponentiated normal approximation),
+for which the submodel's utility estimate is at most one standard error
+smaller than the baseline model's utility estimate (with that standard
+error referring to the utility \emph{difference}).
 
 Apart from the two \code{\link[=summary.vsel]{summary.vsel()}} arguments mentioned above (\code{alpha} and
 \code{baseline}), \code{resp_oscale} is another important \code{\link[=summary.vsel]{summary.vsel()}} argument

--- a/man/summary.vsel.Rd
+++ b/man/summary.vsel.Rd
@@ -41,6 +41,13 @@ density values (with each of these predictive density values being
 a---possibly weighted---average across the parameter draws).
 \item \code{"mlpd"}: mean log predictive density, that is, \code{"elpd"} divided by the
 number of observations.
+\item \code{"gmpd"}: geometric mean predictive density (GMPD), that is, \code{\link[=exp]{exp()}} of
+\code{"mlpd"}. The GMPD is especially helpful for discrete response families
+(because there, the GMPD is bounded by zero and one). For the corresponding
+standard error, the delta method is used. The corresponding confidence
+interval type is an "exponentiated normal approximation" because the
+confidence interval bounds are the exponentiated confidence interval bounds
+of the \code{"mlpd"}.
 \item \code{"mse"}: mean squared error (only available in the situations mentioned
 in section "Details" below).
 \item \code{"rmse"}: root mean squared error (only available in the situations
@@ -57,20 +64,27 @@ and lower and upper confidence interval bounds, bootstrapping is used.
 \code{"diff"}, and \code{"diff.se"} indicating which of these to compute for each
 item from \code{stats} (mean, standard error, lower and upper confidence
 interval bounds, mean difference to the corresponding statistic of the
-reference model, and standard error of this difference, respectively). The
-confidence interval bounds belong to normal-approximation (or bootstrap;
-see argument \code{stats}) confidence intervals with (nominal) coverage \code{1 - alpha}. Items \code{"diff"} and \code{"diff.se"} are only supported if \code{deltas} is
-\code{FALSE}.}
+reference model, and standard error of this difference, respectively; note
+that for the GMPD, \code{"diff"}, and \code{"diff.se"} actually refer to the ratio
+vs. the reference model, not the difference). The confidence interval
+bounds belong to normal-approximation (or bootstrap or exponentiated
+normal-approximation; see argument \code{stats}) confidence intervals with
+(nominal) coverage \code{1 - alpha}. Items \code{"diff"} and \code{"diff.se"} are only
+supported if \code{deltas} is \code{FALSE}.}
 
-\item{deltas}{If \code{TRUE}, the submodel statistics are estimated as differences
-from the baseline model (see argument \code{baseline}). With a "difference
-\emph{from} the baseline model", we mean to take the submodel statistic minus
-the baseline model statistic (not the other way round).}
+\item{deltas}{If \code{TRUE}, the submodel statistics are estimated relatively to
+the baseline model (see argument \code{baseline}). For the GMPD, the term
+"relatively" refers to the ratio vs. the baseline model (i.e., the submodel
+statistic divided by the baseline model statistic). For all other \code{stats},
+"relatively" refers to the difference from the baseline model (i.e., the
+submodel statistic minus the baseline model statistic).}
 
 \item{alpha}{A number determining the (nominal) coverage \code{1 - alpha} of the
-normal-approximation (or bootstrap; see argument \code{stats}) confidence
-intervals. For example, in case of the normal approximation, \code{alpha = 2 * pnorm(-1)} corresponds to a confidence interval stretching by one standard
-error on either side of the point estimate.}
+normal-approximation (or bootstrap or exponentiated normal-approximation;
+see argument \code{stats}) confidence intervals. For example, in case of the
+normal approximation, \code{alpha = 2 * pnorm(-1)} corresponds to a confidence
+interval stretching by one standard error on either side of the point
+estimate.}
 
 \item{baseline}{For \code{\link[=summary.vsel]{summary.vsel()}}: Only relevant if \code{deltas} is \code{TRUE}.
 For \code{\link[=plot.vsel]{plot.vsel()}}: Always relevant. Either \code{"ref"} or \code{"best"}, indicating

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -2649,6 +2649,8 @@ smmry_sub_tester <- function(
           stat_ref <- sum(summaries_ref$lppd)
         } else if (stats_expected[stat_idx] == "mlpd") {
           stat_ref <- mean(summaries_ref$lppd)
+        } else if (stats_expected[stat_idx] == "gmpd") {
+          stat_ref <- exp(mean(summaries_ref$lppd))
         } else {
           # TODO: Implement `stat_ref` for the remaining `stats`.
           stat_ref <- NULL

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -934,7 +934,7 @@ vsel_funs <- nlist("summary.vsel", "plot.vsel", "suggest_size.vsel")
 # projection (or the latent projection with `resp_oscale = FALSE` or the latent
 # projection with `resp_oscale = TRUE`, but the latter only in combination with
 # `<refmodel>$family$cats` being `NULL`):
-stats_common <- c("elpd", "mlpd", "mse", "rmse")
+stats_common <- c("elpd", "mlpd", "gmpd", "mse", "rmse")
 # Performance statistics for the binomial() family only, when using the
 # traditional projection (or the latent projection with `resp_oscale = TRUE`,
 # but the latter only in combination with `<refmodel>$family$cats` being
@@ -945,7 +945,7 @@ stats_tst <- list(
   default_stats = list(),
   common_stats = list(stats = stats_common),
   binom_stats = list(stats = stats_binom),
-  augdat_stats = list(stats = c("elpd", "mlpd", "acc"))
+  augdat_stats = list(stats = c("elpd", "mlpd", "gmpd", "acc"))
 )
 type_tst <- c("mean", "lower", "upper", "se")
 

--- a/tests/testthat/test_augdat.R
+++ b/tests/testthat/test_augdat.R
@@ -599,7 +599,7 @@ test_that(paste(
       "kfold"
     )
     if (is_kfold) {
-      tol_smmry <- 1e-5
+      tol_smmry <- 1e-4
     } else {
       tol_smmry <- 1e-6
     }

--- a/vignettes/projpred.Rmd
+++ b/vignettes/projpred.Rmd
@@ -223,8 +223,8 @@ foreach::registerDoSEQ()
 <!-- Again, we ignore the tail-ESS warnings due to the reduced values for `chains` and `iter` in the reference model fit. -->
 
 We can now select a final submodel size by looking at a predictive performance plot similar to the one created for the preliminary `cv_varsel()` run above.
-By default, the performance statistics are plotted on their original scale, but with `deltas = TRUE`, they are plotted as differences from a baseline model (which is the reference model by default, at least in the most common cases).
-Since the differences and the (frequentist) uncertainty in their estimation are usually of more interest than the original-scale performance statistics (at least with regard to the decision for a final submodel size), we directly plot with `deltas = TRUE` here:
+By default, the performance statistics are plotted on their original scale, but with `deltas = TRUE`, they are plotted as differences^[For the geometric mean predictive density (GMPD, see argument `stats` of `summary.vsel()`), `deltas = TRUE` means to calculate the GMPD *ratio* (not difference) vs. the baseline model.] from a baseline model (which is the reference model by default, at least in the most common cases).
+Since the differences^[For the GMPD, this is again a ratio.] and the (frequentist) uncertainty in their estimation are usually of more interest than the original-scale performance statistics (at least with regard to the decision for a final submodel size), we directly plot with `deltas = TRUE` here:
 ```{r plot_vsel}
 plot(cvvs, stats = "mlpd", deltas = TRUE)
 ```


### PR DESCRIPTION
This adds a new performance statistic, the geometric mean predictive density (GMPD), which is particularly useful for discrete outcomes because there, the GMPD is a geometric mean of probabilities and hence bounded by zero and one. As explained in the documentation for argument `stats` in the `?summary.vsel` help, the SE of the GMPD is derived using the delta method ($SE_{GMPD} = SE_{MLPD} \cdot GMPD$; sorry for the bad math formatting: GitHub does not seem to support `\text{}` or `\mathrm{}`). The confidence interval (CI) for the GMPD is calculated by exponentiating the CI bounds of the MLPD CI. This is also what is done in a similar case in Stata, for example (see [here](https://www.r-bloggers.com/2018/01/delta-method-standard-errors/)).