### PR TITLE
Prepare brms warnings if `wrhs` or `orhs` are specified

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -339,7 +339,7 @@ proj_linpred_aux <- function(proj, newdata, offset, weights, transform = FALSE,
          "recommended.")
   }
   mdat <- mdat_proj(refmodel = proj$refmodel, newdata = newdata, wrhs = weights,
-                    orhs = offset, extract_y = FALSE)
+                    orhs = offset, extract_y = extract_y_ind)
   weights <- mdat$weights
   offset <- mdat$offset
   pred_sub <- proj$refmodel$mu_fun(proj$outdmin, newdata = newdata,
@@ -358,8 +358,7 @@ proj_linpred_aux <- function(proj, newdata, offset, weights, transform = FALSE,
       )
     }
   }
-  ynew <- proj$refmodel$extract_model_data(proj$refmodel$fit, newdata = newdata,
-                                           extract_y = extract_y_ind)$y
+  ynew <- mdat$y
   if (!is.null(ynew) && proj$refmodel$family$for_latent && !transform) {
     if (is.null(newdata)) {
       newdata_lat <- newdata

--- a/R/methods.R
+++ b/R/methods.R
@@ -265,33 +265,6 @@ proj_helper <- function(object, newdata, onesub_fun, filter_nterms = NULL,
   return(unlist_proj(preds))
 }
 
-# Wrapper for refmodel$extract_model_data() (currently used for `refmodel`s
-# stored in objects of class `projection`, but could probably be used more
-# generally):
-mdat_proj <- function(refmodel, newdata, ...) {
-  nobs_new <- nrow(newdata) %||% refmodel$nobs
-  mdat <- refmodel$extract_model_data(refmodel$fit, newdata = newdata, ...)
-  if (length(mdat$weights) != nobs_new) {
-    stop("The function supplied to argument `extract_model_data` of ",
-         "init_refmodel() needs to return an element `weights` with length ",
-         "equal to the number of observations.")
-  }
-  if (length(mdat$offset) != nobs_new) {
-    stop("The function supplied to argument `extract_model_data` of ",
-         "init_refmodel() needs to return an element `offset` with length ",
-         "equal to the number of observations.")
-  }
-  if (refmodel$family$for_augdat && !all(mdat$weights == 1)) {
-    stop("Currently, the augmented-data projection may not be combined with ",
-         "observation weights (other than 1).")
-  }
-  if (refmodel$family$for_latent && !all(mdat$weights == 1)) {
-    stop("Currently, the latent projection may not be combined with ",
-         "observation weights (other than 1).")
-  }
-  return(mdat)
-}
-
 #' @rdname pred-projection
 #' @export
 proj_linpred <- function(object, newdata = NULL, offsetnew = NULL,
@@ -339,9 +312,9 @@ proj_linpred_aux <- function(proj, newdata, offsetnew, weightsnew,
          "into account) or `return_draws_matrix = TRUE`, the latter being ",
          "recommended.")
   }
-  mdat <- mdat_proj(refmodel = proj$refmodel, newdata = newdata,
-                    wrhs = weightsnew, orhs = offsetnew,
-                    extract_y = extract_y_ind)
+  mdat <- proj$refmodel$extract_model_data(proj$refmodel$fit, newdata = newdata,
+                                           wrhs = weightsnew, orhs = offsetnew,
+                                           extract_y = extract_y_ind)
   weights <- mdat$weights
   offset <- mdat$offset
   pred_sub <- proj$refmodel$mu_fun(proj$outdmin, newdata = newdata,
@@ -537,8 +510,9 @@ proj_predict_aux <- function(proj, newdata, offsetnew, weightsnew,
     stop("`resp_oscale = FALSE` can only be used in case of the latent ",
          "projection.")
   }
-  mdat <- mdat_proj(refmodel = proj$refmodel, newdata = newdata,
-                    wrhs = weightsnew, orhs = offsetnew, extract_y = FALSE)
+  mdat <- proj$refmodel$extract_model_data(proj$refmodel$fit, newdata = newdata,
+                                           wrhs = weightsnew, orhs = offsetnew,
+                                           extract_y = FALSE)
   weights <- mdat$weights
   offset <- mdat$offset
   mu <- proj$refmodel$mu_fun(proj$outdmin, newdata = newdata, offset = offset)

--- a/R/methods.R
+++ b/R/methods.R
@@ -356,8 +356,7 @@ proj_linpred_aux <- function(proj, newdata, offset, weights, transform = FALSE,
     }
   }
   w_o <- proj$refmodel$extract_model_data(
-    proj$refmodel$fit, newdata = newdata, wrhs = weights,
-    orhs = offset, extract_y = extract_y_ind
+    proj$refmodel$fit, newdata = newdata, extract_y = extract_y_ind
   )
   ynew <- w_o$y
   if (!is.null(ynew) && proj$refmodel$family$for_latent && !transform) {

--- a/R/methods.R
+++ b/R/methods.R
@@ -355,10 +355,8 @@ proj_linpred_aux <- function(proj, newdata, offset, weights, transform = FALSE,
       )
     }
   }
-  w_o <- proj$refmodel$extract_model_data(
-    proj$refmodel$fit, newdata = newdata, extract_y = extract_y_ind
-  )
-  ynew <- w_o$y
+  ynew <- proj$refmodel$extract_model_data(proj$refmodel$fit, newdata = newdata,
+                                           extract_y = extract_y_ind)$y
   if (!is.null(ynew) && proj$refmodel$family$for_latent && !transform) {
     if (is.null(newdata)) {
       newdata_lat <- newdata

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -519,7 +519,6 @@ predict.refmodel <- function(object, newdata = NULL, ynew = NULL,
   if (!is.null(newdata)) {
     newdata <- na.fail(newdata)
   }
-  nobs_new <- nrow(newdata) %||% refmodel$nobs
   w_o <- refmodel$extract_model_data(refmodel$fit, newdata = newdata,
                                      wrhs = weightsnew, orhs = offsetnew,
                                      extract_y = FALSE)
@@ -572,7 +571,7 @@ predict.refmodel <- function(object, newdata = NULL, ynew = NULL,
       pred <- colMeans(pred)
     }
     if (was_augmat) {
-      pred <- matrix(pred, nrow = nobs_new)
+      pred <- matrix(pred, nrow = nrow(newdata) %||% refmodel$nobs)
     }
     return(pred)
   } else {
@@ -1193,13 +1192,12 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   extract_model_data <- function(object, newdata, ...) {
     newdata <- newdata %||% data
     mdat <- extract_model_data_usr(object = object, newdata = newdata, ...)
-    nobs_new <- nrow(newdata)
-    if (length(mdat$weights) != nobs_new) {
+    if (length(mdat$weights) != nrow(newdata)) {
       stop("The function supplied to argument `extract_model_data` of ",
            "init_refmodel() needs to return an element `weights` with length ",
            "equal to the number of observations.")
     }
-    if (length(mdat$offset) != nobs_new) {
+    if (length(mdat$offset) != nrow(newdata)) {
       stop("The function supplied to argument `extract_model_data` of ",
            "init_refmodel() needs to return an element `offset` with length ",
            "equal to the number of observations.")

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -264,6 +264,12 @@
 #' The weights and offsets returned by `extract_model_data` will be assumed to
 #' hold for the reference model as well as for the submodels.
 #'
+#' Above, arguments `wrhs` and `orhs` were assumed to have defaults of `NULL`.
+#' It should be possible to use defaults other than `NULL`, but we strongly
+#' recommend to use `NULL`. If defaults other than `NULL` are used, they need to
+#' imply the behaviors described at items "(ii)" (see the descriptions of `wrhs`
+#' and `orhs`).
+#'
 #' # Augmented-data projection
 #'
 #' If a custom reference model for an augmented-data projection is needed, see

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1456,22 +1456,6 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
   model_data <- extract_model_data(object, newdata = NULL, extract_y = TRUE)
   weights <- model_data$weights
   offset <- model_data$offset
-  if (length(weights) != nrow(data)) {
-    # Length equal to the number of observations is necessary here, for example
-    # because perf_eval() subsets the weights vector with observation indices by
-    # default.
-    stop("The function supplied to argument `extract_model_data` of ",
-         "init_refmodel() needs to return an element `weights` with length ",
-         "equal to the number of observations.")
-  }
-  if (length(offset) != nrow(data)) {
-    # Length equal to the number of observations is necessary here, for example
-    # because perf_eval() subsets the offsets vector with observation indices by
-    # default.
-    stop("The function supplied to argument `extract_model_data` of ",
-         "init_refmodel() needs to return an element `offset` with length ",
-         "equal to the number of observations.")
-  }
   if (family$for_latent) {
     y <- rowMeans(ref_predfun(
       object, excl_offs = FALSE,
@@ -1552,15 +1536,6 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
       warning("Assuming that the response values are numbers of successes ",
               "(not proportions of successes).")
     }
-  }
-
-  if (family$for_augdat && !all(weights == 1)) {
-    stop("Currently, the augmented-data projection may not be combined with ",
-         "observation weights (other than 1).")
-  }
-  if (family$for_latent && !all(weights == 1)) {
-    stop("Currently, the latent projection may not be combined with ",
-         "observation weights (other than 1).")
   }
 
   if (!proper_model && !all(offset == 0)) {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1237,6 +1237,7 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     ref_predfun <- function(fit, newdata = NULL, excl_offs = TRUE,
                             mlvl_allrandom = getOption("projpred.mlvl_pred_new",
                                                        FALSE)) {
+      newdata_orig <- newdata
       if (length(fml_extractions$group_terms) > 0 && mlvl_allrandom) {
         # Need to replace existing group levels by dummy ones to ensure that we
         # draw new group-level effects for *all* group levels (existing and new
@@ -1329,10 +1330,14 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
       linpred_out <- unname(linpred_out)
 
       if (excl_offs) {
-        # Observation weights are not needed here, so use a vector of ones for
-        # `wrhs` to avoid potential conflicts for a non-`NULL` default `wrhs`:
-        offs <- extract_model_data(fit, newdata = newdata,
-                                   wrhs = rep(1, nrow(newdata %||% data)),
+        # Observation weights are not needed here. To avoid an error in
+        # get_refmodel.stanreg()'s `extract_model_data` function in case of a
+        # non-`NULL` default `wrhs`, use `newdata_orig` (because above, `newdata
+        # = NULL` might have been replaced by the modified data.frame `data`;
+        # note that using `wrhs = rep(1, nrow(newdata %||% data))` in
+        # conjunction with `newdata = newdata` would cause a warning in newer
+        # brms versions):
+        offs <- extract_model_data(fit, newdata = newdata_orig,
                                    extract_y = FALSE)$offset
         stopifnot(length(offs) %in% c(1L, n_obs))
         if (family$family %in% fams_neg_linpred()) {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1237,7 +1237,6 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     ref_predfun <- function(fit, newdata = NULL, excl_offs = TRUE,
                             mlvl_allrandom = getOption("projpred.mlvl_pred_new",
                                                        FALSE)) {
-      newdata_orig <- newdata
       if (length(fml_extractions$group_terms) > 0 && mlvl_allrandom) {
         # Need to replace existing group levels by dummy ones to ensure that we
         # draw new group-level effects for *all* group levels (existing and new
@@ -1330,14 +1329,10 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
       linpred_out <- unname(linpred_out)
 
       if (excl_offs) {
-        # Observation weights are not needed here. To avoid an error in
-        # get_refmodel.stanreg()'s `extract_model_data` function in case of a
-        # non-`NULL` default `wrhs`, use `newdata_orig` (because above, `newdata
-        # = NULL` might have been replaced by the modified data.frame `data`;
-        # note that using `wrhs = rep(1, nrow(newdata %||% data))` in
-        # conjunction with `newdata = newdata` would cause a warning in newer
-        # brms versions):
-        offs <- extract_model_data(fit, newdata = newdata_orig,
+        # Observation weights are not needed here, so we can use the default of
+        # `wrhs = NULL` (using something like `wrhs = rep(1, nrow(newdata %||%
+        # data))` would cause a warning in newer brms versions):
+        offs <- extract_model_data(fit, newdata = newdata,
                                    extract_y = FALSE)$offset
         stopifnot(length(offs) %in% c(1L, n_obs))
         if (family$family %in% fams_neg_linpred()) {

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1538,6 +1538,18 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     }
   }
 
+  # Already performed by extract_model_data(), but repeated here because
+  # get_standard_y() might have altered the observation weights (in case of a
+  # 2-column `y`):
+  if (family$for_augdat && !all(weights == 1)) {
+    stop("Currently, the augmented-data projection may not be combined with ",
+         "observation weights (other than 1).")
+  }
+  if (family$for_latent && !all(weights == 1)) {
+    stop("Currently, the latent projection may not be combined with ",
+         "observation weights (other than 1).")
+  }
+
   if (!proper_model && !all(offset == 0)) {
     # Disallow offsets for `datafit`s because the submodel fitting does not take
     # offsets into account (but `<refmodel>$mu` contains the observed response

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -244,14 +244,14 @@
 #' `data.frame`).
 #' * `wrhs` accepts at least (i) a right-hand side formula consisting only of
 #' the variable in `newdata` containing the observation weights or (ii) `NULL`
-#' (for typical \pkg{rstanarm} and \pkg{brms} reference models, `NULL` causes
-#' the original observation weights to be used if the model was fitted with
-#' weights, otherwise a vector of ones is used).
+#' for using the observation weights corresponding to `newdata` (typically, the
+#' observation weights are stored in a column of `newdata`; if the model was
+#' fitted without observation weights, a vector of ones should be used).
 #' * `orhs` accepts at least (i) a right-hand side formula consisting only of
-#' the variable in `newdata` containing the offsets or (ii) `NULL` (for typical
-#' \pkg{rstanarm} and \pkg{brms} reference models, `NULL` causes the original
-#' offsets to be used if the model was fitted with offsets, otherwise a vector
-#' of zeros is used).
+#' the variable in `newdata` containing the offsets or (ii) `NULL` for using the
+#' offsets corresponding to `newdata` (typically, the offsets are stored in a
+#' column of `newdata`; if the model was fitted without offsets, a vector of
+#' zeros should be used).
 #' * `extract_y` accepts a single logical value indicating whether output
 #' element `y` (see below) shall be `NULL` (`TRUE`) or not (`FALSE`).
 #'

--- a/man/refmodel-init-get.Rd
+++ b/man/refmodel-init-get.Rd
@@ -318,14 +318,14 @@ CV).
 \code{data.frame}).
 \item \code{wrhs} accepts at least (i) a right-hand side formula consisting only of
 the variable in \code{newdata} containing the observation weights or (ii) \code{NULL}
-(for typical \pkg{rstanarm} and \pkg{brms} reference models, \code{NULL} causes
-the original observation weights to be used if the model was fitted with
-weights, otherwise a vector of ones is used).
+for using the observation weights corresponding to \code{newdata} (typically, the
+observation weights are stored in a column of \code{newdata}; if the model was
+fitted without observation weights, a vector of ones should be used).
 \item \code{orhs} accepts at least (i) a right-hand side formula consisting only of
-the variable in \code{newdata} containing the offsets or (ii) \code{NULL} (for typical
-\pkg{rstanarm} and \pkg{brms} reference models, \code{NULL} causes the original
-offsets to be used if the model was fitted with offsets, otherwise a vector
-of zeros is used).
+the variable in \code{newdata} containing the offsets or (ii) \code{NULL} for using the
+offsets corresponding to \code{newdata} (typically, the offsets are stored in a
+column of \code{newdata}; if the model was fitted without offsets, a vector of
+zeros should be used).
 \item \code{extract_y} accepts a single logical value indicating whether output
 element \code{y} (see below) shall be \code{NULL} (\code{TRUE}) or not (\code{FALSE}).
 }

--- a/man/refmodel-init-get.Rd
+++ b/man/refmodel-init-get.Rd
@@ -338,6 +338,12 @@ a non-numeric vector, or a \code{factor}.
 
 The weights and offsets returned by \code{extract_model_data} will be assumed to
 hold for the reference model as well as for the submodels.
+
+Above, arguments \code{wrhs} and \code{orhs} were assumed to have defaults of \code{NULL}.
+It should be possible to use defaults other than \code{NULL}, but we strongly
+recommend to use \code{NULL}. If defaults other than \code{NULL} are used, they need to
+imply the behaviors described at items "(ii)" (see the descriptions of \code{wrhs}
+and \code{orhs}).
 }
 
 \section{Augmented-data projection}{

--- a/tests/testthat/helpers/getters.R
+++ b/tests/testthat/helpers/getters.R
@@ -107,3 +107,12 @@ get_fit_fun_nm <- function(args_fit_i) {
          "brms" = "brm",
          stop("Unknown `pkg_nm`."))
 }
+
+get_warn_wrhs_orhs <- function(tstsetup, weightsnew, offsetnew) {
+  if ((is.null(weightsnew) && is.null(offsetnew)) ||
+      !grepl("^brms\\.", tstsetup) || packageVersion("brms") < "2.20.6") {
+    return(NA)
+  } else {
+    return("^Argument `[wo]rhs` is currently ignored\\.")
+  }
+}

--- a/tests/testthat/test_proj_pred.R
+++ b/tests/testthat/test_proj_pred.R
@@ -334,13 +334,18 @@ test_that("`newdata` and `integrated` work (even in edge cases)", {
       } else {
         offs_crr <- NULL
       }
-      pl_false <- proj_linpred(
-        prjs[[tstsetup]],
-        newdata = head(dat_crr, nobsv_crr),
-        weightsnew = wobs_crr,
-        offsetnew = offs_crr,
-        allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
-        .seed = seed2_tst
+      expect_warning(
+        pl_false <- proj_linpred(
+          prjs[[tstsetup]],
+          newdata = head(dat_crr, nobsv_crr),
+          weightsnew = wobs_crr,
+          offsetnew = offs_crr,
+          allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
+          .seed = seed2_tst
+        ),
+        get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                           offsetnew = offs_crr),
+        info = tstsetup
       )
       pl_tester(pl_false,
                 nprjdraws_expected = ndr_ncl$nprjdraws,
@@ -348,12 +353,17 @@ test_that("`newdata` and `integrated` work (even in edge cases)", {
                 nobsv_expected = nobsv_crr,
                 ncats_nlats_expected = list(ncats_nlats_expected_crr),
                 info_str = paste(tstsetup, nobsv_crr, sep = "__"))
-      pl_true <- proj_linpred(prjs[[tstsetup]],
-                              newdata = head(dat_crr, nobsv_crr),
-                              weightsnew = wobs_crr,
-                              offsetnew = offs_crr,
-                              integrated = TRUE,
-                              .seed = seed2_tst)
+      expect_warning(
+        pl_true <- proj_linpred(prjs[[tstsetup]],
+                                newdata = head(dat_crr, nobsv_crr),
+                                weightsnew = wobs_crr,
+                                offsetnew = offs_crr,
+                                integrated = TRUE,
+                                .seed = seed2_tst),
+        get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                           offsetnew = offs_crr),
+        info = tstsetup
+      )
       pl_tester(pl_true,
                 nprjdraws_expected = 1L,
                 nobsv_expected = nobsv_crr,
@@ -389,18 +399,29 @@ test_that("`newdata` set to the original dataset doesn't change results", {
       offs_crr <- NULL
     }
     # With `transform = FALSE`:
-    pl_newdata <- proj_linpred(
-      prjs[[tstsetup]], newdata = dat_crr, weightsnew = wobs_crr,
-      offsetnew = offs_crr, allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
-      .seed = seed2_tst
+    expect_warning(
+      pl_newdata <- proj_linpred(
+        prjs[[tstsetup]], newdata = dat_crr, weightsnew = wobs_crr,
+        offsetnew = offs_crr,
+        allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1, .seed = seed2_tst
+      ),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                         offsetnew = offs_crr),
+      info = tstsetup
     )
     pl_orig <- pls[[tstsetup]]
     expect_equal(pl_newdata, pl_orig, info = tstsetup)
     # With `transform = TRUE`:
-    pl_newdata_t <- proj_linpred(
-      prjs[[tstsetup]], newdata = dat_crr, weightsnew = wobs_crr,
-      offsetnew = offs_crr, allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
-      transform = TRUE, .seed = seed2_tst
+    expect_warning(
+      pl_newdata_t <- proj_linpred(
+        prjs[[tstsetup]], newdata = dat_crr, weightsnew = wobs_crr,
+        offsetnew = offs_crr,
+        allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1, transform = TRUE,
+        .seed = seed2_tst
+      ),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                         offsetnew = offs_crr),
+      info = tstsetup
     )
     pl_orig_t <- proj_linpred(
       prjs[[tstsetup]], transform = TRUE,
@@ -494,41 +515,58 @@ test_that("`weightsnew` works", {
       ncats_nlats_expected_crr <- integer()
     }
     pl_orig <- pls[[tstsetup]]
-    pl_ones <- proj_linpred(prjs[[tstsetup]],
-                            newdata = get_dat(tstsetup, dat_wobs_ones,
-                                              wobs_brms = 1),
-                            weightsnew = ~ wobs_col_ones,
-                            offsetnew = offs_crr,
-                            allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
-                            .seed = seed2_tst)
+    expect_warning(
+      pl_ones <- proj_linpred(
+        prjs[[tstsetup]],
+        newdata = get_dat(tstsetup, dat_wobs_ones,
+                          wobs_brms = 1),
+        weightsnew = ~ wobs_col_ones,
+        offsetnew = offs_crr,
+        allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
+        .seed = seed2_tst
+      ),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = ~ wobs_col_ones,
+                         offsetnew = offs_crr),
+      info = tstsetup
+    )
     pl_tester(pl_ones,
               nprjdraws_expected = ndr_ncl$nprjdraws,
               wdraws_prj_expected = wdr_crr,
               ncats_nlats_expected = list(ncats_nlats_expected_crr),
               info_str = tstsetup)
     if (!args_prj[[tstsetup]]$prj_nm %in% c("latent", "augdat")) {
-      pl <- proj_linpred(prjs[[tstsetup]],
-                         newdata = get_dat(tstsetup, dat,
-                                           wobs_brms = dat$wobs_col),
-                         weightsnew = ~ wobs_col,
-                         offsetnew = offs_crr,
-                         allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
-                         .seed = seed2_tst)
+      expect_warning(
+        pl <- proj_linpred(prjs[[tstsetup]],
+                           newdata = get_dat(tstsetup, dat,
+                                             wobs_brms = dat$wobs_col),
+                           weightsnew = ~ wobs_col,
+                           offsetnew = offs_crr,
+                           allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
+                           .seed = seed2_tst),
+        get_warn_wrhs_orhs(tstsetup, weightsnew = ~ wobs_col,
+                           offsetnew = offs_crr),
+        info = tstsetup
+      )
       pl_tester(pl,
                 nprjdraws_expected = ndr_ncl$nprjdraws,
                 wdraws_prj_expected = wdr_crr,
                 ncats_nlats_expected = list(ncats_nlats_expected_crr),
                 info_str = tstsetup)
-      plw <- proj_linpred(prjs[[tstsetup]],
-                          newdata = get_dat(
-                            tstsetup,
-                            dat_wobs_new,
-                            wobs_brms = dat_wobs_new$wobs_col_new
-                          ),
-                          weightsnew = ~ wobs_col_new,
-                          offsetnew = offs_crr,
-                          allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
-                          .seed = seed2_tst)
+      expect_warning(
+        plw <- proj_linpred(prjs[[tstsetup]],
+                            newdata = get_dat(
+                              tstsetup,
+                              dat_wobs_new,
+                              wobs_brms = dat_wobs_new$wobs_col_new
+                            ),
+                            weightsnew = ~ wobs_col_new,
+                            offsetnew = offs_crr,
+                            allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
+                            .seed = seed2_tst),
+        get_warn_wrhs_orhs(tstsetup, weightsnew = ~ wobs_col_new,
+                           offsetnew = offs_crr),
+        info = tstsetup
+      )
       pl_tester(plw,
                 nprjdraws_expected = ndr_ncl$nprjdraws,
                 wdraws_prj_expected = wdr_crr,
@@ -590,42 +628,59 @@ test_that("`offsetnew` works", {
     add_offs_crr <- args_prj[[tstsetup]]$prj_nm == "latent" &&
       args_prj[[tstsetup]]$pkg_nm == "rstanarm" &&
       grepl("\\.with_offs\\.", tstsetup)
-    pl_zeros <- proj_linpred(prjs[[tstsetup]],
-                             newdata = get_dat(tstsetup, dat_offs_zeros,
-                                               offs_ylat = 0,
-                                               add_offs_dummy = add_offs_crr,
-                                               offs_brms = 0),
-                             weightsnew = wobs_crr,
-                             offsetnew = ~ offs_col_zeros,
-                             allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
-                             .seed = seed2_tst)
+    expect_warning(
+      pl_zeros <- proj_linpred(
+        prjs[[tstsetup]],
+        newdata = get_dat(tstsetup, dat_offs_zeros,
+                          offs_ylat = 0,
+                          add_offs_dummy = add_offs_crr,
+                          offs_brms = 0),
+        weightsnew = wobs_crr,
+        offsetnew = ~ offs_col_zeros,
+        allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
+        .seed = seed2_tst
+      ),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                         offsetnew = ~ offs_col_zeros),
+      info = tstsetup
+    )
     pl_tester(pl_zeros,
               nprjdraws_expected = ndr_ncl$nprjdraws,
               wdraws_prj_expected = wdr_crr,
               ncats_nlats_expected = list(ncats_nlats_expected_crr),
               info_str = tstsetup)
-    pl <- proj_linpred(prjs[[tstsetup]],
-                       newdata = get_dat(tstsetup, dat),
-                       weightsnew = wobs_crr,
-                       offsetnew = ~ offs_col,
-                       allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
-                       .seed = seed2_tst)
+    expect_warning(
+      pl <- proj_linpred(prjs[[tstsetup]],
+                         newdata = get_dat(tstsetup, dat),
+                         weightsnew = wobs_crr,
+                         offsetnew = ~ offs_col,
+                         allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
+                         .seed = seed2_tst),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                         offsetnew = ~ offs_col),
+      info = tstsetup
+    )
     pl_tester(pl,
               nprjdraws_expected = ndr_ncl$nprjdraws,
               wdraws_prj_expected = wdr_crr,
               ncats_nlats_expected = list(ncats_nlats_expected_crr),
               info_str = tstsetup)
-    plo <- proj_linpred(prjs[[tstsetup]],
-                        newdata = get_dat(
-                          tstsetup, dat_offs_new,
-                          offs_ylat = dat_offs_new$offs_col_new,
-                          add_offs_dummy = add_offs_crr,
-                          offs_brms = dat_offs_new$offs_col_new
-                        ),
-                        weightsnew = wobs_crr,
-                        offsetnew = ~ offs_col_new,
-                        allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
-                        .seed = seed2_tst)
+    expect_warning(
+      plo <- proj_linpred(prjs[[tstsetup]],
+                          newdata = get_dat(
+                            tstsetup, dat_offs_new,
+                            offs_ylat = dat_offs_new$offs_col_new,
+                            add_offs_dummy = add_offs_crr,
+                            offs_brms = dat_offs_new$offs_col_new
+                          ),
+                          weightsnew = wobs_crr,
+                          offsetnew = ~ offs_col_new,
+                          allow_nonconst_wdraws_prj = ndr_ncl$clust_used_gt1,
+                          .seed = seed2_tst),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                         offsetnew = ~ offs_col_new),
+      info = tstsetup
+    )
     pl_tester(plo,
               nprjdraws_expected = ndr_ncl$nprjdraws,
               wdraws_prj_expected = wdr_crr,
@@ -1316,12 +1371,17 @@ test_that("`newdata` and `nresample_clusters` work (even in edge cases)", {
         offs_crr <- NULL
       }
       for (nresample_clusters_crr in nresample_clusters_tst) {
-        pp <- proj_predict(prjs[[tstsetup]],
-                           newdata = head(dat, nobsv_crr),
-                           weightsnew = wobs_crr,
-                           offsetnew = offs_crr,
-                           nresample_clusters = nresample_clusters_crr,
-                           .seed = seed2_tst)
+        expect_warning(
+          pp <- proj_predict(prjs[[tstsetup]],
+                             newdata = head(dat, nobsv_crr),
+                             weightsnew = wobs_crr,
+                             offsetnew = offs_crr,
+                             nresample_clusters = nresample_clusters_crr,
+                             .seed = seed2_tst),
+          get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                             offsetnew = offs_crr),
+          info = tstsetup
+        )
         pp_tester(pp,
                   nprjdraws_out_expected = ndr_pp_out(
                     args_prj[[tstsetup]], prj_out = prjs[[tstsetup]],
@@ -1351,11 +1411,16 @@ test_that("`newdata` set to the original dataset doesn't change results", {
     } else {
       offs_crr <- NULL
     }
-    pp_newdata <- proj_predict(prjs[[tstsetup]],
-                               newdata = dat,
-                               weightsnew = wobs_crr,
-                               offsetnew = offs_crr,
-                               .seed = seed2_tst)
+    expect_warning(
+      pp_newdata <- proj_predict(prjs[[tstsetup]],
+                                 newdata = dat,
+                                 weightsnew = wobs_crr,
+                                 offsetnew = offs_crr,
+                                 .seed = seed2_tst),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                         offsetnew = offs_crr),
+      info = tstsetup
+    )
     pp_orig <- pps[[tstsetup]]
     expect_equal(pp_newdata, pp_orig, info = tstsetup)
   }
@@ -1407,12 +1472,17 @@ test_that("`weightsnew` works", {
       offs_crr <- NULL
     }
     pp_orig <- pps[[tstsetup]]
-    pp_ones <- proj_predict(prjs[[tstsetup]],
-                            newdata = get_dat(tstsetup, dat_wobs_ones,
-                                              wobs_brms = 1),
-                            weightsnew = ~ wobs_col_ones,
-                            offsetnew = offs_crr,
-                            .seed = seed2_tst)
+    expect_warning(
+      pp_ones <- proj_predict(prjs[[tstsetup]],
+                              newdata = get_dat(tstsetup, dat_wobs_ones,
+                                                wobs_brms = 1),
+                              weightsnew = ~ wobs_col_ones,
+                              offsetnew = offs_crr,
+                              .seed = seed2_tst),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = ~ wobs_col_ones,
+                         offsetnew = offs_crr),
+      info = tstsetup
+    )
     pp_tester(pp_ones,
               nprjdraws_out_expected = nprjdraws_out_crr,
               cats_expected = list(
@@ -1420,27 +1490,37 @@ test_that("`weightsnew` works", {
               ),
               info_str = tstsetup)
     if (!args_prj[[tstsetup]]$prj_nm %in% c("latent", "augdat")) {
-      pp <- proj_predict(prjs[[tstsetup]],
-                         newdata = get_dat(tstsetup, dat,
-                                           wobs_brms = dat$wobs_col),
-                         weightsnew = ~ wobs_col,
-                         offsetnew = offs_crr,
-                         .seed = seed2_tst)
+      expect_warning(
+        pp <- proj_predict(prjs[[tstsetup]],
+                           newdata = get_dat(tstsetup, dat,
+                                             wobs_brms = dat$wobs_col),
+                           weightsnew = ~ wobs_col,
+                           offsetnew = offs_crr,
+                           .seed = seed2_tst),
+        get_warn_wrhs_orhs(tstsetup, weightsnew = ~ wobs_col,
+                           offsetnew = offs_crr),
+        info = tstsetup
+      )
       pp_tester(pp,
                 nprjdraws_out_expected = nprjdraws_out_crr,
                 cats_expected = list(
                   refmods[[args_prj[[tstsetup]]$tstsetup_ref]]$family$cats
                 ),
                 info_str = tstsetup)
-      ppw <- proj_predict(prjs[[tstsetup]],
-                          newdata = get_dat(
-                            tstsetup,
-                            dat_wobs_new,
-                            wobs_brms = dat_wobs_new$wobs_col_new
-                          ),
-                          weightsnew = ~ wobs_col_new,
-                          offsetnew = offs_crr,
-                          .seed = seed2_tst)
+      expect_warning(
+        ppw <- proj_predict(prjs[[tstsetup]],
+                            newdata = get_dat(
+                              tstsetup,
+                              dat_wobs_new,
+                              wobs_brms = dat_wobs_new$wobs_col_new
+                            ),
+                            weightsnew = ~ wobs_col_new,
+                            offsetnew = offs_crr,
+                            .seed = seed2_tst),
+        get_warn_wrhs_orhs(tstsetup, weightsnew = ~ wobs_col_new,
+                           offsetnew = offs_crr),
+        info = tstsetup
+      )
       pp_tester(ppw,
                 nprjdraws_out_expected = nprjdraws_out_crr,
                 cats_expected = list(
@@ -1494,40 +1574,55 @@ test_that("`offsetnew` works", {
     add_offs_crr <- args_prj[[tstsetup]]$prj_nm == "latent" &&
       args_prj[[tstsetup]]$pkg_nm == "rstanarm" &&
       grepl("\\.with_offs\\.", tstsetup)
-    pp_zeros <- proj_predict(prjs[[tstsetup]],
-                             newdata = get_dat(tstsetup, dat_offs_zeros,
-                                               add_offs_dummy = add_offs_crr,
-                                               offs_brms = 0),
-                             weightsnew = wobs_crr,
-                             offsetnew = ~ offs_col_zeros,
-                             .seed = seed2_tst)
+    expect_warning(
+      pp_zeros <- proj_predict(prjs[[tstsetup]],
+                               newdata = get_dat(tstsetup, dat_offs_zeros,
+                                                 add_offs_dummy = add_offs_crr,
+                                                 offs_brms = 0),
+                               weightsnew = wobs_crr,
+                               offsetnew = ~ offs_col_zeros,
+                               .seed = seed2_tst),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                         offsetnew = ~ offs_col_zeros),
+      info = tstsetup
+    )
     pp_tester(pp_zeros,
               nprjdraws_out_expected = nprjdraws_out_crr,
               cats_expected = list(
                 refmods[[args_prj[[tstsetup]]$tstsetup_ref]]$family$cats
               ),
               info_str = tstsetup)
-    pp <- proj_predict(prjs[[tstsetup]],
-                       newdata = dat,
-                       weightsnew = wobs_crr,
-                       offsetnew = ~ offs_col,
-                       .seed = seed2_tst)
+    expect_warning(
+      pp <- proj_predict(prjs[[tstsetup]],
+                         newdata = dat,
+                         weightsnew = wobs_crr,
+                         offsetnew = ~ offs_col,
+                         .seed = seed2_tst),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                         offsetnew = ~ offs_col),
+      info = tstsetup
+    )
     pp_tester(pp,
               nprjdraws_out_expected = nprjdraws_out_crr,
               cats_expected = list(
                 refmods[[args_prj[[tstsetup]]$tstsetup_ref]]$family$cats
               ),
               info_str = tstsetup)
-    ppo <- proj_predict(prjs[[tstsetup]],
-                        newdata = get_dat(
-                          tstsetup, dat_offs_new,
-                          offs_ylat = dat_offs_new$offs_col_new,
-                          add_offs_dummy = add_offs_crr,
-                          offs_brms = dat_offs_new$offs_col_new
-                        ),
-                        weightsnew = wobs_crr,
-                        offsetnew = ~ offs_col_new,
-                        .seed = seed2_tst)
+    expect_warning(
+      ppo <- proj_predict(prjs[[tstsetup]],
+                          newdata = get_dat(
+                            tstsetup, dat_offs_new,
+                            offs_ylat = dat_offs_new$offs_col_new,
+                            add_offs_dummy = add_offs_crr,
+                            offs_brms = dat_offs_new$offs_col_new
+                          ),
+                          weightsnew = wobs_crr,
+                          offsetnew = ~ offs_col_new,
+                          .seed = seed2_tst),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                         offsetnew = ~ offs_col_new),
+      info = tstsetup
+    )
     pp_tester(ppo,
               nprjdraws_out_expected = nprjdraws_out_crr,
               cats_expected = list(

--- a/tests/testthat/test_refmodel.R
+++ b/tests/testthat/test_refmodel.R
@@ -259,18 +259,38 @@ test_that(paste(
     }
 
     # Without `ynew`:
-    predref_resp <- predict(refmods[[tstsetup]], dat, weightsnew = wobs_crr,
-                            offsetnew = offs_crr, type = "response")
-    predref_link <- predict(refmods[[tstsetup]], dat, weightsnew = wobs_crr,
-                            offsetnew = offs_crr, type = "link")
+    expect_warning(
+      predref_resp <- predict(refmods[[tstsetup]], dat, weightsnew = wobs_crr,
+                              offsetnew = offs_crr, type = "response"),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                         offsetnew = offs_crr),
+      info = tstsetup
+    )
+    expect_warning(
+      predref_link <- predict(refmods[[tstsetup]], dat, weightsnew = wobs_crr,
+                              offsetnew = offs_crr, type = "link"),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                         offsetnew = offs_crr),
+      info = tstsetup
+    )
 
     # With `ynew`:
-    predref_ynew_resp <- predict(refmods[[tstsetup]], dat,
-                                 weightsnew = wobs_crr, offsetnew = offs_crr,
-                                 ynew = y_crr, type = "response")
-    predref_ynew_link <- predict(refmods[[tstsetup]], dat,
-                                 weightsnew = wobs_crr, offsetnew = offs_crr,
-                                 ynew = y_crr_link, type = "link")
+    expect_warning(
+      predref_ynew_resp <- predict(refmods[[tstsetup]], dat,
+                                   weightsnew = wobs_crr, offsetnew = offs_crr,
+                                   ynew = y_crr, type = "response"),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                         offsetnew = offs_crr),
+      info = tstsetup
+    )
+    expect_warning(
+      predref_ynew_link <- predict(refmods[[tstsetup]], dat,
+                                   weightsnew = wobs_crr, offsetnew = offs_crr,
+                                   ynew = y_crr_link, type = "link"),
+      get_warn_wrhs_orhs(tstsetup, weightsnew = wobs_crr,
+                         offsetnew = offs_crr),
+      info = tstsetup
+    )
 
     # Checks without `ynew`:
     if (prj_crr %in% c("latent", "augdat")) {

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -297,6 +297,8 @@ test_that(paste(
       set.seed(args_vs_i$seed)
       p_sel_dummy <- get_refdist(refmods[[tstsetup_ref]],
                                  nclusters = vs_indep$nprjdraws_search)
+      # Use suppressWarnings() because test_that() somehow redirects stderr()
+      # and so throws warnings that projpred wants to capture internally:
       pl_indep <- suppressWarnings(proj_linpred(
         vs_indep,
         newdata = dat_indep_crr,
@@ -329,17 +331,22 @@ test_that(paste(
         p_sel_dummy <- get_refdist(refmods[[tstsetup_ref]],
                                    nclusters = vs_indep$nprjdraws_search)
         dat_indep_crr[[paste0(".", y_nm_crr)]] <- d_test_crr$y
-        pl_indep_lat <- proj_linpred(
-          vs_indep,
-          newdata = dat_indep_crr,
-          offsetnew = d_test_crr$offset,
-          weightsnew = d_test_crr$weights,
-          transform = FALSE,
-          integrated = TRUE,
-          .seed = NA,
-          nterms = c(0L, seq_along(vs_indep$predictor_ranking)),
-          nclusters = args_vs_i$nclusters_pred,
-          seed = NA
+        expect_warning(
+          pl_indep_lat <- proj_linpred(
+            vs_indep,
+            newdata = dat_indep_crr,
+            offsetnew = d_test_crr$offset,
+            weightsnew = d_test_crr$weights,
+            transform = FALSE,
+            integrated = TRUE,
+            .seed = NA,
+            nterms = c(0L, seq_along(vs_indep$predictor_ranking)),
+            nclusters = args_vs_i$nclusters_pred,
+            seed = NA
+          ),
+          get_warn_wrhs_orhs(tstsetup, weightsnew = d_test_crr$weights,
+                             offsetnew = d_test_crr$offset),
+          info = tstsetup
         )
         y_lat_mat <- matrix(d_test_crr$y, nrow = args_vs_i$nclusters_pred,
                             ncol = nobsv_indep, byrow = TRUE)


### PR DESCRIPTION
This PR allows `brms:::.extract_model_data()` to throw warnings if `wrhs` or `orhs` are specified (`brms:::.extract_model_data()` ignores these, which is so far only documented but not warned about). In fact, such warnings could be thrown also without this PR, but then we would have a lot of false positive alarms. The key to avoiding such false positives is to avoid the projpred-internal specification of `wrhs` and `orhs` inside of `init_refmodel()` and to pass arguments `weightsnew` and `offsetnew` from `proj_linpred()`, `proj_predict()`, and `predict.refmodel()` to the `extract_model_data()` function as they are.

The `init_refmodel()` adjustment is performed by commits 61c4c8c1b0ca54659bcc99e2a0b1e56c7b9f77c7 and 70cc5466ed394a3823cfe61ef3a554acf93768a1. The `proj_linpred()` and `proj_predict()` adjustment (`predict.refmodel()` did not require an adjustment; here, we only perform some simplifications for it) is performed by commits 0cf096ccb1643ff9ea4316c2ee5815b7c008d9e1, 392578647d43033f21df60ee037d5e8f7fc9873f, and fa12c484429cc36faf46540c3ac083d2a15099c2.