### PR TITLE
Rename internal functions (with dot as prefix)

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -349,7 +349,7 @@ cv_varsel.refmodel <- function(
     }
     verb_txt_search <- paste0(verb_txt_search, "...")
     verb_out(verb_txt_search, verbose = verbose)
-    search_path_fulldata <- select(
+    search_path_fulldata <- .select(
       refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
       method = method, nterms_max = nterms_max, penalty = penalty,
       verbose = verbose, search_control = search_control,
@@ -987,7 +987,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       if (!search_out_rks_was_null) {
         search_path <- list(predictor_ranking = search_out_rks[[run_index]])
       } else {
-        search_path <- select(
+        search_path <- .select(
           refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
           reweighting_args = list(cl_ref = cl_sel, wdraws_ref = exp(lw[, i])),
           method = method, nterms_max = nterms_max, penalty = penalty,
@@ -1304,7 +1304,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
     } else if (!search_out_rks_was_null) {
       search_path <- list(predictor_ranking = rk)
     } else {
-      search_path <- select(
+      search_path <- .select(
         refmodel = fold$refmodel, ndraws = ndraws, nclusters = nclusters,
         method = method, nterms_max = nterms_max, penalty = penalty,
         verbose = verbose_search, search_control = search_control,

--- a/R/glmfun.R
+++ b/R/glmfun.R
@@ -16,7 +16,7 @@ standardization <- function(x, center = TRUE, scale = TRUE, weights = NULL) {
     mx <- rep(0, ncol(x))
   }
   if (scale) {
-    sx <- apply(x, 2, weighted.sd, w)
+    sx <- apply(x, 2, .weighted_sd, w)
   } else {
     sx <- rep(1, ncol(x))
   }

--- a/R/misc.R
+++ b/R/misc.R
@@ -14,7 +14,7 @@ nms_y_wobs_test <- function(wobs_nm = "wobs") {
   c("y", "y_oscale", wobs_nm)
 }
 
-weighted.sd <- function(x, w, na.rm = FALSE) {
+.weighted_sd <- function(x, w, na.rm = FALSE) {
   if (length(w) == 1 && length(x) > 1) {
     w <- rep_len(w, length.out = length(x))
   }
@@ -66,7 +66,7 @@ ilinkfun_raw <- function(x, link_nm) {
   return(basic_ilink(x))
 }
 
-auc <- function(x) {
+.auc <- function(x) {
   resp <- x[, 1]
   pred <- x[, 2]
   wobs <- x[, 3]

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -343,7 +343,7 @@ get_stat <- function(summaries, summaries_baseline = NULL,
     } else {
       # full LOO estimator
       value <- mean(wobs * (mu - y)^2)
-      value_se <- weighted.sd((mu - y)^2, wobs) / sqrt(n_full)
+      value_se <- .weighted_sd((mu - y)^2, wobs) / sqrt(n_full)
     }
     # store for later calculations
     mse_e <- value
@@ -353,7 +353,7 @@ get_stat <- function(summaries, summaries_baseline = NULL,
       # limit theorem would ensure convergence -- probably slower, though -- to
       # a normal distribution even for MSE and RMSE)
       mse_b <- mean(wobs * (mu_baseline - y)^2)
-      var_mse_b <- weighted.sd((mu_baseline - y)^2, wobs)^2 / n_full
+      var_mse_b <- .weighted_sd((mu_baseline - y)^2, wobs)^2 / n_full
       if (n_loo < n_full) {
         mse_e_fast <- mean(wobs * (summaries_fast$mu - y)^2)
         srs_diffe <-
@@ -391,7 +391,7 @@ get_stat <- function(summaries, summaries_baseline = NULL,
       mse_y <- mean(wobs * (y_mean_w - y)^2)
       value <- 1 - mse_e / mse_y - ifelse(is.null(summaries_baseline), 0, 1 - mse_b / mse_y)
       # the first-order Taylor approximation of the variance
-      var_mse_y <- weighted.sd((y_mean_w - y)^2, wobs)^2 / n_full
+      var_mse_y <- .weighted_sd((y_mean_w - y)^2, wobs)^2 / n_full
       if (n_loo < n_full) {
         mse_e_fast <- mean(wobs * (summaries_fast$mu - y)^2)
         if (is.null(summaries_baseline)) {
@@ -524,7 +524,7 @@ get_stat <- function(summaries, summaries_baseline = NULL,
       } else {
         # full LOO estimator
         value <- mean(wobs * correct) - mean(wobs * correct_baseline)
-        value_se <- weighted.sd(correct - correct_baseline, wobs) / sqrt(n_full)
+        value_se <- .weighted_sd(correct - correct_baseline, wobs) / sqrt(n_full)
       }
     } else if (stat == "auc") {
       if (n_loo < n_full) {
@@ -535,15 +535,15 @@ get_stat <- function(summaries, summaries_baseline = NULL,
       if (!is.null(mu_baseline)) {
         auc_data <- cbind(y, mu, wobs)
         auc_data_baseline <- cbind(y, mu_baseline, wobs)
-        value <- auc(auc_data) - auc(auc_data_baseline)
+        value <- .auc(auc_data) - .auc(auc_data_baseline)
         idxs_cols <- seq_len(ncol(auc_data))
         idxs_cols_bs <- setdiff(seq_len(ncol(auc_data) + ncol(auc_data_baseline)),
                                 idxs_cols)
         diffvalue.bootstrap <- bootstrap(
           cbind(auc_data, auc_data_baseline),
           function(x) {
-            auc(x[, idxs_cols, drop = FALSE]) -
-              auc(x[, idxs_cols_bs, drop = FALSE])
+            .auc(x[, idxs_cols, drop = FALSE]) -
+              .auc(x[, idxs_cols_bs, drop = FALSE])
           },
           ...
         )
@@ -558,8 +558,8 @@ get_stat <- function(summaries, summaries_baseline = NULL,
         }
       } else {
         auc_data <- cbind(y, mu, wobs)
-        value <- auc(auc_data)
-        value.bootstrap <- bootstrap(auc_data, auc, ...)
+        value <- .auc(auc_data)
+        value.bootstrap <- bootstrap(auc_data, .auc, ...)
         value_se <- sd(value.bootstrap)
         if (any(is.na(value.bootstrap))) {
           # quantile() is not able to deal with `NA`s
@@ -654,7 +654,7 @@ get_nfeat_baseline <- function(object, baseline, stat, ...) {
   # eq (7)
   est_list$y_hat <- t_pi_tilde + t_e
   # eq (8)
-  var_e_i <- weighted.sd(e_i, w = wobs_m)^2
+  var_e_i <- .weighted_sd(e_i, w = wobs_m)^2
   est_list$v_y_hat <- N^2 * (1 - m / N) * var_e_i / m
   # eq (9) first row second `+` should be `-`
   # Supplementary material eq (6) has this correct

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -376,7 +376,7 @@ varsel.refmodel <- function(object, d_test = NULL, method = "forward",
     search_path <- search_out[["search_path"]]
   } else {
     verb_out("-----\nRunning the search ...", verbose = verbose)
-    search_path <- select(
+    search_path <- .select(
       refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
       method = method, nterms_max = nterms_max, penalty = penalty,
       verbose = verbose, search_control = search_control,
@@ -511,8 +511,8 @@ varsel.refmodel <- function(object, d_test = NULL, method = "forward",
 #   `outdmins` (the submodel fits along the predictor ranking, with the number
 #   of fits per model size being equal to the number of projected draws), and
 #   `p_sel` (the output from get_refdist() for the search).
-select <- function(refmodel, ndraws, nclusters, reweighting_args = NULL, method,
-                   nterms_max, penalty, verbose, search_control, ...) {
+.select <- function(refmodel, ndraws, nclusters, reweighting_args = NULL,
+                    method, nterms_max, penalty, verbose, search_control, ...) {
   if (is.null(reweighting_args)) {
     p_sel <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)
   } else {

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -273,142 +273,142 @@ test_that(".srs_diff_est_w() propagates input `NA`s to its output", {
   )
 })
 
-test_that("weighted.sd() with `na.rm = FALSE` propagates input `NA`s to its output", {
+test_that(".weighted_sd() with `na.rm = FALSE` propagates input `NA`s to its output", {
   expect_identical(
-    weighted.sd(x = rep(NA, nobsv),
-                w = rep(NA, nobsv)),
+    .weighted_sd(x = rep(NA, nobsv),
+                 w = rep(NA, nobsv)),
     NA_real_,
     info = "all inputs are all-`NA`s"
   )
   expect_identical(
-    weighted.sd(x = rep(-0.8, nobsv),
-                w = c(rep_len(c(2, 3), length.out = nobsv - 1L), NA)),
+    .weighted_sd(x = rep(-0.8, nobsv),
+                 w = c(rep_len(c(2, 3), length.out = nobsv - 1L), NA)),
     NA_real_,
     info = "`x` without `NA`s, `w` with a single `NA`"
   )
   expect_identical(
-    weighted.sd(x = c(rep(-0.8, nobsv - 1L), NA),
-                w = rep_len(c(2, 3), length.out = nobsv)),
+    .weighted_sd(x = c(rep(-0.8, nobsv - 1L), NA),
+                 w = rep_len(c(2, 3), length.out = nobsv)),
     NA_real_,
     info = "`x` with a single `NA`, `w` without `NA`s"
   )
   expect_identical(
-    weighted.sd(x = rep(-0.8, nobsv),
-                w = rep(NA, nobsv)),
+    .weighted_sd(x = rep(-0.8, nobsv),
+                 w = rep(NA, nobsv)),
     NA_real_,
     info = "`x` without `NA`s, `w` all-`NA`s"
   )
   expect_identical(
-    weighted.sd(x = rep(NA, nobsv),
-                w = rep_len(c(2, 3), length.out = nobsv)),
+    .weighted_sd(x = rep(NA, nobsv),
+                 w = rep_len(c(2, 3), length.out = nobsv)),
     NA_real_,
     info = "`x` all-`NA`s, `w` without `NA`s"
   )
 })
 
-test_that("auc() works", {
+test_that(".auc() works", {
   nobsv_auc <- 19L
   expect_equal(
-    auc(cbind(rep_len(c(0, 1), length.out = nobsv_auc),
-              imperfect_alternation(c(0.3, 0.8), length.out = nobsv_auc),
-              rep(1, nobsv_auc))),
+    .auc(cbind(rep_len(c(0, 1), length.out = nobsv_auc),
+               imperfect_alternation(c(0.3, 0.8), length.out = nobsv_auc),
+               rep(1, nobsv_auc))),
     0.6833333333333333333333,
     info = "`wobs` column only `1`s"
   )
   expect_equal(
-    auc(cbind(rep_len(c(0, 1), length.out = nobsv_auc),
-              imperfect_alternation(c(0.3, 0.8), length.out = nobsv_auc),
-              imperfect_alternation(c(1, 2), n_tail = 11L, length.out = nobsv_auc))),
+    .auc(cbind(rep_len(c(0, 1), length.out = nobsv_auc),
+               imperfect_alternation(c(0.3, 0.8), length.out = nobsv_auc),
+               imperfect_alternation(c(1, 2), n_tail = 11L, length.out = nobsv_auc))),
     0.717948717948718062587,
     info = "`wobs` column with imperfect alternation of `1`s and `2`s"
   )
 })
 
-test_that("auc() propagates input `NA`s to its output", {
+test_that(".auc() propagates input `NA`s to its output", {
   nobsv_auc <- 19L
   expect_identical(
-    auc(cbind(rep(NA, nobsv_auc),
-              rep(NA, nobsv_auc),
-              rep(NA, nobsv_auc))),
+    .auc(cbind(rep(NA, nobsv_auc),
+               rep(NA, nobsv_auc),
+               rep(NA, nobsv_auc))),
     NA_real_,
     info = "all inputs are all-`NA`s"
   )
   expect_identical(
-    auc(cbind(rep(1, nobsv_auc),
-              rep(NA, nobsv_auc),
-              rep(1, nobsv_auc))),
+    .auc(cbind(rep(1, nobsv_auc),
+               rep(NA, nobsv_auc),
+               rep(1, nobsv_auc))),
     NA_real_,
     info = paste0("`resp` column without `NA`s, ",
                   "`pred` column only `NA`s, ",
                   "`wobs` column without `NA`s")
   )
   expect_identical(
-    auc(cbind(rep(1, nobsv_auc),
-              rep(NA, nobsv_auc),
-              c(rep(1, nobsv_auc - 1L), NA))),
+    .auc(cbind(rep(1, nobsv_auc),
+               rep(NA, nobsv_auc),
+               c(rep(1, nobsv_auc - 1L), NA))),
     NA_real_,
     info = paste0("`resp` column without `NA`s, ",
                   "`pred` column only `NA`s, ",
                   "`wobs` column with a single `NA`")
   )
   expect_identical(
-    auc(cbind(c(rep_len(c(0, 1), length.out = nobsv_auc - 1L), NA),
-              rep(0.7, nobsv_auc),
-              rep(1, nobsv_auc))),
+    .auc(cbind(c(rep_len(c(0, 1), length.out = nobsv_auc - 1L), NA),
+               rep(0.7, nobsv_auc),
+               rep(1, nobsv_auc))),
     NA_real_,
     info = paste0("`resp` column with a single `NA`, ",
                   "`pred` column without `NA`s, ",
                   "`wobs` column without `NA`s")
   )
   expect_identical(
-    auc(cbind(rep(NA, nobsv_auc),
-              rep(0.7, nobsv_auc),
-              rep(1, nobsv_auc))),
+    .auc(cbind(rep(NA, nobsv_auc),
+               rep(0.7, nobsv_auc),
+               rep(1, nobsv_auc))),
     NA_real_,
     info = paste0("`resp` column only `NA`s, ",
                   "`pred` column without `NA`s, ",
                   "`wobs` column without `NA`s")
   )
   expect_identical(
-    auc(cbind(c(rep_len(c(0, 1), length.out = nobsv_auc - 1L), NA),
-              c(rep(0.7, nobsv_auc - 1L), NA),
-              rep(1, nobsv_auc))),
+    .auc(cbind(c(rep_len(c(0, 1), length.out = nobsv_auc - 1L), NA),
+               c(rep(0.7, nobsv_auc - 1L), NA),
+               rep(1, nobsv_auc))),
     NA_real_,
     info = paste0("`resp` column with a single `NA`, ",
                   "`pred` column with a single `NA`, ",
                   "`wobs` column without `NA`s")
   )
   expect_identical(
-    auc(cbind(c(rep_len(c(0, 1), length.out = nobsv_auc - 1L), NA),
-              c(NA, rep(0.7, nobsv_auc - 1L)),
-              rep(1, nobsv_auc))),
+    .auc(cbind(c(rep_len(c(0, 1), length.out = nobsv_auc - 1L), NA),
+               c(NA, rep(0.7, nobsv_auc - 1L)),
+               rep(1, nobsv_auc))),
     NA_real_,
     info = paste0("`resp` column with a single `NA`, ",
                   "`pred` column with a single `NA` (at different position), ",
                   "`wobs` column without `NA`s")
   )
   expect_identical(
-    auc(cbind(c(rep_len(c(0, 1), length.out = nobsv_auc - 1L), NA),
-              rep(NA, nobsv_auc),
-              rep(1, nobsv_auc))),
+    .auc(cbind(c(rep_len(c(0, 1), length.out = nobsv_auc - 1L), NA),
+               rep(NA, nobsv_auc),
+               rep(1, nobsv_auc))),
     NA_real_,
     info = paste0("`resp` column with a single `NA`, ",
                   "`pred` column only `NA`s, ",
                   "`wobs` column without `NA`s")
   )
   expect_identical(
-    auc(cbind(rep(NA, nobsv_auc),
-              rep(0.7, nobsv_auc),
-              c(rep(1, nobsv_auc - 1L), NA))),
+    .auc(cbind(rep(NA, nobsv_auc),
+               rep(0.7, nobsv_auc),
+               c(rep(1, nobsv_auc - 1L), NA))),
     NA_real_,
     info = paste0("`resp` column only `NA`s, ",
                   "`pred` column without `NA`s, ",
                   "`wobs` column with a single `NA`")
   )
   expect_identical(
-    auc(cbind(rep_len(c(0, 1), length.out = nobsv_auc),
-              imperfect_alternation(c(0.3, 0.8), length.out = nobsv_auc),
-              rep(NA, nobsv_auc))),
+    .auc(cbind(rep_len(c(0, 1), length.out = nobsv_auc),
+               imperfect_alternation(c(0.3, 0.8), length.out = nobsv_auc),
+               rep(NA, nobsv_auc))),
     NA_real_,
     info = paste0("`resp` column without `NA`s, ",
                   "`pred` column without `NA`s, ",


### PR DESCRIPTION
This renames some internal functions, most importantly by adding a dot as prefix. Originally, this was implemented by @avehtari as part of #496.