### PR TITLE
subsampling LOO estimates with diff-est-srs-wor start

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -1065,7 +1065,7 @@ plot.vsel <- function(
     #                        direction = 1)
     ###
   }
-  if (all(stats %in% c("rmse", "auc"))) {
+  if (all(stats %in% c("rmse","auc"))) {
     ci_type <- "bootstrap "
   } else if (all(stats %in% c("gmpd"))) {
     ci_type <- "exponentiated normal-approximation "
@@ -1319,7 +1319,6 @@ summary.vsel <- function(
   stats_table_all <- .tabulate_stats(object, stats, alpha = alpha,
                                      nfeat_baseline = nfeat_baseline_for_tab,
                                      resp_oscale = resp_oscale, ...)
-
   # Extract the reference model performance results from `stats_table_all`:
   stats_table_ref <- subset(stats_table_all, stats_table_all$size == Inf)
 


### PR DESCRIPTION
Work in progress. Tested now with family="normal" and stats %in% c("elpd", "mlpd", "gmpd", "mse", "rmse")

- in `cv_varsel` if nloo<n and fast PSIS-LOO result is not yet available, fast PSIS-LOO result is computed
- in `cv_varsel` if nloo<n, fast PSIS-LOO result is stored in slot $summaries_fast
- the subsampling indices are stored in slot $loo_inds
- the actual subsampling estimating happens in summary_funs.R get_stat()
- removed some NA checking and need to recheck if those need to put back
- improved quantiles for "mse" if the value is close to 0 (can't get negative lq)

Next
- add support for stats %in% c("acc","pctcorr","auc")
- test with other families than normal