### PR TITLE
Dispersion in `latent_ll_oscale()` and `latent_ppd_oscale()`

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -605,8 +605,9 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       stop("Unexpected structure for the output of `latent_ilink`.")
     }
     loglik_forPSIS <- refmodel$family$latent_ll_oscale(
-      mu_offs_oscale, y_oscale = refmodel$y_oscale, wobs = refmodel$wobs,
-      cl_ref = seq_along(refmodel$wdraws_ref), wdraws_ref = refmodel$wdraws_ref
+      mu_offs_oscale, dis = refmodel$dis, y_oscale = refmodel$y_oscale,
+      wobs = refmodel$wobs, cl_ref = seq_along(refmodel$wdraws_ref),
+      wdraws_ref = refmodel$wdraws_ref
     )
     if (!is.matrix(loglik_forPSIS)) {
       stop("Unexpected structure for the output of `latent_ll_oscale`.")
@@ -757,8 +758,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
     perf_eval_out <- perf_eval(
       search_path = search_path_fulldata, refmodel = refmodel,
       refit_prj = refit_prj, ndraws = ndraws_pred, nclusters = nclusters_pred,
-      return_p_ref = TRUE, return_preds = TRUE, indices_test = inds,
-      verbose = verbose, ...
+      return_preds = TRUE, return_p_ref = TRUE, return_dis_sub = TRUE,
+      indices_test = inds, verbose = verbose, ...
     )
     clust_used_eval <- perf_eval_out[["clust_used"]]
     nprjdraws_eval <- perf_eval_out[["nprjdraws"]]
@@ -780,9 +781,9 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
                                                                    drop = FALSE]
       }
       log_lik_ref <- refmodel$family$latent_ll_oscale(
-        refdist_eval_mu_offs_oscale, y_oscale = refmodel$y_oscale[inds],
-        wobs = refmodel$wobs[inds], cl_ref = refdist_eval$cl,
-        wdraws_ref = refdist_eval$wdraws_orig
+        refdist_eval_mu_offs_oscale, dis = refdist_eval$dis,
+        y_oscale = refmodel$y_oscale[inds], wobs = refmodel$wobs[inds],
+        cl_ref = refdist_eval$cl, wdraws_ref = refdist_eval$wdraws_orig
       )
       if (all(is.na(log_lik_ref))) {
         stop("In case of the latent projection, `validate_search = FALSE` ",
@@ -892,9 +893,9 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
           wdraws_ref = refdist_eval$wdraws_orig
         )
         log_lik_sub_oscale <- refmodel$family$latent_ll_oscale(
-          mu_k_oscale, y_oscale = refmodel$y_oscale[inds],
-          wobs = refmodel$wobs[inds], cl_ref = refdist_eval$cl,
-          wdraws_ref = refdist_eval$wdraws_orig
+          mu_k_oscale, dis = perf_eval_out[["dis_sub"]][[k]],
+          y_oscale = refmodel$y_oscale[inds], wobs = refmodel$wobs[inds],
+          cl_ref = refdist_eval$cl, wdraws_ref = refdist_eval$wdraws_orig
         )
         loo_sub_oscale[[k]][inds] <- apply(log_lik_sub_oscale + lw_sub, 2,
                                            log_sum_exp)
@@ -1239,8 +1240,9 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       # Need to use `mlvl_allrandom = TRUE` (`loo_ref_oscale` is based on
       # `mlvl_allrandom = getOption("projpred.mlvl_proj_ref_new", FALSE)`):
       loglik_mlvlRan <- refmodel$family$latent_ll_oscale(
-        mu_offs_mlvlRan_oscale_odim, y_oscale = refmodel$y_oscale,
-        wobs = refmodel$wobs, cl_ref = seq_along(refmodel$wdraws_ref),
+        mu_offs_mlvlRan_oscale_odim, dis = refmodel$dis,
+        y_oscale = refmodel$y_oscale, wobs = refmodel$wobs,
+        cl_ref = seq_along(refmodel$wdraws_ref),
         wdraws_ref = refmodel$wdraws_ref
       )
       lppd_ref_oscale <- apply(loglik_mlvlRan + lw, 2, log_sum_exp)

--- a/R/extend_family.R
+++ b/R/extend_family.R
@@ -156,11 +156,13 @@
 #' The function supplied to argument `latent_ll_oscale` needs to have the
 #' prototype
 #' ```{r, eval = FALSE}
-#' latent_ll_oscale(ilpreds, y_oscale, wobs = rep(1, length(y_oscale)), cl_ref,
-#'                  wdraws_ref = rep(1, length(cl_ref)))
+#' latent_ll_oscale(ilpreds, dis, y_oscale, wobs = rep(1, length(y_oscale)),
+#'                  cl_ref, wdraws_ref = rep(1, length(cl_ref)))
 #' ```
 #' where:
 #' * `ilpreds` accepts the return value from `latent_ilink`.
+#' * `dis` accepts a vector of length \eqn{S} containing dispersion parameter
+#' draws.
 #' * `y_oscale` accepts a vector of length \eqn{N} containing response values on
 #' the original response scale.
 #' * `wobs` accepts a numeric vector of length \eqn{N} containing observation

--- a/R/extend_family.R
+++ b/R/extend_family.R
@@ -178,13 +178,16 @@
 #' The function supplied to argument `latent_ppd_oscale` needs to have the
 #' prototype
 #' ```{r, eval = FALSE}
-#' latent_ppd_oscale(ilpreds_resamp, wobs, cl_ref,
+#' latent_ppd_oscale(ilpreds_resamp, dis_resamp, wobs, cl_ref,
 #'                   wdraws_ref = rep(1, length(cl_ref)), idxs_prjdraws)
 #' ```
 #' where:
 #' * `ilpreds_resamp` accepts the return value from `latent_ilink`, but possibly
 #' with resampled (clustered) draws (see argument `nresample_clusters` of
 #' [proj_predict()]).
+#' * `dis_resamp` accepts a vector of length \eqn{\texttt{dim(ilpreds)[1]}}
+#' containing dispersion parameter draws, possibly resampled (in the same way as
+#' the draws in `ilpreds_resamp`, see also argument `idxs_prjdraws`).
 #' * `wobs` accepts a numeric vector of length \eqn{N} containing observation
 #' weights.
 #' * `cl_ref` accepts the same input as argument `cl_ref` of `latent_ilink`.

--- a/R/latent.R
+++ b/R/latent.R
@@ -18,7 +18,10 @@ latent_ll_oscale_cats <- function(ilpreds,
                                   wdraws_ref = rep(1, length(cl_ref))) {
   return(ll_cats(ilpreds, margin_draws = 1, y = y_oscale, wobs = wobs))
 }
-latent_ppd_oscale_cats <- function(ilpreds_resamp, wobs, cl_ref,
+latent_ppd_oscale_cats <- function(ilpreds_resamp,
+                                   dis_resamp = rep(NA, nrow(ilpreds_resamp)),
+                                   wobs,
+                                   cl_ref,
                                    wdraws_ref = rep(1, length(cl_ref)),
                                    idxs_prjdraws) {
   return(ppd_cats(ilpreds_resamp, margin_draws = 1, wobs = wobs))
@@ -40,7 +43,10 @@ latent_ll_oscale_binom_nocats <- function(ilpreds,
   ll_unw <- y_oscale * log(ilpreds) + (1 - y_oscale) * log(1 - ilpreds)
   return(t(wobs * ll_unw))
 }
-latent_ppd_oscale_binom_nocats <- function(ilpreds_resamp, wobs, cl_ref,
+latent_ppd_oscale_binom_nocats <- function(ilpreds_resamp,
+                                           dis_resamp = rep(NA, nrow(ilpreds_resamp)),
+                                           wobs,
+                                           cl_ref,
                                            wdraws_ref = rep(1, length(cl_ref)),
                                            idxs_prjdraws) {
   ilpreds_resamp <- t(ilpreds_resamp)
@@ -59,7 +65,10 @@ latent_ll_oscale_poiss <- function(ilpreds,
   ll_unw <- dpois(y_oscale, lambda = t(ilpreds), log = TRUE)
   return(t(wobs * ll_unw))
 }
-latent_ppd_oscale_poiss <- function(ilpreds_resamp, wobs, cl_ref,
+latent_ppd_oscale_poiss <- function(ilpreds_resamp,
+                                    dis_resamp = rep(NA, nrow(ilpreds_resamp)),
+                                    wobs,
+                                    cl_ref,
                                     wdraws_ref = rep(1, length(cl_ref)),
                                     idxs_prjdraws) {
   wobs <- parse_wobs_ppd(wobs, n_obs = ncol(ilpreds_resamp))
@@ -78,7 +87,10 @@ latent_ll_oscale_NA <- function(ilpreds,
                                 wdraws_ref = rep(1, length(cl_ref))) {
   return(array(dim = dim(ilpreds)[1:2]))
 }
-latent_ppd_oscale_NA <- function(ilpreds_resamp, wobs, cl_ref,
+latent_ppd_oscale_NA <- function(ilpreds_resamp,
+                                 dis_resamp = rep(NA, nrow(ilpreds_resamp)),
+                                 wobs,
+                                 cl_ref,
                                  wdraws_ref = rep(1, length(cl_ref)),
                                  idxs_prjdraws) {
   return(array(dim = dim(ilpreds_resamp)[1:2]))

--- a/R/latent.R
+++ b/R/latent.R
@@ -10,8 +10,11 @@
 
 # Situation: If `family$cats` (*after* applying extend_family(); see
 # extend_family()'s argument `latent_y_unqs`) is not `NULL`.
-latent_ll_oscale_cats <- function(ilpreds, y_oscale,
-                                  wobs = rep(1, length(y_oscale)), cl_ref,
+latent_ll_oscale_cats <- function(ilpreds,
+                                  dis = rep(NA, nrow(ilpreds)),
+                                  y_oscale,
+                                  wobs = rep(1, length(y_oscale)),
+                                  cl_ref,
                                   wdraws_ref = rep(1, length(cl_ref))) {
   return(ll_cats(ilpreds, margin_draws = 1, y = y_oscale, wobs = wobs))
 }
@@ -23,7 +26,9 @@ latent_ppd_oscale_cats <- function(ilpreds_resamp, wobs, cl_ref,
 
 # Situation: For the binomial family if `family$cats` (*after* applying
 # extend_family(); see extend_family()'s argument `latent_y_unqs`) is `NULL`.
-latent_ll_oscale_binom_nocats <- function(ilpreds, y_oscale,
+latent_ll_oscale_binom_nocats <- function(ilpreds,
+                                          dis = rep(NA, nrow(ilpreds)),
+                                          y_oscale,
                                           wobs = rep(1, length(y_oscale)),
                                           cl_ref,
                                           wdraws_ref = rep(1, length(cl_ref))) {
@@ -45,8 +50,11 @@ latent_ppd_oscale_binom_nocats <- function(ilpreds_resamp, wobs, cl_ref,
 }
 
 # Situation: For the Poisson family.
-latent_ll_oscale_poiss <- function(ilpreds, y_oscale,
-                                   wobs = rep(1, length(y_oscale)), cl_ref,
+latent_ll_oscale_poiss <- function(ilpreds,
+                                   dis = rep(NA, nrow(ilpreds)),
+                                   y_oscale,
+                                   wobs = rep(1, length(y_oscale)),
+                                   cl_ref,
                                    wdraws_ref = rep(1, length(cl_ref))) {
   ll_unw <- dpois(y_oscale, lambda = t(ilpreds), log = TRUE)
   return(t(wobs * ll_unw))
@@ -62,8 +70,11 @@ latent_ppd_oscale_poiss <- function(ilpreds_resamp, wobs, cl_ref,
 
 # Situation: For a family for which response-scale log likelihood values cannot
 # or should not be calculated.
-latent_ll_oscale_NA <- function(ilpreds, y_oscale,
-                                wobs = rep(1, length(y_oscale)), cl_ref,
+latent_ll_oscale_NA <- function(ilpreds,
+                                dis = rep(NA, nrow(ilpreds)),
+                                y_oscale,
+                                wobs = rep(1, length(y_oscale)),
+                                cl_ref,
                                 wdraws_ref = rep(1, length(cl_ref))) {
   return(array(dim = dim(ilpreds)[1:2]))
 }

--- a/R/methods.R
+++ b/R/methods.R
@@ -537,8 +537,9 @@ proj_predict_aux <- function(proj, newdata, offsetnew, weightsnew,
       mu_oscale_resamp <- mu_oscale[draw_inds, , drop = FALSE]
     }
     pppd_out <- proj$refmodel$family$latent_ppd_oscale(
-      mu_oscale_resamp, wobs = weights, cl_ref = proj$cl_ref,
-      wdraws_ref = proj$wdraws_ref, idxs_prjdraws = draw_inds
+      mu_oscale_resamp, dis_resamp = proj$dis[draw_inds], wobs = weights,
+      cl_ref = proj$cl_ref, wdraws_ref = proj$wdraws_ref,
+      idxs_prjdraws = draw_inds
     )
     if (!is.matrix(pppd_out)) {
       stop("Unexpected structure for the output of `latent_ppd_oscale`.")

--- a/R/methods.R
+++ b/R/methods.R
@@ -445,8 +445,8 @@ compute_lpd <- function(ynew, pred_sub, proj, weights, transformed) {
     }
     if (proj$refmodel$family$for_latent && transformed) {
       ll_oscale_out <- proj$refmodel$family$latent_ll_oscale(
-        pred_sub, y_oscale = ynew, wobs = weights, cl_ref = proj$cl_ref,
-        wdraws_ref = proj$wdraws_ref
+        pred_sub, dis = proj$dis, y_oscale = ynew, wobs = weights,
+        cl_ref = proj$cl_ref, wdraws_ref = proj$wdraws_ref
       )
       if (!is.matrix(ll_oscale_out)) {
         stop("Unexpected structure for the output of `latent_ll_oscale`.")

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -54,7 +54,7 @@ perf_eval <- function(search_path,
                       refmodel, refit_prj = FALSE, ndraws, nclusters,
                       reweighting_args = NULL, return_submodls = FALSE,
                       return_preds = FALSE, return_p_ref = FALSE,
-                      refmodel_fulldata = refmodel,
+                      return_dis_sub = FALSE, refmodel_fulldata = refmodel,
                       indices_test, newdata_test = NULL,
                       offset_test = refmodel_fulldata$offset[indices_test],
                       wobs_test = refmodel_fulldata$wobs[indices_test],
@@ -140,13 +140,20 @@ perf_eval <- function(search_path,
       )
       out_j <- nlist(sub_summary)
     }
-    return(c(out_j, list(ce = submodl[["ce"]])))
+    out_j <- c(out_j, list(ce = submodl[["ce"]]))
+    if (return_dis_sub) {
+      # Currently only called in loo_varsel()'s `validate_search = FALSE` case.
+      out_j <- c(out_j, list(dis_sub = submodl[["dis"]]))
+    }
+    return(out_j)
   })
   verb_out("-----", verbose = verbose)
   if (return_submodls) {
+    # Currently only called in project().
     return(out_by_size)
   }
   if (return_preds) {
+    # Currently only called in loo_varsel()'s `validate_search = FALSE` case.
     out <- list(mu_by_size = lapply(out_by_size, "[[", "mu_j"),
                 lppd_by_size = lapply(out_by_size, "[[", "lppd_j"))
   } else {
@@ -157,6 +164,10 @@ perf_eval <- function(search_path,
   if (return_p_ref) {
     # Currently only called in loo_varsel()'s `validate_search = FALSE` case.
     out <- c(out, nlist(p_ref))
+  }
+  if (return_dis_sub) {
+    # Currently only called in loo_varsel()'s `validate_search = FALSE` case.
+    out <- c(out, list(dis_sub = lapply(out_by_size, "[[", "dis_sub")))
   }
   return(out)
 }

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -585,7 +585,7 @@ predict.refmodel <- function(object, newdata = NULL, ynew = NULL,
         stop("Unexpected structure for the output of `latent_ilink`.")
       }
       loglik <- refmodel$family$latent_ll_oscale(
-        mu_oscale, y_oscale = ynew, wobs = weightsnew,
+        mu_oscale, dis = refmodel$dis, y_oscale = ynew, wobs = weightsnew,
         cl_ref = seq_along(refmodel$wdraws_ref),
         wdraws_ref = rep(1, length(refmodel$wdraws_ref))
       )

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -53,8 +53,8 @@ weighted_summary_means <- function(y_wobs_test, family, wdraws, mu, dis, cl_ref,
       stop("Unexpected structure for the output of `latent_ilink`.")
     }
     loglik_oscale <- family$latent_ll_oscale(
-      mu_oscale, y_oscale = y_wobs_test$y_oscale, wobs = y_wobs_test$wobs,
-      cl_ref = cl_ref, wdraws_ref = wdraws_ref
+      mu_oscale, dis = dis, y_oscale = y_wobs_test$y_oscale,
+      wobs = y_wobs_test$wobs, cl_ref = cl_ref, wdraws_ref = wdraws_ref
     )
     if (!is.matrix(loglik_oscale)) {
       stop("Unexpected structure for the output of `latent_ll_oscale`.")

--- a/man/extend_family.Rd
+++ b/man/extend_family.Rd
@@ -193,13 +193,15 @@ given in \code{family$cats}, after taking \code{latent_y_unqs} into account).
 The function supplied to argument \code{latent_ll_oscale} needs to have the
 prototype
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{latent_ll_oscale(ilpreds, y_oscale, wobs = rep(1, length(y_oscale)), cl_ref,
-                 wdraws_ref = rep(1, length(cl_ref)))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{latent_ll_oscale(ilpreds, dis, y_oscale, wobs = rep(1, length(y_oscale)),
+                 cl_ref, wdraws_ref = rep(1, length(cl_ref)))
 }\if{html}{\out{</div>}}
 
 where:
 \itemize{
 \item \code{ilpreds} accepts the return value from \code{latent_ilink}.
+\item \code{dis} accepts a vector of length \eqn{S} containing dispersion parameter
+draws.
 \item \code{y_oscale} accepts a vector of length \eqn{N} containing response values on
 the original response scale.
 \item \code{wobs} accepts a numeric vector of length \eqn{N} containing observation

--- a/man/extend_family.Rd
+++ b/man/extend_family.Rd
@@ -218,7 +218,7 @@ for the \eqn{N} observations from its inputs.
 The function supplied to argument \code{latent_ppd_oscale} needs to have the
 prototype
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{latent_ppd_oscale(ilpreds_resamp, wobs, cl_ref,
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{latent_ppd_oscale(ilpreds_resamp, dis_resamp, wobs, cl_ref,
                   wdraws_ref = rep(1, length(cl_ref)), idxs_prjdraws)
 }\if{html}{\out{</div>}}
 
@@ -227,6 +227,9 @@ where:
 \item \code{ilpreds_resamp} accepts the return value from \code{latent_ilink}, but possibly
 with resampled (clustered) draws (see argument \code{nresample_clusters} of
 \code{\link[=proj_predict]{proj_predict()}}).
+\item \code{dis_resamp} accepts a vector of length \eqn{\texttt{dim(ilpreds)[1]}}
+containing dispersion parameter draws, possibly resampled (in the same way as
+the draws in \code{ilpreds_resamp}, see also argument \code{idxs_prjdraws}).
 \item \code{wobs} accepts a numeric vector of length \eqn{N} containing observation
 weights.
 \item \code{cl_ref} accepts the same input as argument \code{cl_ref} of \code{latent_ilink}.

--- a/tests/testthat/helpers/testers.R
+++ b/tests/testthat/helpers/testers.R
@@ -2206,8 +2206,9 @@ vsel_tester <- function(
           wdraws_ref = vs$refmodel$wdraws_ref
         )
         ll_forPSIS <- vs$refmodel$family$latent_ll_oscale(
-          mu_offs_oscale_tst, y_oscale = vs$refmodel$y_oscale,
-          wobs = vs$refmodel$wobs, cl_ref = seq_along(vs$refmodel$wdraws_ref),
+          mu_offs_oscale_tst, dis = vs$refmodel$dis,
+          y_oscale = vs$refmodel$y_oscale, wobs = vs$refmodel$wobs,
+          cl_ref = seq_along(vs$refmodel$wdraws_ref),
           wdraws_ref = vs$refmodel$wdraws_ref
         )
         psisloo_tst <- suppressWarnings(

--- a/vignettes/latent.Rmd
+++ b/vignettes/latent.Rmd
@@ -331,7 +331,10 @@ latent_ll_oscale_nebin <- function(ilpreds,
   ll_unw <- dnbinom(y_oscale_mat, size = refm_prec_agg, mu = ilpreds, log = TRUE)
   return(wobs_mat * ll_unw)
 }
-latent_ppd_oscale_nebin <- function(ilpreds_resamp, wobs, cl_ref,
+latent_ppd_oscale_nebin <- function(ilpreds_resamp,
+                                    dis_resamp = rep(NA, nrow(ilpreds_resamp)),
+                                    wobs,
+                                    cl_ref,
                                     wdraws_ref = rep(1, length(cl_ref)),
                                     idxs_prjdraws) {
   refm_prec_agg <- cl_agg(refm_prec, cl = cl_ref, wdraws = wdraws_ref)

--- a/vignettes/latent.Rmd
+++ b/vignettes/latent.Rmd
@@ -317,8 +317,11 @@ refm_fit_nebin <- stan_glm(
 To request the latent projection with `latent = TRUE`, we now need to specify more arguments (`latent_ll_oscale` and `latent_ppd_oscale`) which will be passed to `extend_family()`^[The suffix `_prec` in `refm_prec` stands for "precision" because here, we follow the Stan convention (see the Stan documentation for the `neg_binomial_2` distribution, the `brms::negbinomial()` documentation, and the [**brms**](https://paul-buerkner.github.io/brms/) vignette "Parameterization of Response Distributions in brms") and prefer the term *precision* parameter for what is denoted by $\phi$ there (confusingly, argument `size` in `?stats::NegBinomial`---which is the same as $\phi$ from the Stan notation---is called the *dispersion* parameter there, although the variance is increased by its reciprocal).]:
 ```{r vs_nebin}
 refm_prec <- as.matrix(refm_fit_nebin)[, "reciprocal_dispersion", drop = FALSE]
-latent_ll_oscale_nebin <- function(ilpreds, y_oscale,
-                                   wobs = rep(1, length(y_oscale)), cl_ref,
+latent_ll_oscale_nebin <- function(ilpreds,
+                                   dis = rep(NA, nrow(ilpreds)),
+                                   y_oscale,
+                                   wobs = rep(1, length(y_oscale)),
+                                   cl_ref,
                                    wdraws_ref = rep(1, length(cl_ref))) {
   y_oscale_mat <- matrix(y_oscale, nrow = nrow(ilpreds), ncol = ncol(ilpreds),
                          byrow = TRUE)


### PR DESCRIPTION
This adds/requires an argument `dis` to/in `latent_ll_oscale()` functions and an argument `dis_resamp` to/in `latent_ppd_oscale()` functions. This is relevant for a log-normal response family and emerged out of https://discourse.mc-stan.org/t/using-projpred-latent-projection-with-brms-weibull-family-models/39275/4.

A `NEWS.md` entry is still missing here. I will add it as soon as #511 (or #508) has been merged. I would propose the following text for such a `NEWS.md` entry (under "Major changes" because this is a breaking change for users with custom `latent_ll_oscale()` or `latent_ppd_oscale()` functions):
```
* For the latent projection, the function passed to argument `latent_ll_oscale` of `extend_family()` now needs to have an argument `dis` (at the second position). Similarly, the function passed to argument `latent_ppd_oscale` of `extend_family()` now needs to have an argument `dis_resamp` (again at the second position). This makes it possible, e.g., to use the latent projection for a log-normal response family. (GitHub: #513)
```