### PR TITLE
Add `search_control`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * `print.vselsummary()` and `print.vsel()` now use a minimum number of significant digits of `2` by default. The previous behavior can be restored by setting `options(projpred.digits = getOption("digits"))`.
 * Added a new performance statistic, the geometric mean predictive density (GMPD). This is particularly useful for discrete outcomes because there, the GMPD is a geometric mean of probabilities and hence bounded by zero and one. For details, see argument `stats` of the `?summary.vsel` help. (GitHub: #476)
 * `project()`'s argument `verbose` now gets passed to argument `verbose_divmin` (not `projpred_verbose`) of the divergence minimizer function (see argument `div_minimizer` of `init_refmodel()`).
+* `varsel()` and `cv_varsel()` have gained a new argument called `search_control` which accepts control arguments for the search as a `list`. (GitHub: #477)
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,7 +27,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * `print.vselsummary()` and `print.vsel()` now use a minimum number of significant digits of `2` by default. The previous behavior can be restored by setting `options(projpred.digits = getOption("digits"))`.
 * Added a new performance statistic, the geometric mean predictive density (GMPD). This is particularly useful for discrete outcomes because there, the GMPD is a geometric mean of probabilities and hence bounded by zero and one. For details, see argument `stats` of the `?summary.vsel` help. (GitHub: #476)
 * `project()`'s argument `verbose` now gets passed to argument `verbose_divmin` (not `projpred_verbose`) of the divergence minimizer function (see argument `div_minimizer` of `init_refmodel()`).
-* `varsel()` and `cv_varsel()` have gained a new argument called `search_control` which accepts control arguments for the search as a `list`. (GitHub: #477)
+* Arguments `lambda_min_ratio`, `nlambda`, and `thresh` of `varsel()` and `cv_varsel()` have been deprecated. Instead, `varsel()` and `cv_varsel()` have gained a new argument called `search_control` which accepts control arguments for the search as a `list`. Thus, former arguments `lambda_min_ratio`, `nlambda`, and `thresh` should now be specified via `search_control` (but note that `search_control` is more general because it also accepts control arguments for a *forward* search). (GitHub: #477)
 
 ## Bug fixes
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -229,6 +229,9 @@ cv_varsel.refmodel <- function(
     K = if (!inherits(object, "datafit")) 5 else 10,
     cvfits = object$cvfits,
     search_control = NULL,
+    lambda_min_ratio = 1e-5,
+    nlambda = 150,
+    thresh = 1e-6,
     validate_search = TRUE,
     seed = NA,
     search_terms = NULL,
@@ -236,6 +239,26 @@ cv_varsel.refmodel <- function(
     parallel = getOption("projpred.prll_cv", FALSE),
     ...
 ) {
+  if (!missing(lambda_min_ratio)) {
+    warning("Argument `lambda_min_ratio` is deprecated. Please specify ",
+            "control arguments for the search via argument `search_control`. ",
+            "Now using `lambda_min_ratio` as element `lambda_min_ratio` of ",
+            "`search_control`.")
+    search_control$lambda_min_ratio <- lambda_min_ratio
+  }
+  if (!missing(nlambda)) {
+    warning("Argument `nlambda` is deprecated. Please specify control ",
+            "arguments for the search via argument `search_control`. ",
+            "Now using `nlambda` as element `nlambda` of `search_control`.")
+    search_control$nlambda <- nlambda
+  }
+  if (!missing(thresh)) {
+    warning("Argument `thresh` is deprecated. Please specify control ",
+            "arguments for the search via argument `search_control`. ",
+            "Now using `thresh` as element `thresh` of `search_control`.")
+    search_control$thresh <- thresh
+  }
+
   if (exists(".Random.seed", envir = .GlobalEnv)) {
     rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
   }

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -228,7 +228,7 @@ cv_varsel.refmodel <- function(
     nloo = object$nobs,
     K = if (!inherits(object, "datafit")) 5 else 10,
     cvfits = object$cvfits,
-    search_control = list(),
+    search_control = NULL,
     validate_search = TRUE,
     seed = NA,
     search_terms = NULL,
@@ -392,7 +392,11 @@ cv_varsel.refmodel <- function(
               validate_search,
               cvfits,
               args_search = nlist(
-                method, ndraws, nclusters, nterms_max, search_control, penalty,
+                method, ndraws, nclusters, nterms_max,
+                search_control = if (
+                  method == "forward" && is.null(search_control)
+                ) list(...) else search_control,
+                penalty,
                 search_terms = if (search_terms_was_null) NULL else search_terms
               ),
               clust_used_search = refdist_info_search$clust_used,

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -1,10 +1,12 @@
 # Function to project the reference model onto a single submodel with predictor
 # terms given in `predictor_terms`. Note that "single submodel" does not refer
 # to a single fit (there are as many fits for this single submodel as there are
-# projected draws). At the end, init_submodl() is called, so the output is of
-# class `submodl`.
+# projected draws). The case `is.null(search_control)` occurs in two situations:
+# (i) when called from search_forward() with `...` as the intended control
+# arguments and (ii) when called from perf_eval(). At the end, init_submodl() is
+# called, so the output is of class `submodl`.
 proj_to_submodl <- function(predictor_terms, p_ref, refmodel,
-                            search_control = list(), ...) {
+                            search_control = NULL, ...) {
   y_unqs_aug <- refmodel$family$cats
   if (refmodel$family$for_latent && !is.null(y_unqs_aug)) {
     y_unqs_aug <- NULL
@@ -30,7 +32,7 @@ proj_to_submodl <- function(predictor_terms, p_ref, refmodel,
                       weights = refmodel$wobs,
                       projpred_var = p_ref$var,
                       projpred_ws_aug = p_ref$mu)
-  if (length(search_control) > 0) {
+  if (!is.null(search_control)) {
     args_divmin <- c(args_divmin, search_control)
   } else {
     args_divmin <- c(args_divmin, list(...))

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -53,7 +53,9 @@
 #'   parameters) for the search. In case of forward search, these arguments are
 #'   passed to the divergence minimizer (see argument `div_minimizer` of
 #'   [init_refmodel()] as well as section "Draw-wise divergence minimizers" of
-#'   [projpred-package]). In case of L1 search, possible arguments are:
+#'   [projpred-package]). In case of forward search, `NULL` causes `...` to be
+#'   used not only for the performance evaluation, but also for the search. In
+#'   case of L1 search, possible arguments are:
 #'   * `lambda_min_ratio`: Ratio between the smallest and largest lambda in the
 #'   L1-penalized search (default: `1e-5`). This parameter essentially
 #'   determines how long the search is carried out, i.e., how large submodels
@@ -226,7 +228,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = "forward",
                             nclusters_pred = NULL,
                             refit_prj = !inherits(object, "datafit"),
                             nterms_max = NULL, verbose = TRUE,
-                            search_control = list(),
+                            search_control = NULL,
                             penalty = NULL, search_terms = NULL,
                             search_out = NULL, seed = NA, ...) {
   if (exists(".Random.seed", envir = .GlobalEnv)) {
@@ -421,7 +423,11 @@ varsel.refmodel <- function(object, d_test = NULL, method = "forward",
               cvfits = refmodel$cvfits,
               ###
               args_search = nlist(
-                method, ndraws, nclusters, nterms_max, search_control, penalty,
+                method, ndraws, nclusters, nterms_max,
+                search_control = if (
+                  method == "forward" && is.null(search_control)
+                ) list(...) else search_control,
+                penalty,
                 search_terms = if (search_terms_was_null) NULL else search_terms
               ),
               clust_used_search = search_path$p_sel$clust_used,

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -66,6 +66,18 @@
 #'   about this.
 #'   * `thresh`: Convergence threshold when computing the L1 path (default:
 #'   `1e-6`). Usually, there is no need to change this.
+#' @param lambda_min_ratio Deprecated (please use `search_control` instead).
+#'   Only relevant for L1 search. Ratio between the smallest and largest lambda
+#'   in the L1-penalized search. This parameter essentially determines how long
+#'   the search is carried out, i.e., how large submodels are explored. No need
+#'   to change this unless the program gives a warning about this.
+#' @param nlambda Deprecated (please use `search_control` instead). Only
+#'   relevant for L1 search. Number of values in the lambda grid for
+#'   L1-penalized search. No need to change this unless the program gives a
+#'   warning about this.
+#' @param thresh Deprecated (please use `search_control` instead). Only relevant
+#'   for L1 search. Convergence threshold when computing the L1 path. Usually,
+#'   there is no need to change this.
 #' @param search_terms Only relevant for forward search. A custom character
 #'   vector of predictor term blocks to consider for the search. Section
 #'   "Details" below describes more precisely what "predictor term block" means.
@@ -228,9 +240,30 @@ varsel.refmodel <- function(object, d_test = NULL, method = "forward",
                             nclusters_pred = NULL,
                             refit_prj = !inherits(object, "datafit"),
                             nterms_max = NULL, verbose = TRUE,
-                            search_control = NULL,
-                            penalty = NULL, search_terms = NULL,
-                            search_out = NULL, seed = NA, ...) {
+                            search_control = NULL, lambda_min_ratio = 1e-5,
+                            nlambda = 150, thresh = 1e-6, penalty = NULL,
+                            search_terms = NULL, search_out = NULL, seed = NA,
+                            ...) {
+  if (!missing(lambda_min_ratio)) {
+    warning("Argument `lambda_min_ratio` is deprecated. Please specify ",
+            "control arguments for the search via argument `search_control`. ",
+            "Now using `lambda_min_ratio` as element `lambda_min_ratio` of ",
+            "`search_control`.")
+    search_control$lambda_min_ratio <- lambda_min_ratio
+  }
+  if (!missing(nlambda)) {
+    warning("Argument `nlambda` is deprecated. Please specify control ",
+            "arguments for the search via argument `search_control`. ",
+            "Now using `nlambda` as element `nlambda` of `search_control`.")
+    search_control$nlambda <- nlambda
+  }
+  if (!missing(thresh)) {
+    warning("Argument `thresh` is deprecated. Please specify control ",
+            "arguments for the search via argument `search_control`. ",
+            "Now using `thresh` as element `thresh` of `search_control`.")
+    search_control$thresh <- thresh
+  }
+
   if (exists(".Random.seed", envir = .GlobalEnv)) {
     rng_state_old <- get(".Random.seed", envir = .GlobalEnv)
   }

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -36,9 +36,7 @@ cv_varsel(object, ...)
   nloo = object$nobs,
   K = if (!inherits(object, "datafit")) 5 else 10,
   cvfits = object$cvfits,
-  lambda_min_ratio = 1e-05,
-  nlambda = 150,
-  thresh = 1e-06,
+  search_control = list(),
   validate_search = TRUE,
   seed = NA,
   search_terms = NULL,
@@ -55,8 +53,10 @@ cv_varsel(object, ...)
 \item{...}{For \code{\link[=cv_varsel.default]{cv_varsel.default()}}: Arguments passed to \code{\link[=get_refmodel]{get_refmodel()}} as
 well as to \code{\link[=cv_varsel.refmodel]{cv_varsel.refmodel()}}. For \code{\link[=cv_varsel.vsel]{cv_varsel.vsel()}}: Arguments passed
 to \code{\link[=cv_varsel.refmodel]{cv_varsel.refmodel()}}. For \code{\link[=cv_varsel.refmodel]{cv_varsel.refmodel()}}: Arguments passed to
-the divergence minimizer (during a forward search and also during the
-evaluation part, but the latter only if \code{refit_prj} is \code{TRUE}).}
+the divergence minimizer (see argument \code{div_minimizer} of \code{\link[=init_refmodel]{init_refmodel()}}
+as well as section "Draw-wise divergence minimizers" of \link{projpred-package})
+when refitting the submodels for the performance evaluation (if \code{refit_prj}
+is \code{TRUE}).}
 
 \item{cv_method}{The CV method, either \code{"LOO"} or \code{"kfold"}. In the \code{"LOO"}
 case, a Pareto-smoothed importance sampling leave-one-out CV (PSIS-LOO CV)
@@ -135,18 +135,23 @@ used for each predictor.}
 \item{verbose}{A single logical value indicating whether to print out
 additional information during the computations.}
 
-\item{lambda_min_ratio}{Only relevant for L1 search. Ratio between the
-smallest and largest lambda in the L1-penalized search. This parameter
-essentially determines how long the search is carried out, i.e., how large
-submodels are explored. No need to change this unless the program gives a
-warning about this.}
-
-\item{nlambda}{Only relevant for L1 search. Number of values in the lambda
-grid for L1-penalized search. No need to change this unless the program
-gives a warning about this.}
-
-\item{thresh}{Only relevant for L1 search. Convergence threshold when
-computing the L1 path. Usually, there is no need to change this.}
+\item{search_control}{A \code{list} of "control" arguments (i.e., tuning
+parameters) for the search. In case of forward search, these arguments are
+passed to the divergence minimizer (see argument \code{div_minimizer} of
+\code{\link[=init_refmodel]{init_refmodel()}} as well as section "Draw-wise divergence minimizers" of
+\link{projpred-package}). In case of L1 search, possible arguments are:
+\itemize{
+\item \code{lambda_min_ratio}: Ratio between the smallest and largest lambda in the
+L1-penalized search (default: \code{1e-5}). This parameter essentially
+determines how long the search is carried out, i.e., how large submodels
+are explored. No need to change this unless the program gives a warning
+about this.
+\item \code{nlambda}: Number of values in the lambda grid for L1-penalized search
+(default: \code{150}). No need to change this unless the program gives a warning
+about this.
+\item \code{thresh}: Convergence threshold when computing the L1 path (default:
+\code{1e-6}). Usually, there is no need to change this.
+}}
 
 \item{seed}{Pseudorandom number generation (PRNG) seed by which the same
 results can be obtained again if needed. Passed to argument \code{seed} of

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -36,7 +36,7 @@ cv_varsel(object, ...)
   nloo = object$nobs,
   K = if (!inherits(object, "datafit")) 5 else 10,
   cvfits = object$cvfits,
-  search_control = list(),
+  search_control = NULL,
   validate_search = TRUE,
   seed = NA,
   search_terms = NULL,
@@ -139,7 +139,9 @@ additional information during the computations.}
 parameters) for the search. In case of forward search, these arguments are
 passed to the divergence minimizer (see argument \code{div_minimizer} of
 \code{\link[=init_refmodel]{init_refmodel()}} as well as section "Draw-wise divergence minimizers" of
-\link{projpred-package}). In case of L1 search, possible arguments are:
+\link{projpred-package}). In case of forward search, \code{NULL} causes \code{...} to be
+used not only for the performance evaluation, but also for the search. In
+case of L1 search, possible arguments are:
 \itemize{
 \item \code{lambda_min_ratio}: Ratio between the smallest and largest lambda in the
 L1-penalized search (default: \code{1e-5}). This parameter essentially

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -37,6 +37,9 @@ cv_varsel(object, ...)
   K = if (!inherits(object, "datafit")) 5 else 10,
   cvfits = object$cvfits,
   search_control = NULL,
+  lambda_min_ratio = 1e-05,
+  nlambda = 150,
+  thresh = 1e-06,
   validate_search = TRUE,
   seed = NA,
   search_terms = NULL,
@@ -154,6 +157,21 @@ about this.
 \item \code{thresh}: Convergence threshold when computing the L1 path (default:
 \code{1e-6}). Usually, there is no need to change this.
 }}
+
+\item{lambda_min_ratio}{Deprecated (please use \code{search_control} instead).
+Only relevant for L1 search. Ratio between the smallest and largest lambda
+in the L1-penalized search. This parameter essentially determines how long
+the search is carried out, i.e., how large submodels are explored. No need
+to change this unless the program gives a warning about this.}
+
+\item{nlambda}{Deprecated (please use \code{search_control} instead). Only
+relevant for L1 search. Number of values in the lambda grid for
+L1-penalized search. No need to change this unless the program gives a
+warning about this.}
+
+\item{thresh}{Deprecated (please use \code{search_control} instead). Only relevant
+for L1 search. Convergence threshold when computing the L1 path. Usually,
+there is no need to change this.}
 
 \item{seed}{Pseudorandom number generation (PRNG) seed by which the same
 results can be obtained again if needed. Passed to argument \code{seed} of

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -25,6 +25,9 @@ varsel(object, ...)
   nterms_max = NULL,
   verbose = TRUE,
   search_control = NULL,
+  lambda_min_ratio = 1e-05,
+  nlambda = 150,
+  thresh = 1e-06,
   penalty = NULL,
   search_terms = NULL,
   search_out = NULL,
@@ -108,6 +111,21 @@ about this.
 \item \code{thresh}: Convergence threshold when computing the L1 path (default:
 \code{1e-6}). Usually, there is no need to change this.
 }}
+
+\item{lambda_min_ratio}{Deprecated (please use \code{search_control} instead).
+Only relevant for L1 search. Ratio between the smallest and largest lambda
+in the L1-penalized search. This parameter essentially determines how long
+the search is carried out, i.e., how large submodels are explored. No need
+to change this unless the program gives a warning about this.}
+
+\item{nlambda}{Deprecated (please use \code{search_control} instead). Only
+relevant for L1 search. Number of values in the lambda grid for
+L1-penalized search. No need to change this unless the program gives a
+warning about this.}
+
+\item{thresh}{Deprecated (please use \code{search_control} instead). Only relevant
+for L1 search. Convergence threshold when computing the L1 path. Usually,
+there is no need to change this.}
 
 \item{penalty}{Only relevant for L1 search. A numeric vector determining the
 relative penalties or costs for the predictors. A value of \code{0} means that

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -24,9 +24,7 @@ varsel(object, ...)
   refit_prj = !inherits(object, "datafit"),
   nterms_max = NULL,
   verbose = TRUE,
-  lambda_min_ratio = 1e-05,
-  nlambda = 150,
-  thresh = 1e-06,
+  search_control = list(),
   penalty = NULL,
   search_terms = NULL,
   search_out = NULL,
@@ -42,8 +40,10 @@ varsel(object, ...)
 \item{...}{For \code{\link[=varsel.default]{varsel.default()}}: Arguments passed to \code{\link[=get_refmodel]{get_refmodel()}} as
 well as to \code{\link[=varsel.refmodel]{varsel.refmodel()}}. For \code{\link[=varsel.vsel]{varsel.vsel()}}: Arguments passed to
 \code{\link[=varsel.refmodel]{varsel.refmodel()}}. For \code{\link[=varsel.refmodel]{varsel.refmodel()}}: Arguments passed to the
-divergence minimizer (during a forward search and also during the
-evaluation part, but the latter only if \code{refit_prj} is \code{TRUE}).}
+divergence minimizer (see argument \code{div_minimizer} of \code{\link[=init_refmodel]{init_refmodel()}} as
+well as section "Draw-wise divergence minimizers" of \link{projpred-package})
+when refitting the submodels for the performance evaluation (if \code{refit_prj}
+is \code{TRUE}).}
 
 \item{d_test}{A \code{list} of the structure outlined in section "Argument
 \code{d_test}" below, providing test data for evaluating the predictive
@@ -89,18 +89,23 @@ does not count the intercept.)}
 \item{verbose}{A single logical value indicating whether to print out
 additional information during the computations.}
 
-\item{lambda_min_ratio}{Only relevant for L1 search. Ratio between the
-smallest and largest lambda in the L1-penalized search. This parameter
-essentially determines how long the search is carried out, i.e., how large
-submodels are explored. No need to change this unless the program gives a
-warning about this.}
-
-\item{nlambda}{Only relevant for L1 search. Number of values in the lambda
-grid for L1-penalized search. No need to change this unless the program
-gives a warning about this.}
-
-\item{thresh}{Only relevant for L1 search. Convergence threshold when
-computing the L1 path. Usually, there is no need to change this.}
+\item{search_control}{A \code{list} of "control" arguments (i.e., tuning
+parameters) for the search. In case of forward search, these arguments are
+passed to the divergence minimizer (see argument \code{div_minimizer} of
+\code{\link[=init_refmodel]{init_refmodel()}} as well as section "Draw-wise divergence minimizers" of
+\link{projpred-package}). In case of L1 search, possible arguments are:
+\itemize{
+\item \code{lambda_min_ratio}: Ratio between the smallest and largest lambda in the
+L1-penalized search (default: \code{1e-5}). This parameter essentially
+determines how long the search is carried out, i.e., how large submodels
+are explored. No need to change this unless the program gives a warning
+about this.
+\item \code{nlambda}: Number of values in the lambda grid for L1-penalized search
+(default: \code{150}). No need to change this unless the program gives a warning
+about this.
+\item \code{thresh}: Convergence threshold when computing the L1 path (default:
+\code{1e-6}). Usually, there is no need to change this.
+}}
 
 \item{penalty}{Only relevant for L1 search. A numeric vector determining the
 relative penalties or costs for the predictors. A value of \code{0} means that

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -24,7 +24,7 @@ varsel(object, ...)
   refit_prj = !inherits(object, "datafit"),
   nterms_max = NULL,
   verbose = TRUE,
-  search_control = list(),
+  search_control = NULL,
   penalty = NULL,
   search_terms = NULL,
   search_out = NULL,
@@ -93,7 +93,9 @@ additional information during the computations.}
 parameters) for the search. In case of forward search, these arguments are
 passed to the divergence minimizer (see argument \code{div_minimizer} of
 \code{\link[=init_refmodel]{init_refmodel()}} as well as section "Draw-wise divergence minimizers" of
-\link{projpred-package}). In case of L1 search, possible arguments are:
+\link{projpred-package}). In case of forward search, \code{NULL} causes \code{...} to be
+used not only for the performance evaluation, but also for the search. In
+case of L1 search, possible arguments are:
 \itemize{
 \item \code{lambda_min_ratio}: Ratio between the smallest and largest lambda in the
 L1-penalized search (default: \code{1e-5}). This parameter essentially

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -1965,6 +1965,7 @@ vsel_tester <- function(
     penalty_expected = NULL,
     search_terms_expected = NULL,
     search_trms_empty_size = FALSE,
+    search_control_expected = NULL,
     extra_tol = 1.1,
     info_str = ""
 ) {
@@ -2398,6 +2399,10 @@ vsel_tester <- function(
   expect_identical(vs$cvfits, cvfits_expected, info = info_str)
 
   # args_search
+  sce <- search_control_expected[!sapply(search_control_expected, is.null)]
+  if (!length(sce)) {
+    sce <- if (method_expected == "forward") list() else NULL
+  }
   expect_equal(
     vs$args_search,
     list(
@@ -2411,7 +2416,7 @@ vsel_tester <- function(
         NULL
       },
       nterms_max = vs$nterms_max,
-      search_control = list(),
+      search_control = sce,
       penalty = penalty_expected,
       search_terms = if (is.null(search_terms_expected)) {
         NULL

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -2411,7 +2411,7 @@ vsel_tester <- function(
         NULL
       },
       nterms_max = vs$nterms_max,
-      lambda_min_ratio = 1e-5, nlambda = 150, thresh = 1e-6,
+      search_control = list(),
       penalty = penalty_expected,
       search_terms = if (is.null(search_terms_expected)) {
         NULL

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -682,8 +682,9 @@ test_that(paste(
     )
     vs <- suppressWarnings(varsel(
       ref,
-      method = "L1", lambda_min_ratio = lambda_min_ratio,
-      nlambda = nlambda, thresh = 1e-12, verbose = FALSE
+      method = "L1",
+      search_control = nlist(lambda_min_ratio, nlambda, thresh = 1e-12),
+      verbose = FALSE
     ))
     pred1 <- proj_linpred(vs,
                           newdata = data.frame(x = x, weights = weights),

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -22,6 +22,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_vs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs[[tstsetup]]$search_terms)),
+      search_control_expected = args_vs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
   }
@@ -162,6 +163,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_vs_i$search_terms) &&
         all(grepl("\\+", args_vs_i$search_terms)),
+      search_control_expected = args_vs_i[c("avoid.increase")],
       info_str = tstsetup
     )
     expect_equal(vs_repr[setdiff(names(vs_repr),
@@ -289,6 +291,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_vs_i$search_terms) &&
         all(grepl("\\+", args_vs_i$search_terms)),
+      search_control_expected = args_vs_i[c("avoid.increase")],
       info_str = tstsetup
     )
 
@@ -560,6 +563,7 @@ test_that("`refit_prj` works", {
       search_trms_empty_size =
         length(args_vs_i$search_terms) &&
         all(grepl("\\+", args_vs_i$search_terms)),
+      search_control_expected = args_vs_i[c("avoid.increase")],
       extra_tol = extra_tol_crr,
       info_str = tstsetup
     )
@@ -779,6 +783,8 @@ test_that(paste(
           search_trms_empty_size =
             length(args_vs_i$search_terms) &&
             all(grepl("\\+", args_vs_i$search_terms)),
+          search_control_expected = c(args_vs_i[c("avoid.increase")],
+                                      list(regul = regul_tst[j])),
           info_str = tstsetup
         )
       }
@@ -1139,6 +1145,7 @@ test_that("varsel.vsel() works for `vsel` objects from varsel()", {
       search_trms_empty_size =
         length(args_vs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs[[tstsetup]]$search_terms)),
+      search_control_expected = args_vs[[tstsetup]][c("avoid.increase")],
       extra_tol = extra_tol_crr,
       info_str = tstsetup
     )
@@ -1195,6 +1202,7 @@ test_that("varsel.vsel() works for `vsel` objects from cv_varsel()", {
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
+      search_control_expected = args_cvvs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
     tstsetup_counter <- tstsetup_counter + 1L
@@ -1233,6 +1241,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
+      search_control_expected = args_cvvs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
   }
@@ -1358,6 +1367,7 @@ test_that("`refit_prj` works", {
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
         all(grepl("\\+", args_cvvs_i$search_terms)),
+      search_control_expected = args_cvvs_i[c("avoid.increase")],
       info_str = tstsetup
     )
   }
@@ -1498,6 +1508,7 @@ test_that("setting `nloo` smaller than the number of observations works", {
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
         all(grepl("\\+", args_cvvs_i$search_terms)),
+      search_control_expected = args_cvvs_i[c("avoid.increase")],
       info_str = tstsetup
     )
     # Expected equality for most elements with a few exceptions:
@@ -1573,6 +1584,7 @@ test_that("`validate_search` works", {
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
         all(grepl("\\+", args_cvvs_i$search_terms)),
+      search_control_expected = args_cvvs_i[c("avoid.increase")],
       info_str = tstsetup
     )
     # Expected equality for most elements with a few exceptions:
@@ -1863,6 +1875,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_cvvs_i$search_terms) &&
         all(grepl("\\+", args_cvvs_i$search_terms)),
+      search_control_expected = args_cvvs_i[c("avoid.increase")],
       info_str = tstsetup
     )
     # Expected equality for most elements with a few exceptions:
@@ -1913,6 +1926,7 @@ test_that("`cvfun` included in the `refmodel` object works", {
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
+      search_control_expected = args_cvvs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
   }
@@ -1967,6 +1981,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
+      search_control_expected = args_cvvs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
   }
@@ -2017,6 +2032,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_vs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs[[tstsetup]]$search_terms)),
+      search_control_expected = args_vs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
     tstsetup_counter <- tstsetup_counter + 1L
@@ -2076,6 +2092,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_vs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs[[tstsetup]]$search_terms)),
+      search_control_expected = args_vs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
     tstsetup_counter <- tstsetup_counter + 1L
@@ -2143,6 +2160,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
+      search_control_expected = args_cvvs[[tstsetup]][c("avoid.increase")],
       extra_tol = extra_tol_crr,
       info_str = tstsetup
     )
@@ -2203,6 +2221,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
+      search_control_expected = args_cvvs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
   }
@@ -2265,6 +2284,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
+      search_control_expected = args_cvvs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
   }
@@ -2327,6 +2347,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
+      search_control_expected = args_cvvs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
   }
@@ -2388,6 +2409,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_vs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs[[tstsetup]]$search_terms)),
+      search_control_expected = args_vs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
     tstsetup_counter <- tstsetup_counter + 1L
@@ -2465,6 +2487,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_vs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs[[tstsetup]]$search_terms)),
+      search_control_expected = args_vs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
     tstsetup_counter <- tstsetup_counter + 1L
@@ -2559,6 +2582,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
+      search_control_expected = args_cvvs[[tstsetup]][c("avoid.increase")],
       extra_tol = extra_tol_crr,
       info_str = tstsetup
     )
@@ -2641,6 +2665,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
+      search_control_expected = args_cvvs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
   }
@@ -2697,6 +2722,7 @@ test_that("cv_varsel.vsel(): `nloo` works for `vsel` objects from varsel()", {
       search_trms_empty_size =
         length(args_vs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs[[tstsetup]]$search_terms)),
+      search_control_expected = args_vs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
     vsel_tester(
@@ -2713,6 +2739,7 @@ test_that("cv_varsel.vsel(): `nloo` works for `vsel` objects from varsel()", {
       search_trms_empty_size =
         length(args_vs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_vs[[tstsetup]]$search_terms)),
+      search_control_expected = args_vs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
     tstsetup_counter <- tstsetup_counter + 1L
@@ -2800,6 +2827,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
+      search_control_expected = args_cvvs[[tstsetup]][c("avoid.increase")],
       extra_tol = extra_tol_crr,
       info_str = tstsetup
     )
@@ -2833,6 +2861,7 @@ test_that(paste(
       search_trms_empty_size =
         length(args_cvvs[[tstsetup]]$search_terms) &&
         all(grepl("\\+", args_cvvs[[tstsetup]]$search_terms)),
+      search_control_expected = args_cvvs[[tstsetup]][c("avoid.increase")],
       info_str = tstsetup
     )
   }


### PR DESCRIPTION
This deprecates arguments `lambda_min_ratio`, `nlambda`, and `thresh` of `varsel()` and `cv_varsel()`. Instead, `varsel()` and `cv_varsel()` gain a new argument called `search_control` which accepts *any* control arguments for the search (as a `list`). Thus, former arguments `lambda_min_ratio`, `nlambda`, and `thresh` should now be specified via `search_control` (but note that `search_control` is more general because it also accepts control arguments for a *forward* search).

The main reason for this change is to allow different tuning parameters (= control arguments) for the `<refmodel_object>$div_minimizer()` function in `search_forward()` and `perf_eval()`. However, this change is also the most straightforward solution to ensure that fold-wise searches from `cv_varsel.vsel()` use the same tuning parameters as the previously run full-data search (output element `args_search` of `vsel` objects did not take `...` into account).

Note that `search_control = list()` can be specified when the defaults of the underlying draw-wise divergence minimizer(s) should be used in a (forward) search, but not in the performance evaluation.