### PR TITLE
Single-draw bug fix for augmented-data and latent projection

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -916,10 +916,11 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
           i_flx <- inds[run_index]
           run_index_flx <- run_index
         }
-        mu_sub[[k]][i_flx] <- mu_k[run_index_flx, ] %*% exp(lw_sub[, run_index])
+        mu_sub[[k]][i_flx] <- mu_k[run_index_flx, , drop = FALSE] %*%
+          exp(lw_sub[, run_index])
         if (refmodel$family$for_latent) {
           if (inherits(mu_k_oscale, "augmat")) {
-            mu_sub_oscale[[k]][i_aug] <- mu_k_oscale[run_index_aug, ] %*%
+            mu_sub_oscale[[k]][i_aug] <- mu_k_oscale[run_index_aug, , drop = FALSE] %*%
               exp(lw_sub[, run_index])
           } else {
             # In principle, we could use the same code for averaging across the
@@ -927,7 +928,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
             # `mu_k_oscale <- t(mu_k_oscale)` beforehand, so the following
             # should be more efficient:
             mu_sub_oscale[[k]][i_aug] <- exp(lw_sub[, run_index]) %*%
-              mu_k_oscale[, run_index_aug]
+              mu_k_oscale[, run_index_aug, drop = FALSE]
           }
         }
       }
@@ -1171,7 +1172,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     if (refmodel$family$for_latent && !is.null(refmodel$family$cats)) {
       i_flx <- i
     }
-    return(as.vector(mu_offs_mlvlRan[i_flx, ] %*% exp(lw[, i])))
+    return(as.vector(mu_offs_mlvlRan[i_flx, , drop = FALSE] %*% exp(lw[, i])))
   })))
   mu_ref <- structure(
     mu_ref,
@@ -1218,13 +1219,14 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
         i_aug <- i_aug + (seq_along(refmodel$family$cats) - 1L) * n
       }
       if (inherits(mu_offs_mlvlRan_oscale, "augmat")) {
-        return(as.vector(mu_offs_mlvlRan_oscale[i_aug, ] %*% exp(lw[, i])))
+        return(as.vector(mu_offs_mlvlRan_oscale[i_aug, , drop = FALSE] %*%
+                           exp(lw[, i])))
       } else {
         # In principle, we could use the same code for averaging across the
         # draws as above in the `augmat` case. However, that would require
         # `mu_offs_mlvlRan_oscale <- t(mu_offs_mlvlRan_oscale)` beforehand, so
         # the following should be more efficient:
-        return(exp(lw[, i]) %*% mu_offs_mlvlRan_oscale[, i_aug])
+        return(exp(lw[, i]) %*% mu_offs_mlvlRan_oscale[, i_aug, drop = FALSE])
       }
     })))
     mu_ref_oscale <- structure(


### PR DESCRIPTION
This fixes a bug for augmented-data and latent projection when using a single projected draw for performance evaluation in `cv_varsel()` with `cv_method = "LOO"` and `validate_search = FALSE`. Reprex:
```r
data(inhaler, package = "brms")
inhaler$rating <- as.factor(paste0("rtg", inhaler$rating))
inhaler$subject <- scale(inhaler$subject)[,]
rfit <- rstanarm::stan_polr(
  rating ~ period + carry + treat + offset(subject),
  data = inhaler,
  prior = rstanarm::R2(location = 0.5, what = "median"),
  chains = 1,
  iter = 500,
  seed = 1140350788,
  refresh = 0
)

devtools::load_all()

# Augmented-data projection:
refm_aug <- get_refmodel(rfit)
cvvs_aug_no_refit <- cv_varsel(refm_aug,
                               validate_search = FALSE,
                               nclusters = 1,
                               refit_prj = FALSE,
                               nterms_max = 2,
                               seed = 46782345)
cvvs_aug <- cv_varsel(refm_aug,
                      validate_search = FALSE,
                      nclusters = 1,
                      nclusters_pred = 1,
                      nterms_max = 2,
                      seed = 46782345)

# Latent projection:
refm_lat <- get_refmodel(rfit, latent = TRUE)
cvvs_lat_no_refit <- cv_varsel(refm_lat,
                               validate_search = FALSE,
                               method = "L1",
                               refit_prj = FALSE,
                               nterms_max = 2,
                               seed = 46782345)
cvvs_lat <- cv_varsel(refm_lat,
                      validate_search = FALSE,
                      method = "L1",
                      nclusters_pred = 1,
                      nterms_max = 2,
                      seed = 46782345)

```
This bug is fixed here by adding `drop = FALSE` to the relevant matrix subsetting operations. In theory, a similar bug could occur for analogous reference model quantities (that's why `drop = FALSE` is added there, too), but this is only a theoretical problem as a reference model with a single draw is unlikely to occur in practice.

A `NEWS.md` entry is still missing here. I will add it as soon as #511 (or #508) has been merged. I would propose the following text for such a `NEWS.md` entry (under "Bug fixes"):
```
* Fixed a bug that caused an error when using the augmented-data or latent projection in combination with a single projected draw for performance evaluation in `cv_varsel()` with `cv_method = "LOO"` and `validate_search = FALSE`. (GitHub: #512)
```