### PR TITLE
Fix #497 (export of global objects to parallel workers)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Use the updated threshold for high Pareto-$\hat{k}$ values presented by Vehtari et al. (2024, "Pareto smoothed importance sampling", *Journal of Machine Learning Research*, 25(72):1-58, <https://www.jmlr.org/papers/v25/19-556.html>). This threshold depends on the Monte Carlo sample size and is often close to the former fixed threshold of 0.7 (a short introduction may also be found in the [LOO glossary](https://mc-stan.org/loo/reference/loo-glossary.html)). Correspondingly, the former "secondary" threshold of 0.5 is not used anymore either. (GitHub: #490, #498)
 * When using the **doFuture** backend for parallelization, progression updates can now be received via the **progressr** package, see `` ?`projpred-package` `` (section "Parallelization"). (GitHub: #504)
 * Minor enhancements concerning verbosity (e.g., the number of projected draws---resulting from clustering or thinning---is now printed out during the different steps of the computations). Also introduced global option `projpred.verbose` which may be used to set argument `verbose` of `varsel()` and `cv_varsel()` globally. (GitHub: #506)
+* For the CV parallelization (see argument `parallel` of `cv_varsel()`), a new global option `projpred.export_to_workers` may be set to a character vector of names of objects to export from the global environment to the parallel workers. (GitHub: #497, #510)
 
 # projpred 2.8.0
 

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -60,7 +60,7 @@
 #'   from a multilevel submodel (however, not yet in case of a GAMM).
 #' @param parallel A single logical value indicating whether to run costly parts
 #'   of the CV in parallel (`TRUE`) or not (`FALSE`). See also section "Note"
-#'   below.
+#'   below as well as section "Parallelization" in [projpred-package].
 #' @param ... For [cv_varsel.default()]: Arguments passed to [get_refmodel()] as
 #'   well as to [cv_varsel.refmodel()]. For [cv_varsel.vsel()]: Arguments passed
 #'   to [cv_varsel.refmodel()]. For [cv_varsel.refmodel()]: Arguments passed to
@@ -1069,7 +1069,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       res_cv <- foreach::foreach(
         run_index = seq_along(inds),
         .packages = c("projpred"),
-        .export = c("one_obs", "dot_args", "progressor_obj"),
+        .export = c("one_obs", "dot_args", "progressor_obj",
+                    getOption("projpred.export_to_workers", character())),
         .noexport = c("mu_offs_oscale", "loglik_forPSIS", "psisloo", "y_lat_E",
                       "loo_ref_oscale", "validset", "loo_sub", "mu_sub",
                       "loo_sub_oscale", "mu_sub_oscale")
@@ -1436,7 +1437,8 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
       list_cv_k = list_cv,
       search_out_rks_k = search_out_rks,
       .packages = c("projpred"),
-      .export = c("one_fold", "dot_args", "progressor_obj"),
+      .export = c("one_fold", "dot_args", "progressor_obj",
+                  getOption("projpred.export_to_workers", character())),
       .noexport = c("list_cv", "search_out_rks")
     ) %do_projpred% {
       out_one_fold <- do_call(one_fold, c(list(fold = list_cv_k,

--- a/R/projpred-package.R
+++ b/R/projpred-package.R
@@ -138,6 +138,10 @@
 #' (i.e., a parallelization of \pkg{projpred}'s cross-validation) which can be
 #' activated via argument `parallel`.
 #'
+#' For the CV parallelization, global option `projpred.export_to_workers` may be
+#' set to a character vector of names of objects to export from the global
+#' environment to the parallel workers.
+#'
 #' During parallelization (either of the projection or the CV), progression
 #' updates can be received via the \pkg{progressr} package. This only works if
 #' the \pkg{doFuture} backend is used for parallelization, e.g., via

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -202,7 +202,7 @@ formula.}
 
 \item{parallel}{A single logical value indicating whether to run costly parts
 of the CV in parallel (\code{TRUE}) or not (\code{FALSE}). See also section "Note"
-below.}
+below as well as section "Parallelization" in \link{projpred-package}.}
 }
 \value{
 An object of class \code{vsel}. The elements of this object are not meant

--- a/man/projpred-package.Rd
+++ b/man/projpred-package.Rd
@@ -135,6 +135,10 @@ is a GLM). However, for \code{\link[=cv_varsel]{cv_varsel()}}, there is also a \
 (i.e., a parallelization of \pkg{projpred}'s cross-validation) which can be
 activated via argument \code{parallel}.
 
+For the CV parallelization, global option \code{projpred.export_to_workers} may be
+set to a character vector of names of objects to export from the global
+environment to the parallel workers.
+
 During parallelization (either of the projection or the CV), progression
 updates can be received via the \pkg{progressr} package. This only works if
 the \pkg{doFuture} backend is used for parallelization, e.g., via


### PR DESCRIPTION
This fixes #497.