### PR TITLE
Add mixed deltas plot support

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -668,13 +668,11 @@ proj_predict_aux <- function(proj, newdata, offsetnew, weightsnew,
 #' # Horizontal lines
 #'
 #' As long as the reference model's performance is computable, it is always
-#' shown in the plot as a dashed red horizontal line. If `baseline = "best"`,
-#' the baseline model's performance is shown as a dotted black horizontal line.
+#' shown in the plot as a dashed red horizontal line. 
 #' If `!is.na(thres_elpd)` and `any(stats %in% c("elpd", "mlpd", "gmpd"))`, the
 #' value supplied to `thres_elpd` (which is automatically adapted internally in
 #' case of the MLPD or the GMPD or `deltas = FALSE`) is shown as a dot-dashed
-#' gray horizontal line for the reference model and, if `baseline = "best"`, as
-#' a long-dashed green horizontal line for the baseline model.
+#' gray horizontal line for the reference model.
 #'
 #' @examplesIf requireNamespace("rstanarm", quietly = TRUE)
 #' # Data:
@@ -702,7 +700,7 @@ plot.vsel <- function(
     stats = "elpd",
     deltas = FALSE,
     alpha = 2 * pnorm(-1),
-    baseline = if (!inherits(x$refmodel, "datafit")) "ref" else "best",
+    baseline = "ref",
     thres_elpd = NA,
     resp_oscale = TRUE,
     point_size = 3,
@@ -722,7 +720,7 @@ plot.vsel <- function(
   # Parse input:
   object <- x
   validate_vsel_object_stats(object, stats, resp_oscale = resp_oscale)
-  baseline <- validate_baseline(object, baseline, deltas)
+  baseline <- validate_baseline(object$refmodel, baseline, deltas)
   if (!is.null(ranking_repel) && !requireNamespace("ggrepel", quietly = TRUE)) {
     warning("Package 'ggrepel' is needed for a non-`NULL` argument ",
             "`ranking_repel`, but could not be found. Setting `ranking_repel` ",
@@ -736,12 +734,17 @@ plot.vsel <- function(
   # .tabulate_stats()'s argument `nfeat_baseline`:
   nfeat_baseline <- get_nfeat_baseline(object, baseline, stats[1],
                                        resp_oscale = resp_oscale)
-  if (deltas) {
+  ## if (getOption("projpred.extra_verbose",FALSE) &&
+  ##       deltas &&
+  ##       !all(stats %in% c("elpd","mlpd","gmpd"))) {
+  ##   message(paste0("With deltas=TRUE, statistics ", paste(stats[!(stats %in% c("elpd","mlpd","gmpd"))], collapse=", "),
+  ##                  " report the uncertainty relative to the baseline, but the value in the original scale."))
+  ## }
+  if (is.character(deltas) || deltas) {
     nfeat_baseline_for_tab <- nfeat_baseline
   } else {
     nfeat_baseline_for_tab <- NULL
   }
-
   # Compute the predictive performance statistics:
   stats_table_all <- .tabulate_stats(object, stats, alpha = alpha,
                                      nfeat_baseline = nfeat_baseline_for_tab,
@@ -750,6 +753,23 @@ plot.vsel <- function(
   stats_sub <- subset(stats_table_all, stats_table_all$size != Inf)
   stats_bs <- subset(stats_table_all, stats_table_all$size == nfeat_baseline)
 
+  if (!is.character(deltas) && deltas) {
+    stats_ref[,'value'] <- 0
+    stats_ref[stats_ref[,'statistic']=="gmpd",'value'] <- 1
+  } else if (is.character(deltas) && identical(deltas,'mixed')) {
+    stats_ref[stats_ref[,'statistic'] %in% c("elpd","mlpd"),'value'] <- 0
+    stats_ref[stats_ref[,'statistic']=="gmpd",'value'] <- 1
+    stats_sub[!(stats_sub[,'statistic'] %in% c("elpd","mlpd","gmpd")),'diff'] <-
+      stats_sub[!(stats_sub[,'statistic'] %in% c("elpd","mlpd","gmpd")),'diff'] +
+      stats_ref[!(stats_ref[,'statistic'] %in% c("elpd","mlpd","gmpd")),'value']
+    stats_sub[!(stats_sub[,'statistic'] %in% c("elpd","mlpd","gmpd")),'diff.lq'] <-
+      stats_sub[!(stats_sub[,'statistic'] %in% c("elpd","mlpd","gmpd")),'diff.lq'] +
+      stats_ref[!(stats_ref[,'statistic'] %in% c("elpd","mlpd","gmpd")),'value']
+    stats_sub[!(stats_sub[,'statistic'] %in% c("elpd","mlpd","gmpd")),'diff.uq'] <-
+      stats_sub[!(stats_sub[,'statistic'] %in% c("elpd","mlpd","gmpd")),'diff.uq'] +
+      stats_ref[!(stats_ref[,'statistic'] %in% c("elpd","mlpd","gmpd")),'value']
+  }
+  
   # Catch unexpected output from .tabulate_stats():
   if (NROW(stats_sub) == 0) {
     stop(ifelse(length(stats) > 1, "Statistics ", "Statistic "),
@@ -777,21 +797,11 @@ plot.vsel <- function(
   nterms_max <- as.integer(nterms_max)
 
   # Define some "pretty" text strings for the plot:
-  if (baseline == "ref") {
-    baseline_pretty <- "reference model"
+  ylab <- "Value"
+  if (is.character(deltas) || deltas) {
+    delta_lab <- "for baseline comparison"
   } else {
-    baseline_pretty <- "best submodel"
-  }
-  if (deltas) {
-    if (all(stats != "gmpd")) {
-      ylab <- paste0("Difference vs. ", baseline_pretty)
-    } else if (all(stats == "gmpd")) {
-      ylab <- paste0("Ratio vs. ", baseline_pretty)
-    } else {
-      ylab <- paste0("Difference (ratio for GMPD) vs. ", baseline_pretty)
-    }
-  } else {
-    ylab <- "Value"
+    delta_lab <- ""
   }
   if (object$refmodel$family$for_latent) {
     if (resp_oscale) {
@@ -962,9 +972,39 @@ plot.vsel <- function(
   }
 
   # Create the plot:
-  pp <- ggplot(data = data_gg,
-               mapping = aes(x = .data[["size"]], y = .data[["value"]],
-                             ymin = .data[["lq"]], ymax = .data[["uq"]]))
+  if (is.character(deltas) || deltas) {
+    data_gg$statistic[data_gg$statistic=="elpd"] <- "elpd_diff"
+    stats_ref$statistic[stats_ref$statistic=="elpd"] <- "elpd_diff"
+    data_gg$statistic[data_gg$statistic=="mlpd"] <- "mlpd_diff"
+    stats_ref$statistic[stats_ref$statistic=="mlpd"] <- "mlpd_diff"
+    data_gg$statistic[data_gg$statistic=="gmpd"] <- "gmpd_ratio"
+    stats_ref$statistic[stats_ref$statistic=="gmpd"] <- "gmpd_ratio"
+    if (!(is.character(deltas) && identical(deltas,'mixed'))) {
+      data_gg$statistic[data_gg$statistic=="mse"] <- "mse_diff"
+      stats_ref$statistic[stats_ref$statistic=="mse"] <- "mse_diff"
+      data_gg$statistic[data_gg$statistic=="rmse"] <- "rmse_diff"
+      stats_ref$statistic[stats_ref$statistic=="rmse"] <- "rmse_diff"
+      data_gg$statistic[data_gg$statistic=="rmse"] <- "rmse_diff"
+      stats_ref$statistic[stats_ref$statistic=="R2"] <- "R2_diff"
+      data_gg$statistic[data_gg$statistic=="R2"] <- "R2_diff"
+      stats_ref$statistic[stats_ref$statistic=="acc"] <- "acc_diff"
+      data_gg$statistic[data_gg$statistic=="acc"] <- "acc_diff"
+      stats_ref$statistic[stats_ref$statistic=="pctcorr"] <- "pctcorr_diff"
+      data_gg$statistic[data_gg$statistic=="pctcorr"] <- "pctcorr_diff"
+      stats_ref$statistic[stats_ref$statistic=="auc"] <- "auc_diff"
+      data_gg$statistic[data_gg$statistic=="auc"] <- "auc_diff"
+    }
+  }
+
+  if (is.character(deltas) || deltas) {
+    pp <- ggplot(data = data_gg,
+                 mapping = aes(x = .data[["size"]], y = .data[["diff"]],
+                               ymin = .data[["diff.lq"]], ymax = .data[["diff.uq"]]))
+  } else {
+    pp <- ggplot(data = data_gg,
+                 mapping = aes(x = .data[["size"]], y = .data[["value"]],
+                               ymin = .data[["lq"]], ymax = .data[["uq"]]))
+  }
   if (!all(is.na(stats_ref$se))) {
     # In this case, add the predictive performance of the reference model.
     pp <- pp +
@@ -981,9 +1021,9 @@ plot.vsel <- function(
       thres_tab_ref$thres[is_elpd_mlpd_ref] <-
         thres_tab_ref$value[is_elpd_mlpd_ref] +
         thres_tab_ref$thres[is_elpd_mlpd_ref]
-      is_gmpd_ref <- thres_tab_ref$statistic %in% c("gmpd")
+      is_gmpd_ref <- thres_tab_ref$statistic %in% c("gmpd","gmpd ratio")
       thres_tab_ref$thres[is_gmpd_ref] <-
-        thres_tab_ref$value[is_gmpd_ref] *
+              thres_tab_ref$value[is_gmpd_ref] *
         thres_tab_ref$thres[is_gmpd_ref]
       pp <- pp +
         geom_hline(aes(yintercept = .data[["thres"]]),
@@ -1067,12 +1107,7 @@ plot.vsel <- function(
   }
   if (all(stats %in% c("auc"))) {
     ci_type <- "bootstrap "
-  } else if (all(stats %in% c("gmpd"))) {
-    ci_type <- "exponentiated normal-approximation "
-  } else if (all(stats %in% c("mse", "rmse")) && !deltas) {
-    ci_type <- "log-normal-approximation "
-  } else if (all(!stats %in% c("auc", "gmpd", "mse", "rmse")) ||
-             (all(!stats %in% c("auc", "gmpd")) && deltas)) {
+  } else if (all(!stats %in% c("auc"))) {
     ci_type <- "normal-approximation "
   } else {
     ci_type <- ""
@@ -1107,9 +1142,11 @@ plot.vsel <- function(
                        labels = tick_labs_x,
                        sec.axis = x_axis_sec) +
     labs(x = xlab, y = ylab, title = "Predictive performance",
-         subtitle = paste0("Vertical bars indicate ",
-                           round(100 * (1 - alpha), 1), "% ", ci_type,
-                           "intervals")) +
+         subtitle = paste0("With ",
+                           round(100 * (1 - alpha), 1), "% ",
+                           ci_type,
+                           "intervals ",
+                           delta_lab)) +
     theme(axis.text.x.bottom = element_text(angle = text_angle,
                                             hjust = hjust_val,
                                             vjust = vjust_val)) +
@@ -1214,17 +1251,17 @@ plot.vsel <- function(
 #'   "relatively" refers to the ratio vs. the baseline model (i.e., the submodel
 #'   statistic divided by the baseline model statistic). For all other `stats`,
 #'   "relatively" refers to the difference from the baseline model (i.e., the
-#'   submodel statistic minus the baseline model statistic).
+#'   submodel statistic minus the baseline model statistic). For the ELPD and
+#'   the MLPD, the baseline performance is reported as 0. For the GMPD,
+#'   the baseline performance is reported as 1. For other statistics, the
+#'   baseline performance is reported as 0 if `deltas=TRUE` and in the original
+#'   scale if `deltas="mixed"`. If `deltas=TRUE` or `deltas="mixed"`, for all
+#'   statistics the related uncertainty is reported relative to the baseline.
 #' @param alpha A number determining the (nominal) coverage `1 - alpha` of the
 #'   confidence intervals. For example, in case of a normal-approximation
 #'   confidence interval, `alpha = 2 * pnorm(-1)` corresponds to a confidence
 #'   interval stretching by one standard error on either side of the point
 #'   estimate.
-#' @param baseline For [summary.vsel()]: Only relevant if `deltas` is `TRUE`.
-#'   For [plot.vsel()]: Always relevant. Either `"ref"` or `"best"`, indicating
-#'   whether the baseline is the reference model or the best submodel found (in
-#'   terms of `stats[1]`), respectively. In case of subsampled LOO-CV, `baseline
-#'   = "best"` is not supported.
 #' @param resp_oscale Only relevant for the latent projection. A single logical
 #'   value indicating whether to calculate the performance statistics on the
 #'   original response scale (`TRUE`) or on latent scale (`FALSE`).
@@ -1295,14 +1332,14 @@ summary.vsel <- function(
     type = c("mean", "se", "diff", "diff.se"),
     deltas = FALSE,
     alpha = 2 * pnorm(-1),
-    baseline = if (!inherits(object$refmodel, "datafit")) "ref" else "best",
+    baseline = "ref",
     resp_oscale = TRUE,
     cumulate = FALSE,
     ...
 ) {
   validate_vsel_object_stats(object, stats, resp_oscale = resp_oscale)
-  baseline <- validate_baseline(object, baseline, deltas)
-
+  baseline <- validate_baseline(object$refmodel, baseline, deltas)
+  
   # Initialize output:
   out <- c(
     object$refmodel[c("formula", "family")],
@@ -1328,16 +1365,15 @@ summary.vsel <- function(
   }
 
   # The full table of the performance statistics from `stats`:
-  if (deltas) {
+  ## if (is.character(deltas) || deltas) {
     nfeat_baseline_for_tab <- get_nfeat_baseline(object, baseline, stats[1],
                                                  resp_oscale = resp_oscale)
-  } else {
-    nfeat_baseline_for_tab <- NULL
-  }
+  ## } else {
+  ##   nfeat_baseline_for_tab <- NULL
+  ## }
   stats_table_all <- .tabulate_stats(object, stats, alpha = alpha,
                                      nfeat_baseline = nfeat_baseline_for_tab,
                                      resp_oscale = resp_oscale, ...)
-
   # Extract the reference model performance results from `stats_table_all`:
   stats_table_ref <- subset(stats_table_all, stats_table_all$size == Inf)
 
@@ -1361,7 +1397,7 @@ summary.vsel <- function(
   # For renaming columns of the two output tables (one for the reference model
   # performance and for the submodel performance):
   colnms_ref <- mk_colnms_smmry(type = type, stats = stats, deltas = NULL)
-  colnms_sub <- mk_colnms_smmry(type = type, stats = stats, deltas = deltas)
+  colnms_sub <- mk_colnms_smmry(type = type, stats = stats, deltas = FALSE)
 
   # Fill the output table for the reference model performance (essentially, we
   # reshape `stats_table_ref`, thereby selecting only the requested `type`s and
@@ -1406,7 +1442,7 @@ summary.vsel <- function(
 # reference model performance and one table for the submodel performance):
 mk_colnms_smmry <- function(type, stats, deltas) {
   # Pre-process `type`:
-  if (is.null(deltas) || deltas) {
+  if (is.null(deltas) || (is.character(deltas) || deltas)) {
     type <- setdiff(type, c("diff", "diff.se"))
   }
   type_dot <- paste0(".", type)
@@ -1417,6 +1453,8 @@ mk_colnms_smmry <- function(type, stats, deltas) {
   nms_old[nms_old == "mean"] <- "value"
   nms_old[nms_old == "upper"] <- "uq"
   nms_old[nms_old == "lower"] <- "lq"
+  nms_old[nms_old == "diff.upper"] <- "diff.uq"
+  nms_old[nms_old == "diff.lower"] <- "diff.lq"
   # The clean column names that should be used in the output table:
   nms_new <- lapply(stats, paste0, type_dot)
   return(nlist(nms_old, nms_new))
@@ -1593,8 +1631,7 @@ print.vsel <- function(x, digits = getOption("projpred.digits", 2), ...) {
 #'   falls above (or is equal to) \deqn{\texttt{pct} \cdot (u_0 -
 #'   u_{\mathrm{base}})}{pct * (u_0 - u_base)} where \eqn{u_0} denotes the null
 #'   model's estimated utility and \eqn{u_{\mathrm{base}}}{u_base} the baseline
-#'   model's estimated utility. The baseline model is either the reference model
-#'   or the best submodel found (see argument `baseline` of [summary.vsel()]).
+#'   model's estimated utility.
 #'
 #'   In doing so, loss statistics like the root mean squared error (RMSE) and
 #'   the mean squared error (MSE) are converted to utilities by multiplying them
@@ -1697,9 +1734,10 @@ suggest_size.vsel <- function(
   if (length(stat) > 1) {
     stop("Only one statistic can be specified to suggest_size")
   }
+
   stats <- summary.vsel(object,
                         stats = stat,
-                        type = c("mean", "upper", "lower"),
+                        type = c("diff", "diff.upper", "diff.lower"),
                         deltas = TRUE,
                         ...)
   stats <- stats$perf_sub
@@ -1714,9 +1752,9 @@ suggest_size.vsel <- function(
       type <- "upper"
     }
   }
-  bound <- paste0(stat, ".", type)
-
-  util_null <- sgn * unlist(unname(subset(stats, stats$size == 0, stat)))
+  bound <- paste0(stat, ".diff.", type)
+  stat.diff <- paste0(stat, ".", 'diff')
+  util_null <- sgn * unlist(unname(subset(stats, stats$size == 0, stat.diff)))
   if (stat != "gmpd") {
     util_cutoff <- pct * util_null
   } else {
@@ -1725,12 +1763,13 @@ suggest_size.vsel <- function(
   if (is.na(thres_elpd)) {
     thres_elpd <- Inf
   }
+
   nobs_test <- object$nobs_test
   res <- stats[
     (sgn * stats[, bound] >= util_cutoff) |
-      (stat == "elpd" & stats[, stat] > thres_elpd) |
-      (stat == "mlpd" & stats[, stat] > thres_elpd / nobs_test) |
-      (stat == "gmpd" & stats[, stat] > exp(thres_elpd / nobs_test)),
+      (stat == "elpd" & stats[, stat.diff] > thres_elpd) |
+      (stat == "mlpd" & stats[, stat.diff] > thres_elpd / nobs_test) |
+      (stat == "gmpd" & stats[, stat.diff] > exp(thres_elpd / nobs_test)),
     "size", drop = FALSE
   ]
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -199,21 +199,16 @@ validate_vsel_object_stats <- function(object, stats, resp_oscale = TRUE) {
   return(invisible(TRUE))
 }
 
-validate_baseline <- function(vsel_obj, baseline, deltas) {
+validate_baseline <- function(refmodel, baseline, deltas) {
   stopifnot(!is.null(baseline))
-  if (!(baseline %in% c("ref", "best"))) {
-    stop("Argument 'baseline' must be either 'ref' or 'best'.")
+  if (!(baseline %in% c("ref"))) {
+    stop("Argument 'baseline' must be 'ref'.")
   }
-  if (baseline == "ref" && deltas == TRUE &&
-      inherits(vsel_obj$refmodel, "datafit")) {
+  if (baseline == "ref" && deltas == TRUE && inherits(refmodel, "datafit")) {
     # no reference model (or the results missing for some other reason),
     # so cannot compute differences (or ratios) vs. the reference model
     stop("Cannot use deltas = TRUE and baseline = 'ref' when there is no ",
          "reference model.")
-  }
-  if (baseline == "best" && vsel_obj$cv_method == "LOO" &&
-      isTRUE(vsel_obj$nloo < vsel_obj$refmodel$nobs)) {
-    stop("Cannot use `baseline = \"best\"` in case of subsampled LOO-CV.")
   }
   return(baseline)
 }

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -88,7 +88,7 @@ weighted_summary_means <- function(y_wobs_test, family, wdraws, mu, dis, cl_ref,
 # statistics relative to the baseline model of that size (`nfeat_baseline = Inf`
 # means that the baseline model is the reference model).
 .tabulate_stats <- function(varsel, stats, alpha = 0.05,
-                            nfeat_baseline = NULL, resp_oscale = TRUE, ...) {
+                            nfeat_baseline = Inf, resp_oscale = TRUE, ...) {
   stat_tab <- data.frame()
   summaries_ref <- varsel$summaries$ref
   summaries_sub <- varsel$summaries$sub
@@ -209,57 +209,46 @@ weighted_summary_means <- function(y_wobs_test, family, wdraws, mu, dis, cl_ref,
   }
 
   ## fetch the mu and lppd for the baseline model
-  if (is.null(nfeat_baseline)) {
-    ## no baseline model, i.e, compute the statistics on the actual
-    ## (non-relative) scale
-    summaries_baseline <- NULL
-    delta <- FALSE
-  } else {
-    if (nfeat_baseline == Inf) {
-      summaries_baseline <- summaries_ref
-    } else {
-      summaries_baseline <- summaries_sub[[nfeat_baseline + 1]]
-    }
-    delta <- TRUE
-  }
+  summaries_baseline <- summaries_ref
+  delta <- !is.null(summaries_ref)
 
   for (s in seq_along(stats)) {
     stat <- stats[s]
 
     ## reference model statistics
+    summaries <- summaries_ref
     res <- get_stat(summaries = summaries_ref,
-                    summaries_baseline = summaries_baseline,
+                    summaries_baseline = NULL,
                     summaries_fast = NULL,
                     loo_inds = NULL,
                     varsel$y_wobs_test, stat, alpha = alpha, ...)
     row <- data.frame(
       data = varsel$type_test, size = Inf, delta = delta, statistic = stat,
-      value = res$value, lq = res$lq, uq = res$uq, se = res$se, diff = NA,
-      diff.se = NA
+      value = res$value, lq = res$lq, uq = res$uq, se = res$se,
+      diff = NA, diff.lq = NA, diff.uq = NA, diff.se = NA
     )
     stat_tab <- rbind(stat_tab, row)
 
     ## submodel statistics
     for (k in seq_along(summaries_sub)) {
-      res <- get_stat(summaries = summaries_sub[[k]],
-                      summaries_baseline = summaries_baseline,
-                      summaries_fast = summaries_fast_sub[[k]],
-                      loo_inds = varsel$loo_inds,
-                      varsel$y_wobs_test, stat, alpha = alpha, ...)
       diff <- get_stat(summaries = summaries_sub[[k]],
-                       summaries_baseline = summaries_ref,
+                       summaries_baseline = summaries_baseline,
                        summaries_fast = summaries_fast_sub[[k]],
                        loo_inds = varsel$loo_inds,
                        varsel$y_wobs_test, stat, alpha = alpha, ...)
+      res <- get_stat(summaries = summaries_sub[[k]],
+                      summaries_baseline = NULL,
+                      summaries_fast = summaries_fast_sub[[k]],
+                      loo_inds = varsel$loo_inds,
+                      varsel$y_wobs_test, stat, alpha = alpha, ...)
       row <- data.frame(
-        data = varsel$type_test, size = k - 1, delta = delta, statistic = stat,
-        value = res$value, lq = res$lq, uq = res$uq, se = res$se,
-        diff = diff$value, diff.se = diff$se
+        data = varsel$type_test, size = k - 1, delta = delta,
+        statistic = stat, value = res$value, lq = res$lq, uq = res$uq, se = res$se,
+        diff = diff$value, diff.lq = diff$lq, diff.uq = diff$uq, diff.se = diff$se
       )
       stat_tab <- rbind(stat_tab, row)
     }
   }
-
   return(stat_tab)
 }
 
@@ -275,13 +264,9 @@ check_sub_NA <- function(summaries_sub_k, el_nm) {
   all(is.na(summaries_sub_k[[el_nm]]))
 }
 
-## Calculates given statistic stat with standard error and confidence bounds.
-## `summaries_baseline` contains the pointwise mu and lppd for another model
-## that is used as a baseline for computing the difference (ratio in case of the
-## GMPD) in the given statistic. If these arguments are not given (NULL) then
-## the actual (non-relative) value is computed. The actual observation weights
-## (specified by the user) are contained in `y_wobs_test$wobs`. These are
-## already taken into account by `<refmodel_object>$family$ll_fun()` (or
+## The actual observation weights (specified by the
+## user) are contained in `y_wobs_test$wobs`. These are already taken into
+## account by `<refmodel_object>$family$ll_fun()` (or
 ## `<refmodel_object>$family$latent_ll_oscale()`) and are thus already taken
 ## into account in `lppd`. However, `mu` does not take them into account, so
 ## some further adjustments are necessary below.
@@ -554,7 +539,8 @@ get_stat <- function(summaries, summaries_baseline = NULL,
         } else {
           lq_uq <- quantile(diffvalue.bootstrap,
                             probs = c(alpha_half, one_minus_alpha_half),
-                            names = FALSE)
+                            names = FALSE) +
+            .auc(auc_data_baseline)
         }
       } else {
         auc_data <- cbind(y, mu, wobs)

--- a/man/plot.vsel.Rd
+++ b/man/plot.vsel.Rd
@@ -10,7 +10,7 @@
   stats = "elpd",
   deltas = FALSE,
   alpha = 2 * pnorm(-1),
-  baseline = if (!inherits(x$refmodel, "datafit")) "ref" else "best",
+  baseline = "ref",
   thres_elpd = NA,
   resp_oscale = TRUE,
   point_size = 3,
@@ -92,18 +92,18 @@ the baseline model (see argument \code{baseline}). For the GMPD, the term
 "relatively" refers to the ratio vs. the baseline model (i.e., the submodel
 statistic divided by the baseline model statistic). For all other \code{stats},
 "relatively" refers to the difference from the baseline model (i.e., the
-submodel statistic minus the baseline model statistic).}
+submodel statistic minus the baseline model statistic). For the ELPD and
+the MLPD, the baseline performance is reported as 0. For the GMPD,
+the baseline performance is reported as 1. For other statistics, the
+baseline performance is reported as 0 if \code{deltas=TRUE} and in the original
+scale if \code{deltas="mixed"}. If \code{deltas=TRUE} or \code{deltas="mixed"}, for all
+statistics the related uncertainty is reported relative to the baseline.}
 
 \item{alpha}{A number determining the (nominal) coverage \code{1 - alpha} of the
 confidence intervals. For example, in case of a normal-approximation
 confidence interval, \code{alpha = 2 * pnorm(-1)} corresponds to a confidence
 interval stretching by one standard error on either side of the point
 estimate.}
-
-\item{baseline}{For \code{\link[=summary.vsel]{summary.vsel()}}: Only relevant if \code{deltas} is \code{TRUE}.
-For \code{\link[=plot.vsel]{plot.vsel()}}: Always relevant. Either \code{"ref"} or \code{"best"}, indicating
-whether the baseline is the reference model or the best submodel found (in
-terms of \code{stats[1]}), respectively. In case of subsampled LOO-CV, \code{baseline = "best"} is not supported.}
 
 \item{thres_elpd}{Only relevant if \code{any(stats \%in\% c("elpd", "mlpd", "gmpd"))}. The threshold for the ELPD difference (taking the submodel's
 ELPD minus the baseline model's ELPD) above which the submodel's ELPD is
@@ -237,13 +237,11 @@ LOO-CV (see argument \code{nloo} of \code{\link[=cv_varsel]{cv_varsel()}}).
 }
 \section{Horizontal lines}{
 As long as the reference model's performance is computable, it is always
-shown in the plot as a dashed red horizontal line. If \code{baseline = "best"},
-the baseline model's performance is shown as a dotted black horizontal line.
+shown in the plot as a dashed red horizontal line.
 If \code{!is.na(thres_elpd)} and \code{any(stats \%in\% c("elpd", "mlpd", "gmpd"))}, the
 value supplied to \code{thres_elpd} (which is automatically adapted internally in
 case of the MLPD or the GMPD or \code{deltas = FALSE}) is shown as a dot-dashed
-gray horizontal line for the reference model and, if \code{baseline = "best"}, as
-a long-dashed green horizontal line for the baseline model.
+gray horizontal line for the reference model.
 }
 
 \examples{

--- a/man/suggest_size.Rd
+++ b/man/suggest_size.Rd
@@ -76,8 +76,7 @@ interval (with nominal coverage \code{1 - alpha}; see argument \code{alpha} of
 falls above (or is equal to) \deqn{\texttt{pct} \cdot (u_0 -
   u_{\mathrm{base}})}{pct * (u_0 - u_base)} where \eqn{u_0} denotes the null
 model's estimated utility and \eqn{u_{\mathrm{base}}}{u_base} the baseline
-model's estimated utility. The baseline model is either the reference model
-or the best submodel found (see argument \code{baseline} of \code{\link[=summary.vsel]{summary.vsel()}}).
+model's estimated utility.
 
 In doing so, loss statistics like the root mean squared error (RMSE) and
 the mean squared error (MSE) are converted to utilities by multiplying them

--- a/man/summary.vsel.Rd
+++ b/man/summary.vsel.Rd
@@ -11,7 +11,7 @@
   type = c("mean", "se", "diff", "diff.se"),
   deltas = FALSE,
   alpha = 2 * pnorm(-1),
-  baseline = if (!inherits(object$refmodel, "datafit")) "ref" else "best",
+  baseline = "ref",
   resp_oscale = TRUE,
   cumulate = FALSE,
   ...
@@ -92,18 +92,18 @@ the baseline model (see argument \code{baseline}). For the GMPD, the term
 "relatively" refers to the ratio vs. the baseline model (i.e., the submodel
 statistic divided by the baseline model statistic). For all other \code{stats},
 "relatively" refers to the difference from the baseline model (i.e., the
-submodel statistic minus the baseline model statistic).}
+submodel statistic minus the baseline model statistic). For the ELPD and
+the MLPD, the baseline performance is reported as 0. For the GMPD,
+the baseline performance is reported as 1. For other statistics, the
+baseline performance is reported as 0 if \code{deltas=TRUE} and in the original
+scale if \code{deltas="mixed"}. If \code{deltas=TRUE} or \code{deltas="mixed"}, for all
+statistics the related uncertainty is reported relative to the baseline.}
 
 \item{alpha}{A number determining the (nominal) coverage \code{1 - alpha} of the
 confidence intervals. For example, in case of a normal-approximation
 confidence interval, \code{alpha = 2 * pnorm(-1)} corresponds to a confidence
 interval stretching by one standard error on either side of the point
 estimate.}
-
-\item{baseline}{For \code{\link[=summary.vsel]{summary.vsel()}}: Only relevant if \code{deltas} is \code{TRUE}.
-For \code{\link[=plot.vsel]{plot.vsel()}}: Always relevant. Either \code{"ref"} or \code{"best"}, indicating
-whether the baseline is the reference model or the best submodel found (in
-terms of \code{stats[1]}), respectively. In case of subsampled LOO-CV, \code{baseline = "best"} is not supported.}
 
 \item{resp_oscale}{Only relevant for the latent projection. A single logical
 value indicating whether to calculate the performance statistics on the


### PR DESCRIPTION
For some measures like R^2, it is more natural to look at the performance plot in the original scale even when using intervals for the difference from the reference model. With this PR, `deltas` argument accepts values `TRUE`, `FALSE` and `"mixed"`. `TRUE` and `FALSE` behave as before, and `"mixed"` uses the diff_se's but original scales for selected measures.