### PR TITLE
Collect draw-wise projection warnings and check projection convergence

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * `print.vselsummary()` (and hence also `print.vsel()`) now prints the reference model's performance evaluation results as well (not just those of the submodels). Correspondingly, a new helper function `performances()` has been added which allows to access the reference model's (as well as the submodels') performance evaluation results. (GitHub: #471)
 * Argument `solution_terms` of `project()` has been deprecated. Please use the new argument `predictor_terms` instead. (GitHub: #472)
 * For expert users of the augmented-data projection only: Objects of class `augmat` or `augvec` do not need to have an attribute called `nobs_orig` anymore, but a new attribute called `ndiscrete`, giving the number of (possibly latent) response categories instead of the number of observations (see `` ?`augdat-internals` ``). This simplifies the subsetting of such objects. (GitHub: #473)
+* By default, **projpred** now catches messages and warnings from the draw-wise divergence minimizers and throws their unique collection after performing all draw-wise divergence minimizations (i.e., draw-wise projections). This can be deactivated by setting global option `projpred.warn_prj_drawwise` to `FALSE`. Previously, **projpred** suppressed such messages and warnings. (GitHub: #478)
+* By default, **projpred** now checks the convergence of the draw-wise divergence minimizers and throws a warning in case of potential convergence problems. This can be deactivated by setting global option `projpred.check_conv` to `FALSE`. (GitHub: #478)
 
 ## Minor changes
 

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -169,7 +169,7 @@ fit_glm_ridge_callback <- function(formula, data,
       dot_args
     ))
   )
-  out_capt <- grep("[Ww]arning|bug", out_capt, value = TRUE)
+  out_capt <- unique(grep("[Ww]arning|bug", out_capt, value = TRUE))
   if (length(out_capt) > 0) {
     warning(paste(out_capt, collapse = "\n"))
   }

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -997,7 +997,7 @@ check_conv_s <- function(fit_s) {
     return(fit_s$convergence == 0)
   } else if (inherits(fit_s, "gam")) {
     # TODO (GAMs): Is this correct?:
-    return(fit_s$converged && fit_s$mgcv.conv$fully.converged)
+    return(fit_s$converged && fit_s$mgcv.conv$fully.converged %||% TRUE)
   } else if (inherits(fit_s, "gamm4")) {
     # TODO (GAMMs): I couldn't find any convergence-related information in
     # element `fit_s$gam`, so the GAM part is currently not checked for

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -142,11 +142,17 @@ fit_glm_ridge_callback <- function(formula, data,
     methods::formalArgs(glm_ridge)
   )]
   # Call the submodel fitter:
-  fit <- do.call(glm_ridge, c(
-    list(x = x, y = y, obsvar = projpred_var, lambda = regul,
-         thresh = thresh_conv),
-    dot_args
-  ))
+  out_capt <- utils::capture.output(
+    fit <- do.call(glm_ridge, c(
+      list(x = x, y = y, obsvar = projpred_var, lambda = regul,
+           thresh = thresh_conv),
+      dot_args
+    ))
+  )
+  out_capt <- grep("[Ww]arning|bug", out_capt, value = TRUE)
+  if (length(out_capt) > 0) {
+    warning(paste(out_capt, collapse = "\n"))
+  }
   # Post-processing:
   rownames(fit$beta) <- colnames(x)
   sub <- nlist(alpha = fit$beta0, beta = fit$beta, w = fit$w, formula, x, y,

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -936,7 +936,7 @@ check_conv <- function(outdmin, lengths_mssgs_warns) {
       update(formula(outdmin[[1]]), NULL ~ .)
     )
   }
-  return(invisible(TRUE))
+  return()
 }
 
 # Helper function for checking the convergence of a single submodel fit (not of

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -142,6 +142,10 @@ divmin <- function(
       ))
     }
   }
+  # Check convergence (also taking messages and warnings into account):
+  if (getOption("projpred.check_conv", TRUE)) {
+    check_conv(outdmin, lengths(mssgs_warns_capts))
+  }
   return(outdmin)
 }
 
@@ -919,8 +923,9 @@ fit_categ_mlvl <- function(formula, projpred_formula_no_random,
 # Convergence checker -----------------------------------------------------
 
 # For checking the convergence of a whole `outdmin` object:
-check_conv <- function(fit) {
-  is_conv <- unlist(lapply(fit, check_conv_s))
+check_conv <- function(outdmin, lengths_mssgs_warns) {
+  is_conv <- unlist(lapply(outdmin, check_conv_s))
+  is_conv <- is_conv & (lengths_mssgs_warns == 0)
   if (any(!is_conv)) {
     warning(
       sum(!is_conv), " out of ", length(is_conv), " submodel fits (there is ",
@@ -929,7 +934,7 @@ check_conv <- function(fit) {
       "necessary) to adjust tuning parameters (e.g., for the lme4 package in ",
       "case of a multilevel submodel) via `...` or via a custom ",
       "`divergence_minimizer` function. Formula (right-hand side): ",
-      update(formula(fit[[1]]), NULL ~ .)
+      update(formula(outdmin[[1]]), NULL ~ .)
     )
   }
   return(invisible(TRUE))

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -953,8 +953,9 @@ warn_prj_drawwise <- function(mssgs_warns_capts, throw_warn = TRUE) {
   mssgs_warns_capts_unq <- unique(unlist(mssgs_warns_capts))
   if (length(mssgs_warns_capts_unq) > 0) {
     warning(paste(
-      c(paste0("The following warnings have been thrown by the current ",
-               "submodel fitter (i.e., draw-wise divergence minimizer):"),
+      c(paste0("The following messages and/or warnings have been thrown by ",
+               "the current submodel fitter (i.e., the current draw-wise ",
+               "divergence minimizer):"),
         "---", mssgs_warns_capts_unq, "---"),
       collapse = "\n"
     ))

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -985,7 +985,9 @@ check_conv <- function(outdmin, lengths_mssgs_warns, do_check = TRUE) {
 # Helper function for checking the convergence of a single submodel fit (not of
 # a whole `outdmin` object):
 check_conv_s <- function(fit_s) {
-  if (inherits(fit_s, "gam")) {
+  if (inherits(fit_s, "polr")) {
+    return(fit_s$convergence == 0)
+  } else if (inherits(fit_s, "gam")) {
     # TODO (GAMs): Is this correct?:
     return(fit_s$converged && fit_s$mgcv.conv$fully.converged)
   } else if (inherits(fit_s, "gamm4")) {

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -985,7 +985,9 @@ check_conv <- function(outdmin, lengths_mssgs_warns, do_check = TRUE) {
 # Helper function for checking the convergence of a single submodel fit (not of
 # a whole `outdmin` object):
 check_conv_s <- function(fit_s) {
-  if (inherits(fit_s, "polr")) {
+  if (inherits(fit_s, "clmm")) {
+    return(fit_s$optRes$convergence == 0)
+  } else if (inherits(fit_s, "polr")) {
     return(fit_s$convergence == 0)
   } else if (inherits(fit_s, "gam")) {
     # TODO (GAMs): Is this correct?:

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -132,16 +132,7 @@ divmin <- function(
     return(mssgs_warns_capt)
   })
   # Throw the unique set of messages and warnings:
-  if (getOption("projpred.warn_submodel_fits", TRUE)) {
-    mssgs_warns_capts_unq <- unique(unlist(mssgs_warns_capts))
-    if (length(mssgs_warns_capts_unq) > 0) {
-      warning(paste(
-        c("The following warnings have been thrown by submodel fitters:",
-          mssgs_warns_capts_unq),
-        collapse = "\n"
-      ))
-    }
-  }
+  warn_submodel_fits(mssgs_warns_capts)
   # Check convergence (also taking messages and warnings into account):
   check_conv(outdmin, lengths(mssgs_warns_capts))
   return(outdmin)
@@ -918,7 +909,20 @@ fit_categ_mlvl <- function(formula, projpred_formula_no_random,
   return(fitobj)
 }
 
-# Convergence checker -----------------------------------------------------
+# Convergence issues ------------------------------------------------------
+
+warn_submodel_fits <- function(mssgs_warns_capts) {
+  if (!getOption("projpred.warn_submodel_fits", TRUE)) return()
+  mssgs_warns_capts_unq <- unique(unlist(mssgs_warns_capts))
+  if (length(mssgs_warns_capts_unq) > 0) {
+    warning(paste(
+      c("The following warnings have been thrown by submodel fitters:", "---",
+        mssgs_warns_capts_unq, "---"),
+      collapse = "\n"
+    ))
+  }
+  return()
+}
 
 # For checking the convergence of a whole `outdmin` object:
 check_conv <- function(outdmin, lengths_mssgs_warns) {

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -967,7 +967,17 @@ warn_prj_drawwise <- function(mssgs_warns_capts, throw_warn = TRUE) {
 # argument `lengths_mssgs_warns` which must be of the same length as `outdmin`):
 check_conv <- function(outdmin, lengths_mssgs_warns, do_check = TRUE) {
   if (!do_check) return()
-  is_conv <- unlist(lapply(outdmin, check_conv_s))
+  is_conv <- tryCatch(
+    unlist(lapply(outdmin, check_conv_s)),
+    error = function(e) {
+      warning("The draw-wise convergence checker errored with message \n```\n",
+              e, "```\nso the convergence of the current submodel fits cannot ",
+              "be checked. Please notify the package maintainer. Current ",
+              "submodel formula (right-hand side): ",
+              update(formula(outdmin[[1]]), NULL ~ .))
+      return(rep(TRUE, length(outdmin)))
+    }
+  )
   is_conv <- is_conv & (lengths_mssgs_warns == 0)
   not_conv <- sum(!is_conv)
   if (not_conv > 0) {

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -939,9 +939,8 @@ check_conv <- function(fit) {
 # a whole `outdmin` object):
 check_conv_s <- function(fit_s) {
   if (inherits(fit_s, "gam")) {
-    # TODO (GAMs): There is also `fit_s$mgcv.conv` (see `?mgcv::gamObject`).
-    # Do we need to take this into account?
-    return(fit_s$converged)
+    # TODO (GAMs): Is this correct?:
+    return(fit_s$converged && fit_s$mgcv.conv$fully.converged)
   } else if (inherits(fit_s, "gamm4")) {
     # TODO (GAMMs): I couldn't find any convergence-related information in
     # element `fit_s$gam`, so the GAM part is currently not checked for

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -117,8 +117,8 @@ divmin <- function(
   outdmin <- lapply(outdmin, "[[", "soutdmin")
   # Filter out some warnings:
   mssgs_warns_capts <- setdiff(mssgs_warns_capts, "")
-  mssgs_warns_capts <- grep("Warning in .*:$", mssgs_warns_capts, value = TRUE,
-                            invert = TRUE)
+  mssgs_warns_capts <- grep("Warning in [^:]*:$",
+                            mssgs_warns_capts, value = TRUE, invert = TRUE)
   mssgs_warns_capts <- grep("non-integer #successes in a binomial glm!$",
                             mssgs_warns_capts, value = TRUE, invert = TRUE)
   mssgs_warns_capts <- grep(paste("Using formula\\(x\\) is deprecated when x",

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -959,8 +959,8 @@ check_conv_s <- function(fit_s) {
   } else if (inherits(fit_s, "glm")) {
     return(fit_s$converged)
   } else if (inherits(fit_s, "lm")) {
-    # Note: There doesn't seem to be a better way to check for convergence
-    # other than checking `NA` coefficients (see below).
+    # There doesn't seem to be a better way to check for convergence other than
+    # checking `NA` coefficients:
     return(all(!is.na(coef(fit_s))))
   } else if (inherits(fit_s, "subfit")) {
     # Note: There doesn't seem to be any way to check for convergence, so

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -716,7 +716,7 @@ fit_cumul <- function(formula, data, family, weights, ...) {
     # Start with thresholds which imply equal probabilities for the response
     # categories:
     start_thres <- linkfun_raw(seq_len(nthres) / ncats, link_nm = link_nm)
-    fitobj <- try(do.call(MASS::polr, c(
+    fitobj <- do.call(MASS::polr, c(
       list(formula = formula,
            data = data,
            weights = quote(projpred_internal_w_aug),
@@ -724,9 +724,8 @@ fit_cumul <- function(formula, data, family, weights, ...) {
            method = link_nm,
            start = c(start_coefs, start_thres)),
       dot_args
-    )), silent = TRUE)
-  }
-  if (inherits(fitobj, "try-error")) {
+    ))
+  } else if (inherits(fitobj, "try-error")) {
     stop(attr(fitobj, "condition")$message)
   }
   return(fitobj)
@@ -768,7 +767,7 @@ fit_cumul_mlvl <- function(formula, data, family, weights, ...) {
     link_nm <- "probit"
   }
   # Call the submodel fitter:
-  fitobj <- try(do.call(ordinal::clmm, c(
+  fitobj <- do.call(ordinal::clmm, c(
     list(formula = formula,
          data = data,
          weights = quote(projpred_internal_w_aug),
@@ -777,10 +776,7 @@ fit_cumul_mlvl <- function(formula, data, family, weights, ...) {
          model = FALSE,
          link = link_nm),
     dot_args
-  )), silent = TRUE)
-  if (inherits(fitobj, "try-error")) {
-    stop(attr(fitobj, "condition")$message)
-  }
+  ))
   # Needed for the ordinal:::predict.clm() workaround (the value `"negative"` is
   # the default, see `?ordinal::clm.control`):
   fitobj$control$sign.location <- "negative"

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -117,6 +117,13 @@ divmin <- function(
   }
   mssgs_warns_capts <- lapply(outdmin, "[[", "mssgs_warns_capt")
   outdmin <- lapply(outdmin, "[[", "soutdmin")
+  mssgs_warns_capts <- lapply(mssgs_warns_capts, function(mssgs_warns_capt) {
+    # Filter out some warnings.
+    mssgs_warns_capt <- setdiff(mssgs_warns_capt, "")
+    mssgs_warns_capt <- grep("Warning in [^:]*:$",
+                             mssgs_warns_capt, value = TRUE, invert = TRUE)
+    return(mssgs_warns_capt)
+  })
   warn_submodel_fits(mssgs_warns_capts, throw_warn = throw_warn_sdivmin)
   check_conv(outdmin, lengths(mssgs_warns_capts), do_check = do_check_conv)
   return(outdmin)

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -13,6 +13,8 @@ divmin <- function(
     formula,
     projpred_var,
     verbose_divmin = getOption("projpred.verbose_project", FALSE),
+    throw_warn_sdivmin = getOption("projpred.warn_submodel_fits", TRUE),
+    do_check_conv = getOption("projpred.check_conv", TRUE),
     ...
 ) {
   trms_all <- extract_terms_response(formula)
@@ -132,9 +134,9 @@ divmin <- function(
     return(mssgs_warns_capt)
   })
   # Throw the unique set of messages and warnings:
-  warn_submodel_fits(mssgs_warns_capts)
+  warn_submodel_fits(mssgs_warns_capts, throw_warn = throw_warn_sdivmin)
   # Check convergence (also taking messages and warnings into account):
-  check_conv(outdmin, lengths(mssgs_warns_capts))
+  check_conv(outdmin, lengths(mssgs_warns_capts), do_check = do_check_conv)
   return(outdmin)
 }
 
@@ -911,8 +913,8 @@ fit_categ_mlvl <- function(formula, projpred_formula_no_random,
 
 # Convergence issues ------------------------------------------------------
 
-warn_submodel_fits <- function(mssgs_warns_capts) {
-  if (!getOption("projpred.warn_submodel_fits", TRUE)) return()
+warn_submodel_fits <- function(mssgs_warns_capts, throw_warn = TRUE) {
+  if (!throw_warn) return()
   mssgs_warns_capts_unq <- unique(unlist(mssgs_warns_capts))
   if (length(mssgs_warns_capts_unq) > 0) {
     warning(paste(
@@ -925,8 +927,8 @@ warn_submodel_fits <- function(mssgs_warns_capts) {
 }
 
 # For checking the convergence of a whole `outdmin` object:
-check_conv <- function(outdmin, lengths_mssgs_warns) {
-  if (!getOption("projpred.check_conv", TRUE)) return()
+check_conv <- function(outdmin, lengths_mssgs_warns, do_check = TRUE) {
+  if (!do_check) return()
   is_conv <- unlist(lapply(outdmin, check_conv_s))
   is_conv <- is_conv & (lengths_mssgs_warns == 0)
   if (any(!is_conv)) {

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -992,10 +992,10 @@ check_conv_s <- function(fit_s) {
     # checking `NA` coefficients:
     return(all(!is.na(coef(fit_s))))
   } else if (inherits(fit_s, "subfit")) {
-    # Note: There doesn't seem to be any way to check for convergence, so
-    # return `TRUE` for now.
-    # TODO (GLMs with ridge regularization): Add a logical indicating
-    # convergence to objects of class `subfit` (i.e., from glm_ridge())?
+    # For a submodel of class `subfit`, non-convergence is only indicated by
+    # output written to the console (which is converted to a warning in
+    # fit_glm_ridge_callback() and then checked in check_conv()), so we need to
+    # return `TRUE` here:
     return(TRUE)
   } else {
     warning("Unrecognized submodel fit. Please notify the package maintainer.")

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -992,7 +992,7 @@ check_conv <- function(outdmin, lengths_mssgs_warns, do_check = TRUE) {
     cls <- paste0("c(", paste(paste0("\"", cls, "\""), collapse = ", "), ")")
     warning(
       not_conv, " out of ", length(is_conv), " submodel fits (there is one ",
-      "submodel fit per projected draw) seem to have not converged ",
+      "submodel fit per projected draw) might not have converged ",
       "(appropriately). It is recommended to inspect this in detail and (if ",
       "necessary) to adjust tuning parameters via `...` (the ellipsis of the ",
       "employed top-level function such as project(), varsel(), or ",

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -13,7 +13,7 @@ divmin <- function(
     formula,
     projpred_var,
     verbose_divmin = getOption("projpred.verbose_project", FALSE),
-    throw_warn_sdivmin = getOption("projpred.warn_submodel_fits", TRUE),
+    throw_warn_sdivmin = getOption("projpred.warn_prj_drawwise", TRUE),
     do_check_conv = getOption("projpred.check_conv", TRUE),
     ...
 ) {
@@ -124,7 +124,7 @@ divmin <- function(
                              mssgs_warns_capt, value = TRUE, invert = TRUE)
     return(mssgs_warns_capt)
   })
-  warn_submodel_fits(mssgs_warns_capts, throw_warn = throw_warn_sdivmin)
+  warn_prj_drawwise(mssgs_warns_capts, throw_warn = throw_warn_sdivmin)
   check_conv(outdmin, lengths(mssgs_warns_capts), do_check = do_check_conv)
   return(outdmin)
 }
@@ -545,7 +545,7 @@ divmin_augdat <- function(
     projpred_var,
     projpred_ws_aug,
     verbose_divmin = getOption("projpred.verbose_project", FALSE),
-    throw_warn_sdivmin = getOption("projpred.warn_submodel_fits", TRUE),
+    throw_warn_sdivmin = getOption("projpred.warn_prj_drawwise", TRUE),
     do_check_conv = getOption("projpred.check_conv", TRUE),
     ...
 ) {
@@ -685,7 +685,7 @@ divmin_augdat <- function(
     )
     return(mssgs_warns_capt)
   })
-  warn_submodel_fits(mssgs_warns_capts, throw_warn = throw_warn_sdivmin)
+  warn_prj_drawwise(mssgs_warns_capts, throw_warn = throw_warn_sdivmin)
   check_conv(outdmin, lengths(mssgs_warns_capts), do_check = do_check_conv)
   return(outdmin)
 }
@@ -935,7 +935,7 @@ fit_categ_mlvl <- function(formula, projpred_formula_no_random,
 # Convergence issues ------------------------------------------------------
 
 # Throw unique messages and warnings from a list of messages and warnings:
-warn_submodel_fits <- function(mssgs_warns_capts, throw_warn = TRUE) {
+warn_prj_drawwise <- function(mssgs_warns_capts, throw_warn = TRUE) {
   if (!throw_warn) return()
   mssgs_warns_capts_unq <- unique(unlist(mssgs_warns_capts))
   if (length(mssgs_warns_capts_unq) > 0) {

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -948,14 +948,27 @@ check_conv <- function(outdmin, lengths_mssgs_warns, do_check = TRUE) {
   if (!do_check) return()
   is_conv <- unlist(lapply(outdmin, check_conv_s))
   is_conv <- is_conv & (lengths_mssgs_warns == 0)
-  if (any(!is_conv)) {
+  not_conv <- sum(!is_conv)
+  if (not_conv > 0) {
+    if (getOption("projpred.additional_checks", FALSE)) {
+      cls <- unique(lapply(outdmin, class))
+      stopifnot(length(cls) == 1)
+      cls <- cls[[1]]
+    } else {
+      cls <- class(outdmin[[1]])
+    }
+    cls <- paste0("c(", paste(paste0("\"", cls, "\""), collapse = ", "), ")")
     warning(
-      sum(!is_conv), " out of ", length(is_conv), " submodel fits (there is ",
-      "one submodel fit per projected draw) probably have not converged ",
+      not_conv, " out of ", length(is_conv), " submodel fits (there is one ",
+      "submodel fit per projected draw) seem to have not converged ",
       "(appropriately). It is recommended to inspect this in detail and (if ",
-      "necessary) to adjust tuning parameters (e.g., for the lme4 package in ",
-      "case of a multilevel submodel) via `...` or via a custom ",
-      "`divergence_minimizer` function. Formula (right-hand side): ",
+      "necessary) to adjust tuning parameters via `...` (the ellipsis of the ",
+      "employed top-level function such as project(), varsel(), or ",
+      "cv_varsel()) or via a custom `div_minimizer` function (an argument of ",
+      "init_refmodel()). In the present case, the submodel fits are of ",
+      "class(es) `", cls, "`. Documentation for corresponding tuning ",
+      "parameters is linked in section \"Draw-wise divergence minimizers\" of ",
+      "`` ?`projpred-package` ``. Current submodel formula (right-hand side): ",
       update(formula(outdmin[[1]]), NULL ~ .)
     )
   }

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -940,8 +940,9 @@ warn_submodel_fits <- function(mssgs_warns_capts, throw_warn = TRUE) {
   mssgs_warns_capts_unq <- unique(unlist(mssgs_warns_capts))
   if (length(mssgs_warns_capts_unq) > 0) {
     warning(paste(
-      c("The following warnings have been thrown by submodel fitters:", "---",
-        mssgs_warns_capts_unq, "---"),
+      c(paste0("The following warnings have been thrown by the current ",
+               "draw-wise divergence minimizer (i.e., \"submodel fitter\"):"),
+        "---", mssgs_warns_capts_unq, "---"),
       collapse = "\n"
     ))
   }

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -943,8 +943,11 @@ check_conv_s <- function(fit_s) {
     # Do we need to take this into account?
     return(fit_s$converged)
   } else if (inherits(fit_s, "gamm4")) {
-    # TODO (GAMMs): Needs to be implemented. Return `TRUE` for now.
-    return(TRUE)
+    # TODO (GAMMs): I couldn't find any convergence-related information in
+    # element `fit_s$gam`, so the GAM part is currently not checked for
+    # convergence. For now, all we can check is the GLMM part from element
+    # `fit_s$mer`:
+    return(check_conv_s(fit_s$mer))
   } else if (inherits(fit_s, c("lmerMod", "glmerMod"))) {
     # The following was inferred from the source code of lme4::checkConv() and
     # lme4::.prt.warn() (see also `?lme4::mkMerMod`).

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -922,12 +922,15 @@ fit_categ_mlvl <- function(formula, projpred_formula_no_random,
 check_conv <- function(fit) {
   is_conv <- unlist(lapply(fit, check_conv_s))
   if (any(!is_conv)) {
-    warning(sum(!is_conv), " out of ", length(is_conv), " submodel fits ",
-            "(there is one submodel fit per projected draw) probably have not ",
-            "converged (appropriately). It is recommended to inspect this in ",
-            "detail and (if necessary) to adjust lme4's tuning parameters via ",
-            "`...` or via a custom `divergence_minimizer` function. ",
-            "Formula (right-hand side): ", update(formula(fit[[1]]), NULL ~ .))
+    warning(
+      sum(!is_conv), " out of ", length(is_conv), " submodel fits (there is ",
+      "one submodel fit per projected draw) probably have not converged ",
+      "(appropriately). It is recommended to inspect this in detail and (if ",
+      "necessary) to adjust tuning parameters (e.g., for the lme4 package in ",
+      "case of a multilevel submodel) via `...` or via a custom ",
+      "`divergence_minimizer` function. Formula (right-hand side): ",
+      update(formula(fit[[1]]), NULL ~ .)
+    )
   }
   return(invisible(TRUE))
 }

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -971,7 +971,8 @@ check_conv_s <- function(fit_s) {
     # convergence to objects of class `subfit` (i.e., from glm_ridge())?
     return(TRUE)
   } else {
-    stop("Unrecognized submodel fit. Please notify the package maintainer.")
+    warning("Unrecognized submodel fit. Please notify the package maintainer.")
+    return(TRUE)
   }
 }
 

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -115,8 +115,8 @@ divmin <- function(
   }
   mssgs_warns_capts <- lapply(outdmin, "[[", "mssgs_warns_capt")
   outdmin <- lapply(outdmin, "[[", "soutdmin")
+  # Filter out some warnings:
   mssgs_warns_capts <- lapply(mssgs_warns_capts, function(mssgs_warns_capt) {
-    # Filter out some warnings:
     mssgs_warns_capt <- setdiff(mssgs_warns_capt, "")
     mssgs_warns_capt <- grep("Warning in [^:]*:$",
                              mssgs_warns_capt, value = TRUE, invert = TRUE)
@@ -131,10 +131,16 @@ divmin <- function(
     )
     return(mssgs_warns_capt)
   })
-  mssgs_warns_capts <- unique(unlist(mssgs_warns_capts))
-  if (length(mssgs_warns_capts) > 0 &&
-      getOption("projpred.warn_submodel_fits", TRUE)) {
-    warning(mssgs_warns_capts)
+  # Throw the unique set of messages and warnings:
+  if (getOption("projpred.warn_submodel_fits", TRUE)) {
+    mssgs_warns_capts_unq <- unique(unlist(mssgs_warns_capts))
+    if (length(mssgs_warns_capts_unq) > 0) {
+      warning(paste(
+        c("The following warnings have been thrown by submodel fitters:",
+          mssgs_warns_capts_unq),
+        collapse = "\n"
+      ))
+    }
   }
   return(outdmin)
 }

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -113,22 +113,25 @@ divmin <- function(
       return(nlist(soutdmin, mssgs_warns_capt))
     }
   }
-  mssgs_warns_capts <- unlist(lapply(outdmin, "[[", "mssgs_warns_capt"))
+  mssgs_warns_capts <- lapply(outdmin, "[[", "mssgs_warns_capt")
   outdmin <- lapply(outdmin, "[[", "soutdmin")
-  # Filter out some warnings:
-  mssgs_warns_capts <- setdiff(mssgs_warns_capts, "")
-  mssgs_warns_capts <- grep("Warning in [^:]*:$",
-                            mssgs_warns_capts, value = TRUE, invert = TRUE)
-  mssgs_warns_capts <- grep("non-integer #successes in a binomial glm!$",
-                            mssgs_warns_capts, value = TRUE, invert = TRUE)
-  mssgs_warns_capts <- grep(paste("Using formula\\(x\\) is deprecated when x",
-                                  "is a character vector of length > 1\\.$"),
-                            mssgs_warns_capts, value = TRUE, invert = TRUE)
-  mssgs_warns_capts <- grep(
-    "Consider formula\\(paste\\(x, collapse = .*\\)\\) instead\\.$",
-    mssgs_warns_capts, value = TRUE, invert = TRUE
-  )
-  mssgs_warns_capts <- unique(mssgs_warns_capts)
+  mssgs_warns_capts <- lapply(mssgs_warns_capts, function(mssgs_warns_capt) {
+    # Filter out some warnings:
+    mssgs_warns_capt <- setdiff(mssgs_warns_capt, "")
+    mssgs_warns_capt <- grep("Warning in [^:]*:$",
+                             mssgs_warns_capt, value = TRUE, invert = TRUE)
+    mssgs_warns_capt <- grep("non-integer #successes in a binomial glm!$",
+                             mssgs_warns_capt, value = TRUE, invert = TRUE)
+    mssgs_warns_capt <- grep(paste("Using formula\\(x\\) is deprecated when x",
+                                   "is a character vector of length > 1\\.$"),
+                             mssgs_warns_capt, value = TRUE, invert = TRUE)
+    mssgs_warns_capt <- grep(
+      "Consider formula\\(paste\\(x, collapse = .*\\)\\) instead\\.$",
+      mssgs_warns_capt, value = TRUE, invert = TRUE
+    )
+    return(mssgs_warns_capt)
+  })
+  mssgs_warns_capts <- unique(unlist(mssgs_warns_capts))
   if (length(mssgs_warns_capts) > 0 &&
       getOption("projpred.warn_submodel_fits", TRUE)) {
     warning(mssgs_warns_capts)

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -143,9 +143,7 @@ divmin <- function(
     }
   }
   # Check convergence (also taking messages and warnings into account):
-  if (getOption("projpred.check_conv", TRUE)) {
-    check_conv(outdmin, lengths(mssgs_warns_capts))
-  }
+  check_conv(outdmin, lengths(mssgs_warns_capts))
   return(outdmin)
 }
 
@@ -924,6 +922,7 @@ fit_categ_mlvl <- function(formula, projpred_formula_no_random,
 
 # For checking the convergence of a whole `outdmin` object:
 check_conv <- function(outdmin, lengths_mssgs_warns) {
+  if (!getOption("projpred.check_conv", TRUE)) return()
   is_conv <- unlist(lapply(outdmin, check_conv_s))
   is_conv <- is_conv & (lengths_mssgs_warns == 0)
   if (any(!is_conv)) {

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -985,7 +985,9 @@ check_conv <- function(outdmin, lengths_mssgs_warns, do_check = TRUE) {
 # Helper function for checking the convergence of a single submodel fit (not of
 # a whole `outdmin` object):
 check_conv_s <- function(fit_s) {
-  if (inherits(fit_s, "clmm")) {
+  if (inherits(fit_s, "multinom")) {
+    return(fit_s$convergence == 0)
+  } else if (inherits(fit_s, "clmm")) {
     return(fit_s$optRes$convergence == 0)
   } else if (inherits(fit_s, "polr")) {
     return(fit_s$convergence == 0)

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -985,7 +985,9 @@ check_conv <- function(outdmin, lengths_mssgs_warns, do_check = TRUE) {
 # Helper function for checking the convergence of a single submodel fit (not of
 # a whole `outdmin` object):
 check_conv_s <- function(fit_s) {
-  if (inherits(fit_s, "multinom")) {
+  if (inherits(fit_s, "mmblogit")) {
+    return(fit_s$converged)
+  } else if (inherits(fit_s, "multinom")) {
     return(fit_s$convergence == 0)
   } else if (inherits(fit_s, "clmm")) {
     return(fit_s$optRes$convergence == 0)

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -934,14 +934,15 @@ fit_categ_mlvl <- function(formula, projpred_formula_no_random,
 
 # Convergence issues ------------------------------------------------------
 
-# Throw unique messages and warnings from a list of messages and warnings:
+# Throw unique messages and warnings from a list of messages and warnings
+# retrieved during draw-wise projections:
 warn_prj_drawwise <- function(mssgs_warns_capts, throw_warn = TRUE) {
   if (!throw_warn) return()
   mssgs_warns_capts_unq <- unique(unlist(mssgs_warns_capts))
   if (length(mssgs_warns_capts_unq) > 0) {
     warning(paste(
       c(paste0("The following warnings have been thrown by the current ",
-               "draw-wise divergence minimizer (i.e., \"submodel fitter\"):"),
+               "submodel fitter (i.e., draw-wise divergence minimizer):"),
         "---", mssgs_warns_capts_unq, "---"),
       collapse = "\n"
     ))

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -965,15 +965,18 @@ check_conv <- function(outdmin, lengths_mssgs_warns, do_check = TRUE) {
 # Helper function for checking the convergence of a single submodel fit (not of
 # a whole `outdmin` object):
 check_conv_s <- function(fit_s) {
-  if (inherits(fit_s, "gam")) {
-    # TODO (GAMs): Is this correct?:
-    return(fit_s$converged && fit_s$mgcv.conv$fully.converged)
-  } else if (inherits(fit_s, "gamm4")) {
-    # TODO (GAMMs): I couldn't find any convergence-related information in
-    # element `fit_s$gam`, so the GAM part is currently not checked for
-    # convergence. For now, all we can check is the GLMM part from element
-    # `fit_s$mer`:
-    return(check_conv_s(fit_s$mer))
+  if (inherits(fit_s, "subfit")) {
+    # For a submodel of class `subfit`, non-convergence is only indicated by
+    # output written to the console (which is converted to a warning in
+    # fit_glm_ridge_callback() and then checked in check_conv()), so we need to
+    # return `TRUE` here:
+    return(TRUE)
+  } else if (inherits(fit_s, "lm")) {
+    # There doesn't seem to be a better way to check for convergence other than
+    # checking `NA` coefficients:
+    return(all(!is.na(coef(fit_s))))
+  } else if (inherits(fit_s, "glm")) {
+    return(fit_s$converged)
   } else if (inherits(fit_s, c("lmerMod", "glmerMod"))) {
     # The following was inferred from the source code of lme4::checkConv() and
     # lme4::.prt.warn() (see also `?lme4::mkMerMod`).
@@ -985,18 +988,15 @@ check_conv_s <- function(fit_s) {
         is.null(fit_s@optinfo$conv$lme4$code)
     ) && length(unlist(fit_s@optinfo$conv$lme4$messages)) == 0 &&
       length(fit_s@optinfo$warnings) == 0)
-  } else if (inherits(fit_s, "glm")) {
-    return(fit_s$converged)
-  } else if (inherits(fit_s, "lm")) {
-    # There doesn't seem to be a better way to check for convergence other than
-    # checking `NA` coefficients:
-    return(all(!is.na(coef(fit_s))))
-  } else if (inherits(fit_s, "subfit")) {
-    # For a submodel of class `subfit`, non-convergence is only indicated by
-    # output written to the console (which is converted to a warning in
-    # fit_glm_ridge_callback() and then checked in check_conv()), so we need to
-    # return `TRUE` here:
-    return(TRUE)
+  } else if (inherits(fit_s, "gam")) {
+    # TODO (GAMs): Is this correct?:
+    return(fit_s$converged && fit_s$mgcv.conv$fully.converged)
+  } else if (inherits(fit_s, "gamm4")) {
+    # TODO (GAMMs): I couldn't find any convergence-related information in
+    # element `fit_s$gam`, so the GAM part is currently not checked for
+    # convergence. For now, all we can check is the GLMM part from element
+    # `fit_s$mer`:
+    return(check_conv_s(fit_s$mer))
   } else {
     warning("Unrecognized submodel fit. Please notify the package maintainer.")
     return(TRUE)

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -149,8 +149,8 @@ perf_eval <- function(search_path,
   return(out)
 }
 
-# Process the output of the `divergence_minimizer` function (see
-# init_refmodel()) to create an object of class `submodl`.
+# Process the output of the `div_minimizer` function (see init_refmodel()) to
+# create an object of class `submodl`.
 init_submodl <- function(outdmin, p_ref, refmodel, predictor_terms, wobs) {
   p_ref$mu <- p_ref$mu_offs
   if (!(all(is.na(p_ref$var)) ||

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -39,10 +39,6 @@ proj_to_submodl <- function(predictor_terms, p_ref, refmodel,
   }
   outdmin <- do.call(refmodel$div_minimizer, args_divmin)
 
-  if (getOption("projpred.check_conv", TRUE)) {
-    check_conv(outdmin)
-  }
-
   return(init_submodl(
     outdmin = outdmin, p_ref = p_ref, refmodel = refmodel,
     predictor_terms = predictor_terms, wobs = refmodel$wobs

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -39,7 +39,7 @@ proj_to_submodl <- function(predictor_terms, p_ref, refmodel,
   }
   outdmin <- do.call(refmodel$div_minimizer, args_divmin)
 
-  if (isTRUE(getOption("projpred.check_conv", FALSE))) {
+  if (getOption("projpred.check_conv", TRUE)) {
     check_conv(outdmin)
   }
 

--- a/R/projpred-package.R
+++ b/R/projpred-package.R
@@ -82,17 +82,28 @@
 #' * Submodel with multilevel and additive terms: [gamm4::gamm4()] (within
 #' \pkg{projpred}, the returned object inherits from class `gamm4`).
 #'
-#' # Verbosity
+#' # Verbosity, messages, warnings, errors
 #'
-#' Setting the global option `projpred.extra_verbose` to `TRUE` will print out
-#' which submodel \pkg{projpred} is currently projecting onto as well as (if
-#' `method = "forward"` and `verbose = TRUE` in [varsel()] or [cv_varsel()])
-#' which submodel has been selected at those steps of the forward search for
-#' which a percentage (of the maximum submodel size that the search is run up
-#' to) is printed. In general, however, we cannot recommend setting this global
-#' option to `TRUE` for [cv_varsel()] with `validate_search = TRUE` (simply due
-#' to the amount of information that will be printed, but also due to the
-#' progress bar which will not work anymore as intended).
+#' Setting global option `projpred.extra_verbose` to `TRUE` will print out which
+#' submodel \pkg{projpred} is currently projecting onto as well as (if `method =
+#' "forward"` and `verbose = TRUE` in [varsel()] or [cv_varsel()]) which
+#' submodel has been selected at those steps of the forward search for which a
+#' percentage (of the maximum submodel size that the search is run up to) is
+#' printed. In general, however, we cannot recommend setting this global option
+#' to `TRUE` for [cv_varsel()] with `validate_search = TRUE` (simply due to the
+#' amount of information that will be printed, but also due to the progress bar
+#' which will not work as intended anymore).
+#'
+#' By default, \pkg{projpred} catches messages and warnings from the draw-wise
+#' divergence minimizers and throws their unique collection after performing all
+#' draw-wise divergence minimizations (i.e., draw-wise projections). This can be
+#' deactivated by setting global option `projpred.warn_prj_drawwise` to `FALSE`.
+#'
+#' Furthermore, by default, \pkg{projpred} checks the convergence of the
+#' draw-wise divergence minimizers and throws a warning if any seem to have not
+#' converged. This warning is thrown after the warning message from global
+#' option `projpred.warn_prj_drawwise` (see above) and can be deactivated by
+#' setting global option `projpred.check_conv` to `FALSE`.
 #'
 #' # Parallelization
 #'

--- a/R/search.R
+++ b/R/search.R
@@ -223,7 +223,15 @@ search_L1_surrogate <- function(p_ref, d_train, family, intercept, nterms_max,
   )
   out_capt <- unique(grep("[Ww]arning|bug", out_capt, value = TRUE))
   if (length(out_capt) > 0) {
-    warning(paste(out_capt, collapse = "\n"))
+    warning(paste(
+      c(paste0("The following warnings have been thrown by projpred's ",
+               "internal L1-search function:"),
+        "---", out_capt, "---",
+        paste0("It is recommended to inspect this in detail and (if ",
+               "necessary) to adjust tuning parameters via argument ",
+               "`search_control` (of varsel() or cv_varsel()).")),
+      collapse = "\n"
+    ))
   }
 
   ## sort the variables according to the order in which they enter the model in

--- a/R/search.R
+++ b/R/search.R
@@ -212,15 +212,19 @@ search_L1_surrogate <- function(p_ref, d_train, family, intercept, nterms_max,
   ## (Notice: here we use pmax = nterms_max+1 so that the computation gets
   ## carried until all the way down to the least regularization also for model
   ## size nterms_max)
-  search <- glm_elnet(
-    d_train$x, mu, family,
-    lambda_min_ratio = search_control$lambda_min_ratio %||% 1e-5,
-    nlambda = search_control$nlambda %||% 150,
-    pmax = nterms_max + 1, pmax_strict = FALSE,
-    weights = d_train$weights,
-    intercept = intercept, obsvar = v, penalty = penalty,
-    thresh = search_control$thresh %||% 1e-6
+  out_capt <- utils::capture.output(
+    search <- glm_elnet(
+      d_train$x, mu, family,
+      lambda_min_ratio = search_control$lambda_min_ratio %||% 1e-5,
+      nlambda = search_control$nlambda %||% 150, pmax = nterms_max + 1,
+      pmax_strict = FALSE, weights = d_train$weights, intercept = intercept,
+      obsvar = v, penalty = penalty, thresh = search_control$thresh %||% 1e-6
+    )
   )
+  out_capt <- grep("[Ww]arning|bug", out_capt, value = TRUE)
+  if (length(out_capt) > 0) {
+    warning(paste(out_capt, collapse = "\n"))
+  }
 
   ## sort the variables according to the order in which they enter the model in
   ## the L1-path

--- a/R/search.R
+++ b/R/search.R
@@ -221,7 +221,7 @@ search_L1_surrogate <- function(p_ref, d_train, family, intercept, nterms_max,
       obsvar = v, penalty = penalty, thresh = search_control$thresh %||% 1e-6
     )
   )
-  out_capt <- grep("[Ww]arning|bug", out_capt, value = TRUE)
+  out_capt <- unique(grep("[Ww]arning|bug", out_capt, value = TRUE))
   if (length(out_capt) > 0) {
     warning(paste(out_capt, collapse = "\n"))
   }

--- a/man/projpred-package.Rd
+++ b/man/projpred-package.Rd
@@ -81,16 +81,26 @@ object inherits from class \code{gam}).
 }
 }
 
-\section{Verbosity}{
-Setting the global option \code{projpred.extra_verbose} to \code{TRUE} will print out
-which submodel \pkg{projpred} is currently projecting onto as well as (if
-\code{method = "forward"} and \code{verbose = TRUE} in \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}})
-which submodel has been selected at those steps of the forward search for
-which a percentage (of the maximum submodel size that the search is run up
-to) is printed. In general, however, we cannot recommend setting this global
-option to \code{TRUE} for \code{\link[=cv_varsel]{cv_varsel()}} with \code{validate_search = TRUE} (simply due
-to the amount of information that will be printed, but also due to the
-progress bar which will not work anymore as intended).
+\section{Verbosity, messages, warnings, errors}{
+Setting global option \code{projpred.extra_verbose} to \code{TRUE} will print out which
+submodel \pkg{projpred} is currently projecting onto as well as (if \code{method = "forward"} and \code{verbose = TRUE} in \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}}) which
+submodel has been selected at those steps of the forward search for which a
+percentage (of the maximum submodel size that the search is run up to) is
+printed. In general, however, we cannot recommend setting this global option
+to \code{TRUE} for \code{\link[=cv_varsel]{cv_varsel()}} with \code{validate_search = TRUE} (simply due to the
+amount of information that will be printed, but also due to the progress bar
+which will not work as intended anymore).
+
+By default, \pkg{projpred} catches messages and warnings from the draw-wise
+divergence minimizers and throws their unique collection after performing all
+draw-wise divergence minimizations (i.e., draw-wise projections). This can be
+deactivated by setting global option \code{projpred.warn_prj_drawwise} to \code{FALSE}.
+
+Furthermore, by default, \pkg{projpred} checks the convergence of the
+draw-wise divergence minimizers and throws a warning if any seem to have not
+converged. This warning is thrown after the warning message from global
+option \code{projpred.warn_prj_drawwise} (see above) and can be deactivated by
+setting global option \code{projpred.check_conv} to \code{FALSE}.
 }
 
 \section{Parallelization}{

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -904,6 +904,8 @@ options(projpred.additional_checks = TRUE)
 # Suppress the warning thrown if `cvrefbuilder` is `NULL` (here in the tests,
 # this should only be relevant for `datafit`s):
 options(projpred.warn_cvrefbuilder_NULL = FALSE)
+# Suppress warnings thrown while fitting the submodels:
+options(projpred.warn_submodel_fits = FALSE)
 # Set default number of significant digits to be printed:
 options(projpred.digits = getOption("digits"))
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -906,6 +906,8 @@ options(projpred.additional_checks = TRUE)
 options(projpred.warn_cvrefbuilder_NULL = FALSE)
 # Suppress warnings thrown while fitting the submodels:
 options(projpred.warn_submodel_fits = FALSE)
+# Don't use the convergence checker:
+options(projpred.check_conv = FALSE)
 # Set default number of significant digits to be printed:
 options(projpred.digits = getOption("digits"))
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1145,9 +1145,14 @@ if (run_vs) {
       warn_expected <- "non-integer #successes in a binomial glm!"
     } else if (!is.null(args_vs_i$avoid.increase)) {
       warn_expected <- warn_mclogit
-    } else if (args_vs_i$mod_nm %in% c("glmm", "gamm") &&
-               args_vs_i$fam_nm %in% c("brnll", "binom")) {
+    } else if ((args_vs_i$mod_nm == "glmm" &&
+                args_vs_i$fam_nm %in% c("brnll", "binom", "cumul")) ||
+               (args_vs_i$mod_nm == "gamm" &&
+                args_vs_i$fam_nm %in% c("brnll", "binom") &&
+                args_vs_i$prj_nm == "trad_compare")) {
       warn_expected <- "boundary"
+    } else if (args_vs_i$mod_nm == "gamm" && args_vs_i$fam_nm == "gauss") {
+      warn_expected <- "seem to have not converged"
     } else {
       warn_expected <- NA
     }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -904,10 +904,6 @@ options(projpred.additional_checks = TRUE)
 # Suppress the warning thrown if `cvrefbuilder` is `NULL` (here in the tests,
 # this should only be relevant for `datafit`s):
 options(projpred.warn_cvrefbuilder_NULL = FALSE)
-# Suppress warnings thrown while fitting the submodels:
-options(projpred.warn_prj_drawwise = FALSE)
-# Don't use the convergence checker:
-options(projpred.check_conv = FALSE)
 # Set default number of significant digits to be printed:
 options(projpred.digits = getOption("digits"))
 
@@ -1149,6 +1145,9 @@ if (run_vs) {
       warn_expected <- "non-integer #successes in a binomial glm!"
     } else if (!is.null(args_vs_i$avoid.increase)) {
       warn_expected <- warn_mclogit
+    } else if (args_vs_i$mod_nm %in% c("glmm", "gamm") &&
+               args_vs_i$fam_nm %in% c("brnll", "binom")) {
+      warn_expected <- "boundary"
     } else {
       warn_expected <- NA
     }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -905,7 +905,7 @@ options(projpred.additional_checks = TRUE)
 # this should only be relevant for `datafit`s):
 options(projpred.warn_cvrefbuilder_NULL = FALSE)
 # Suppress warnings thrown while fitting the submodels:
-options(projpred.warn_submodel_fits = FALSE)
+options(projpred.warn_prj_drawwise = FALSE)
 # Don't use the convergence checker:
 options(projpred.check_conv = FALSE)
 # Set default number of significant digits to be printed:

--- a/tests/testthat/test_div_minimizer.R
+++ b/tests/testthat/test_div_minimizer.R
@@ -163,7 +163,12 @@ test_that("divmin_augdat() works", {
         "length > 1"
       )
     } else if (fam_crr == "categ" && mod_crr == "glmm") {
-      warn_expected <- warn_mclogit
+      warn_expected <- if (packageVersion("mclogit") >= "0.9.6") {
+        "Inner iterations did not coverge"
+      } else {
+        paste0("^step size truncated due to possible divergence$|",
+               "^Algorithm stopped due to false convergence$")
+      }
     } else {
       warn_expected <- NA
     }

--- a/tests/testthat/test_parallel.R
+++ b/tests/testthat/test_parallel.R
@@ -65,8 +65,8 @@ test_that("cv_varsel() in parallel gives the same results as sequentially", {
   tstsetups <- grep("\\.glm\\.", names(cvvss), value = TRUE)
   for (tstsetup in tstsetups) {
     args_cvvs_i <- args_cvvs[[tstsetup]]
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     cvvs_repr <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]],
            cvfits = if (identical(args_cvvs_i$cv_method, "kfold")) {

--- a/tests/testthat/test_proj_pred.R
+++ b/tests/testthat/test_proj_pred.R
@@ -913,13 +913,6 @@ test_that(paste(
     } else {
       ncats_nlats_expected_crr <- integer()
     }
-    if (args_prj[[tstsetup]]$prj_nm == "augdat" &&
-        args_prj[[tstsetup]]$fam_nm == "cumul" &&
-        !any(grepl("\\|", args_prj[[tstsetup]]$predictor_terms))) {
-      warn_expected <- "non-integer #successes in a binomial glm!"
-    } else {
-      warn_expected <- NA
-    }
     pl_args <- list(refmods[[args_prj[[tstsetup]]$tstsetup_ref]],
                     newdata = head(get_dat(tstsetup), 1),
                     weightsnew = wobs_crr,
@@ -931,12 +924,10 @@ test_that(paste(
     if (args_prj[[tstsetup]]$fam_nm == "categ" &&
         any(grepl("\\|", args_prj[[tstsetup]]$predictor_terms))) {
       pl_args <- c(pl_args, list(avoid.increase = TRUE))
-      warn_expected <- warn_mclogit
     }
-    expect_warning(
-      pl1 <- do.call(proj_linpred, pl_args),
-      warn_expected
-    )
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
+    pl1 <- suppressWarnings(do.call(proj_linpred, pl_args))
     pl_tester(pl1,
               nprjdraws_expected = 1L,
               nobsv_expected = 1L,
@@ -1658,13 +1649,6 @@ test_that(paste(
     } else {
       offs_crr <- NULL
     }
-    if (args_prj[[tstsetup]]$prj_nm == "augdat" &&
-        args_prj[[tstsetup]]$fam_nm == "cumul" &&
-        !any(grepl("\\|", args_prj[[tstsetup]]$predictor_terms))) {
-      warn_expected <- "non-integer #successes in a binomial glm!"
-    } else {
-      warn_expected <- NA
-    }
     pp_args <- list(refmods[[args_prj[[tstsetup]]$tstsetup_ref]],
                     newdata = head(get_dat(tstsetup), 1),
                     weightsnew = wobs_crr,
@@ -1677,12 +1661,10 @@ test_that(paste(
     if (args_prj[[tstsetup]]$fam_nm == "categ" &&
         any(grepl("\\|", args_prj[[tstsetup]]$predictor_terms))) {
       pp_args <- c(pp_args, list(avoid.increase = TRUE))
-      warn_expected <- warn_mclogit
     }
-    expect_warning(
-      pp1 <- do.call(proj_predict, pp_args),
-      warn_expected
-    )
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
+    pp1 <- suppressWarnings(do.call(proj_predict, pp_args))
     pp_tester(pp1,
               nprjdraws_out_expected = 1L,
               nobsv_expected = 1L,

--- a/tests/testthat/test_proj_predfun.R
+++ b/tests/testthat/test_proj_predfun.R
@@ -411,7 +411,7 @@ test_that(paste(
     NA
   }
   expect_warning(
-    out_capt <- capture.output({
+    out_capt <- capture.output(
       mfit <- mclogit::mblogit(
         formula = cell ~ treat + age + Karn + prior,
         data = VA,
@@ -419,7 +419,7 @@ test_that(paste(
         model = FALSE,
         y = FALSE
       )
-    }),
+    ),
     warn_expected
   )
   expect_identical(tail(out_capt, 1), "converged")
@@ -653,7 +653,7 @@ test_that(paste(
     NA
   }
   expect_warning(
-    out_capt <- capture.output({
+    out_capt <- capture.output(
       mfit <- mclogit::mblogit(
         formula = cell ~ treat + age + Karn + prior,
         data = VA,
@@ -662,7 +662,7 @@ test_that(paste(
         model = FALSE,
         y = FALSE
       )
-    }),
+    ),
     warn_expected
   )
   expect_identical(tail(out_capt, 1), "converged")

--- a/tests/testthat/test_project.R
+++ b/tests/testthat/test_project.R
@@ -347,22 +347,12 @@ test_that("non-clustered projection does not require a seed", {
     args_prj_i <- args_prj[[tstsetup]]
     p_orig <- prjs[[tstsetup]]
     rand_new1 <- runif(1) # Just to advance `.Random.seed[2]`.
-    if (args_prj_i$prj_nm == "augdat" && args_prj_i$fam_nm == "cumul" &&
-        !any(grepl("\\|", args_prj_i$predictor_terms))) {
-      warn_expected <- "non-integer #successes in a binomial glm!"
-    } else if (!is.null(args_prj_i$avoid.increase) &&
-               any(grepl("\\|", args_prj_i$predictor_terms))) {
-      warn_expected <- warn_mclogit
-    } else {
-      warn_expected <- NA
-    }
-    expect_warning(
-      p_new <- do.call(project, c(
-        list(object = refmods[[args_prj_i$tstsetup_ref]]),
-        excl_nonargs(args_prj_i, nms_excl_add = "seed")
-      )),
-      warn_expected
-    )
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
+    p_new <- suppressWarnings(do.call(project, c(
+      list(object = refmods[[args_prj_i$tstsetup_ref]]),
+      excl_nonargs(args_prj_i, nms_excl_add = "seed")
+    )))
     if (args_prj_i$mod_nm %in% c("glmm", "gamm") &&
         any(grepl("\\|", args_prj_i$predictor_terms))) {
       if (getOption("projpred.mlvl_pred_new", FALSE)) {

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -135,20 +135,12 @@ test_that(paste(
       }
     }
     d_test_crr$y_oscale <- y_oscale_crr
-    if (prj_crr == "augdat" && fam_crr == "cumul") {
-      warn_expected <- "non-integer #successes in a binomial glm!"
-    } else if (!is.null(args_vs_i$avoid.increase)) {
-      warn_expected <- warn_mclogit
-    } else {
-      warn_expected <- NA
-    }
-    expect_warning(
-      vs_repr <- do.call(varsel, c(
-        list(object = refmods[[tstsetup_ref]], d_test = d_test_crr),
-        excl_nonargs(args_vs_i)
-      )),
-      warn_expected
-    )
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
+    vs_repr <- suppressWarnings(do.call(varsel, c(
+      list(object = refmods[[tstsetup_ref]], d_test = d_test_crr),
+      excl_nonargs(args_vs_i)
+    )))
     meth_exp_crr <- args_vs_i$method %||% "forward"
     vsel_tester(
       vs_repr,
@@ -263,20 +255,12 @@ test_that(paste(
       }
     }
     d_test_crr$y_oscale <- y_oscale_crr
-    if (prj_crr == "augdat" && fam_crr == "cumul") {
-      warn_expected <- "non-integer #successes in a binomial glm!"
-    } else if (!is.null(args_vs_i$avoid.increase)) {
-      warn_expected <- warn_mclogit
-    } else {
-      warn_expected <- NA
-    }
-    expect_warning(
-      vs_indep <- do.call(varsel, c(
-        list(object = refmods[[tstsetup_ref]], d_test = d_test_crr),
-        excl_nonargs(args_vs_i)
-      )),
-      warn_expected
-    )
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
+    vs_indep <- suppressWarnings(do.call(varsel, c(
+      list(object = refmods[[tstsetup_ref]], d_test = d_test_crr),
+      excl_nonargs(args_vs_i)
+    )))
     meth_exp_crr <- args_vs_i$method %||% "forward"
     vsel_tester(
       vs_indep,
@@ -309,28 +293,22 @@ test_that(paste(
       # varsel() at the place where the new group-level effects are drawn (not
       # even `.seed = NA` with an appropriate preparation is possible).
 
-      if (!is.null(args_vs_i$avoid.increase)) {
-        warn_expected <- NA
-      }
       # For getting the correct seed in proj_linpred():
       set.seed(args_vs_i$seed)
       p_sel_dummy <- get_refdist(refmods[[tstsetup_ref]],
                                  nclusters = vs_indep$nprjdraws_search)
-      expect_warning(
-        pl_indep <- proj_linpred(
-          vs_indep,
-          newdata = dat_indep_crr,
-          offsetnew = d_test_crr$offset,
-          weightsnew = d_test_crr$weights,
-          transform = TRUE,
-          integrated = TRUE,
-          .seed = NA,
-          nterms = c(0L, seq_along(vs_indep$predictor_ranking)),
-          nclusters = args_vs_i$nclusters_pred,
-          seed = NA
-        ),
-        warn_expected
-      )
+      pl_indep <- suppressWarnings(proj_linpred(
+        vs_indep,
+        newdata = dat_indep_crr,
+        offsetnew = d_test_crr$offset,
+        weightsnew = d_test_crr$weights,
+        transform = TRUE,
+        integrated = TRUE,
+        .seed = NA,
+        nterms = c(0L, seq_along(vs_indep$predictor_ranking)),
+        nclusters = args_vs_i$nclusters_pred,
+        seed = NA
+      ))
       summ_sub_ch <- lapply(pl_indep, function(pl_indep_k) {
         names(pl_indep_k)[names(pl_indep_k) == "pred"] <- "mu"
         names(pl_indep_k)[names(pl_indep_k) == "lpd"] <- "lppd"
@@ -525,21 +503,12 @@ test_that("`refit_prj` works", {
   for (tstsetup in tstsetups) {
     args_vs_i <- args_vs[[tstsetup]]
     args_vs_i$refit_prj <- FALSE
-    if (args_vs_i$prj_nm == "augdat" && args_vs_i$fam_nm == "cumul") {
-      warn_expected <- "non-integer #successes in a binomial glm!"
-    } else if (!is.null(args_vs_i$avoid.increase)) {
-      warn_expected <- warn_mclogit
-    } else {
-      warn_expected <- NA
-    }
-    expect_warning(
-      vs_reuse <- do.call(varsel, c(
-        list(object = refmods[[args_vs_i$tstsetup_ref]]),
-        excl_nonargs(args_vs_i)
-      )),
-      warn_expected,
-      info = tstsetup
-    )
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
+    vs_reuse <- suppressWarnings(do.call(varsel, c(
+      list(object = refmods[[args_vs_i$tstsetup_ref]]),
+      excl_nonargs(args_vs_i)
+    )))
     mod_crr <- args_vs_i$mod_nm
     fam_crr <- args_vs_i$fam_nm
     prj_crr <- args_vs_i$prj_nm
@@ -905,21 +874,13 @@ test_that("for forward search, `penalty` has no effect", {
   }
   for (tstsetup in tstsetups) {
     args_vs_i <- args_vs[[tstsetup]]
-    if (args_vs_i$prj_nm == "augdat" && args_vs_i$fam_nm == "cumul") {
-      warn_expected <- "non-integer #successes in a binomial glm!"
-    } else if (!is.null(args_vs_i$avoid.increase)) {
-      warn_expected <- warn_mclogit
-    } else {
-      warn_expected <- NA
-    }
-    expect_warning(
-      vs_penal <- do.call(varsel, c(
-        list(object = refmods[[args_vs_i$tstsetup_ref]],
-             penalty = penal_tst),
-        excl_nonargs(args_vs_i)
-      )),
-      warn_expected
-    )
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
+    vs_penal <- suppressWarnings(do.call(varsel, c(
+      list(object = refmods[[args_vs_i$tstsetup_ref]],
+           penalty = penal_tst),
+      excl_nonargs(args_vs_i)
+    )))
     vs_penal$args_search["penalty"] <- list(NULL)
     expect_equal(vs_penal, vss[[tstsetup]], info = tstsetup)
   }
@@ -1168,21 +1129,12 @@ test_that("varsel.vsel() works for `vsel` objects from cv_varsel()", {
     }
     fam_crr <- args_cvvs[[tstsetup]]$fam_nm
     prj_crr <- args_cvvs[[tstsetup]]$prj_nm
-    if (refit_prj_crr && prj_crr == "augdat" && fam_crr == "cumul") {
-      warn_expected <- "non-integer #successes in a binomial glm!"
-    } else if (refit_prj_crr &&
-               !is.null(args_cvvs[[tstsetup]]$avoid.increase)) {
-      warn_expected <- warn_mclogit
-    } else {
-      warn_expected <- NA
-    }
-    expect_warning(
-      vs_eval <- varsel(
-        cvvss[[tstsetup]], refit_prj = refit_prj_crr,
-        nclusters_pred = nclusters_pred_crr, verbose = FALSE, seed = seed2_tst
-      ),
-      warn_expected
-    )
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
+    vs_eval <- suppressWarnings(varsel(
+      cvvss[[tstsetup]], refit_prj = refit_prj_crr,
+      nclusters_pred = nclusters_pred_crr, verbose = FALSE, seed = seed2_tst
+    ))
     tstsetup_ref <- args_cvvs[[tstsetup]]$tstsetup_ref
     meth_exp_crr <- args_cvvs[[tstsetup]]$method %||% "forward"
     vsel_tester(
@@ -1297,8 +1249,8 @@ test_that("`seed` works (and restores the RNG state afterwards)", {
     cvvs_orig <- cvvss[[tstsetup]]
     rand_orig <- runif(1) # Just to advance `.Random.seed[2]`.
     .Random.seed_repr1 <- .Random.seed
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     cvvs_repr <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]],
            cvfits = if (identical(args_cvvs_i$cv_method, "kfold")) {
@@ -1427,8 +1379,8 @@ test_that("invalid `nloo` fails", {
                              invert = TRUE)
   for (tstsetup in head(tstsetups_nonkfold, 1)) {
     args_cvvs_i <- args_cvvs[[tstsetup]]
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     expect_error(
       suppressWarnings(do.call(cv_varsel, c(
         list(object = refmods[[args_cvvs_i$tstsetup_ref]],
@@ -1453,8 +1405,8 @@ test_that(paste(
   )
   for (tstsetup in tstsetups) {
     args_cvvs_i <- args_cvvs[[tstsetup]]
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     cvvs_nloo <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]],
            nloo = nloo_tst),
@@ -1488,8 +1440,8 @@ test_that("setting `nloo` smaller than the number of observations works", {
     fam_crr <- args_cvvs_i$fam_nm
     prj_crr <- args_cvvs_i$prj_nm
     meth_exp_crr <- args_cvvs_i$method %||% "forward"
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     cvvs_nloo <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]],
            nloo = nloo_tst),
@@ -1555,8 +1507,8 @@ test_that("`validate_search` works", {
     fam_crr <- args_cvvs_i$fam_nm
     prj_crr <- args_cvvs_i$prj_nm
     meth_exp_crr <- args_cvvs_i$method %||% "forward"
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     cvvs_valsearch <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmods[[args_cvvs_i$tstsetup_ref]],
            validate_search = FALSE,
@@ -1726,10 +1678,12 @@ test_that(paste(
     ))
 
     # Run cv_varsel():
-    cvvs_cvfits <- do.call(cv_varsel, c(
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
+    cvvs_cvfits <- suppressWarnings(do.call(cv_varsel, c(
       list(object = refmod_crr),
       excl_nonargs(args_cvvs_i, nms_excl_add = "K")
-    ))
+    )))
 
     # Checks:
     vsel_tester(
@@ -1947,8 +1901,8 @@ test_that(paste(
     refit_prj_crr <- !identical(args_cvvs[[tstsetup]]$validate_search, FALSE) ||
       identical(args_cvvs[[tstsetup]]$cv_method, "kfold")
     nclusters_pred_crr <- nclusters_pred_tst - if (refit_prj_crr) 1L else 0L
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     cvvs_eval <- suppressWarnings(cv_varsel(
       cvvss[[tstsetup]], refit_prj = refit_prj_crr,
       nclusters_pred = nclusters_pred_crr, verbose = FALSE, seed = seed2_tst
@@ -2004,8 +1958,8 @@ test_that(paste(
       refit_prj_crr <- FALSE
       nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred
     }
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     cvvs_eval <- suppressWarnings(cv_varsel(
       vss[[tstsetup]], validate_search = FALSE, refit_prj = refit_prj_crr,
       nclusters_pred = nclusters_pred_crr, verbose = FALSE, seed = seed2_tst
@@ -2069,8 +2023,8 @@ test_that(paste(
     } else {
       nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred
     }
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     cvvs_eval <- suppressWarnings(cv_varsel(
       vss[[tstsetup]], cv_method = "kfold", cvfits = cvfitss[[tstsetup_ref]],
       validate_search = FALSE, nclusters_pred = nclusters_pred_crr,
@@ -2112,8 +2066,8 @@ test_that(paste(
     if (isFALSE(args_cvvs[[tstsetup]]$validate_search)) {
       next
     }
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     if (identical(args_cvvs[[tstsetup]]$cv_method, "kfold")) {
       cvvs_eval <- suppressWarnings(cv_varsel(
         cvvss[[tstsetup]], cv_method = "LOO", validate_search = FALSE,
@@ -2192,8 +2146,8 @@ test_that(paste(
       next
     }
     nclusters_pred_crr <- args_cvvs[[tstsetup]]$nclusters_pred - 1L
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     if (identical(args_cvvs[[tstsetup]]$cv_method, "kfold")) {
       cvvs_eval <- suppressWarnings(cv_varsel(
         cvvss[[tstsetup]], validate_search = FALSE,
@@ -2252,8 +2206,8 @@ test_that(paste(
       next
     }
     nclusters_pred_crr <- args_cvvs[[tstsetup]]$nclusters_pred - 1L
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     if (identical(args_cvvs[[tstsetup]]$cv_method, "kfold")) {
       cv_meth_crr <- "LOO"
       cvvs_eval <- suppressWarnings(cv_varsel(
@@ -2315,8 +2269,8 @@ test_that(paste(
       next
     }
     nclusters_pred_crr <- args_cvvs[[tstsetup]]$nclusters_pred - 1L
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     if (identical(args_cvvs[[tstsetup]]$cv_method, "kfold")) {
       cv_meth_crr <- "LOO"
       cvvs_eval <- suppressWarnings(cv_varsel(
@@ -2369,8 +2323,8 @@ test_that(paste(
     } else {
       nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred
     }
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     cvvs_eval <- try(
       suppressWarnings(cv_varsel(
         vss[[tstsetup]], nclusters_pred = nclusters_pred_crr, verbose = FALSE,
@@ -2446,8 +2400,8 @@ test_that(paste(
     } else {
       nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred
     }
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     cvvs_eval <- try(
       suppressWarnings(cv_varsel(
         vss[[tstsetup]], cv_method = "kfold", cvfits = cvfitss[[tstsetup_ref]],
@@ -2512,8 +2466,8 @@ test_that(paste(
       next
     }
     nclusters_pred_crr <- args_cvvs[[tstsetup]]$nclusters_pred - 1L
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     if (identical(args_cvvs[[tstsetup]]$cv_method, "kfold")) {
       cvvs_eval <- try(
         suppressWarnings(cv_varsel(
@@ -2614,8 +2568,8 @@ test_that(paste(
       next
     }
     nclusters_pred_crr <- args_cvvs[[tstsetup]]$nclusters_pred - 1L
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     if (identical(args_cvvs[[tstsetup]]$cv_method, "kfold")) {
       cvvs_eval <- try(
         suppressWarnings(cv_varsel(
@@ -2688,8 +2642,8 @@ test_that("cv_varsel.vsel(): `nloo` works for `vsel` objects from varsel()", {
       refit_prj_crr <- FALSE
       nclusters_pred_crr <- args_vs[[tstsetup]]$nclusters_pred
     }
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     cvvs_eval_valF <- suppressWarnings(cv_varsel(
       vss[[tstsetup]], nloo = nloo_tst, validate_search = FALSE,
       refit_prj = refit_prj_crr, nclusters_pred = nclusters_pred_crr,
@@ -2766,8 +2720,8 @@ test_that(paste(
     stopifnot(any(valsearches), any(!valsearches))
   }
   for (tstsetup in tstsetups) {
-    # Use suppressWarnings() because of occasional warnings concerning Pareto k
-    # diagnostics:
+    # Use suppressWarnings() because test_that() somehow redirects stderr() and
+    # so throws warnings that projpred wants to capture internally:
     if (identical(args_cvvs[[tstsetup]]$cv_method, "kfold")) {
       cvvs_eval_valF <- suppressWarnings(cv_varsel(
         cvvss[[tstsetup]], cv_method = "LOO", validate_search = FALSE,


### PR DESCRIPTION
This PR makes projpred catch messages and warnings from the draw-wise divergence minimizers and also check their convergence (as well as possible). Previously, projpred suppressed such messages and warnings and did not check convergence (PRs #259 and #444 started/modified the convergence checker, but it has remained a "hidden"—because unfinished—feature until now).

For deactivating these two features, global options `projpred.warn_prj_drawwise` and `projpred.check_conv` have been added (see the `NEWS.md` entries added here).

In my opinion, especially the convergence checker is a crucial feature, see, e.g., issue #323. The messages and warnings from the draw-wise divergence minimizers are intended as a help for the user to find out what might be going wrong without having to debug.

The convergence checks for additive models are probably still incomplete, even with this PR. I'll open a new issue for this.

Illustration:
```r
# Setup -------------------------------------------------------------------

warn_length_orig <- options(warning.length = 8170)
devtools::load_all()

# glm_ridge(), glm_elnet() as submodel fitters ----------------------------

data("df_binom", package = "projpred")
dat <- data.frame(y = df_binom$y, df_binom$x)
fit_glm <- rstanarm::stan_glm(y ~ X1 + X2 + X3,
                              family = binomial(),
                              data = dat,
                              chains = 1,
                              iter = 500,
                              seed = 1140350788,
                              refresh = 0)

# Warning from glm_ridge():
prj <- project(fit_glm, predictor_terms = c("X1"), nclusters = 1, thresh = 0)

# Warning from glm_ridge() during the refits for performance evaluation:
vs <- varsel(fit_glm, method = "L1", nclusters_pred = 2, qa_updates_max = 2)
# Alternatively (this is a different warning, though):
vs <- varsel(fit_glm, method = "L1", nclusters_pred = 2, thresh_conv = 0)

# Warning from glm_ridge() during the forward search as well as during the
# refits for performance evaluation:
vs <- varsel(fit_glm, nclusters = 1, nclusters_pred = 2, qa_updates_max = 2)
# Alternatively (this is a different warning, though):
vs <- varsel(fit_glm, nclusters = 1, nclusters_pred = 2, thresh_conv = 0)

# Warning from glm_ridge() during the forward search:
vs <- varsel(fit_glm, nclusters = 1, nclusters_pred = 2,
             search_control = list(qa_updates_max = 2))
# Alternatively (this is a different warning, though):
vs <- varsel(fit_glm, nclusters = 1, nclusters_pred = 2,
             search_control = list(thresh_conv = 0))

# Warning from glm_ridge() during the refits for performance evaluation:
vs <- varsel(fit_glm, nclusters = 1, nclusters_pred = 2,
             search_control = list(), qa_updates_max = 2)
# Alternatively (this is a different warning, though):
vs <- varsel(fit_glm, nclusters = 1, nclusters_pred = 2,
             search_control = list(), thresh_conv = 0)

# Warning from glm_elnet() during the L1 search:
vs <- varsel(fit_glm, method = "L1", refit_prj = FALSE,
             search_control = list(thresh = 1e-330, nlambda = 1))

# MASS::polr() as submodel fitter -----------------------------------------

data("inhaler", package = "brms")
inhaler$rating <- as.factor(paste0("rtg", inhaler$rating))

fit_polr <- rstanarm::stan_polr(
  rating ~ period + carry + treat,
  data = inhaler,
  prior = rstanarm::R2(location = 0.5, what = "median"),
  chains = 1,
  iter = 500,
  seed = 1140350788,
  refresh = 0
)

# Non-convergence in MASS::polr():
prj <- project(fit_polr, predictor_terms = c("carry", "treat"), nclusters = 1,
               control = list(maxit = 1))

# Teardown ----------------------------------------------------------------

options(warn_length_orig)

```
