### PR TITLE
Ensure positive input for `sqrt()` in `get_stat()`

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -743,3 +743,15 @@ use_progressr <- function() {
               interactive() &&
               identical(foreach::getDoParName(), "doFuture"))
 }
+
+sqrt_cut0 <- function(x) {
+  if (!is.na(x) && sign(x) == -1) {
+    if (abs(x) < sqrt(.Machine$double.eps)) {
+      x <- 0
+    } else {
+      stop("Negative (and numerically non-zero) value used as input to ",
+           "sqrt_cut0().")
+    }
+  }
+  return(sqrt(x))
+}

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -387,7 +387,7 @@ get_stat <- function(summaries, summaries_baseline = NULL,
       value <- sqrt(mse_e) - ifelse(is.null(summaries_baseline), 0, sqrt(mse_b))
       # the first-order Taylor approximation of the variance
       if (is.null(summaries_baseline)) {
-        value_se <- sqrt_cut0(value_se^2 / mse_e / 4)
+        value_se <- sqrt(value_se^2 / mse_e / 4)
       } else {
         value_se <- sqrt_cut0((value_se^2 / mse_e -
                                  2 * cov_mse_e_b / sqrt(mse_e * mse_b) +

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -395,12 +395,20 @@ get_stat <- function(summaries, summaries_baseline = NULL,
       value <- sqrt(mse_e) - ifelse(is.null(summaries_baseline), 0, sqrt(mse_b))
       # the first-order Taylor approximation of the variance
       if (is.null(summaries_baseline)) {
-        value_se <- sqrt(value_se^2 / mse_e / 4)
+        value_se_sq <- value_se^2 / mse_e / 4
       } else {
-        value_se <- sqrt((value_se^2 / mse_e -
-                            2 * cov_mse_e_b / sqrt(mse_e * mse_b) +
-                            var_mse_b / mse_b) / 4)
+        value_se_sq <- (value_se^2 / mse_e -
+                          2 * cov_mse_e_b / sqrt(mse_e * mse_b) +
+                          var_mse_b / mse_b) / 4
       }
+      if (!is.na(value_se_sq) && sign(value_se_sq) == -1) {
+        if (abs(value_se_sq) < sqrt(.Machine$double.eps)) {
+          value_se_sq <- 0
+        } else {
+          stop("Negative (and numerically non-zero) `value_se_sq`.")
+        }
+      }
+      value_se <- sqrt(value_se_sq)
     } else if (stat == "R2") {
       y_mean_w <- mean(wobs * y)
       # simple transformation of mse

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -377,15 +377,7 @@ get_stat <- function(summaries, summaries_baseline = NULL,
                               ((mu_baseline - y)^2 - mse_b)) / (n_full - 1)
       }
       if (stat != "rmse") {
-        value_se_sq <- value_se^2 - 2 * cov_mse_e_b + var_mse_b
-        if (!is.na(value_se_sq) && sign(value_se_sq) == -1) {
-          if (abs(value_se_sq) < sqrt(.Machine$double.eps)) {
-            value_se_sq <- 0
-          } else {
-            stop("Negative (and numerically non-zero) `value_se_sq`.")
-          }
-        }
-        value_se <- sqrt(value_se_sq)
+        value_se <- sqrt_cut0(value_se^2 - 2 * cov_mse_e_b + var_mse_b)
       }
     }
     if (stat == "mse") {
@@ -395,20 +387,12 @@ get_stat <- function(summaries, summaries_baseline = NULL,
       value <- sqrt(mse_e) - ifelse(is.null(summaries_baseline), 0, sqrt(mse_b))
       # the first-order Taylor approximation of the variance
       if (is.null(summaries_baseline)) {
-        value_se_sq <- value_se^2 / mse_e / 4
+        value_se <- sqrt_cut0(value_se^2 / mse_e / 4)
       } else {
-        value_se_sq <- (value_se^2 / mse_e -
-                          2 * cov_mse_e_b / sqrt(mse_e * mse_b) +
-                          var_mse_b / mse_b) / 4
+        value_se <- sqrt_cut0((value_se^2 / mse_e -
+                                 2 * cov_mse_e_b / sqrt(mse_e * mse_b) +
+                                 var_mse_b / mse_b) / 4)
       }
-      if (!is.na(value_se_sq) && sign(value_se_sq) == -1) {
-        if (abs(value_se_sq) < sqrt(.Machine$double.eps)) {
-          value_se_sq <- 0
-        } else {
-          stop("Negative (and numerically non-zero) `value_se_sq`.")
-        }
-      }
-      value_se <- sqrt(value_se_sq)
     } else if (stat == "R2") {
       y_mean_w <- mean(wobs * y)
       # simple transformation of mse
@@ -454,17 +438,9 @@ get_stat <- function(summaries, summaries_baseline = NULL,
         # delta=TRUE
         mse_e <- mse_e - mse_b
       }
-      value_se_sq <- (value_se^2 -
-                        2 * mse_e / mse_y * cov_mse_e_y +
-                        (mse_e / mse_y)^2 * var_mse_y) / mse_y^2
-      if (!is.na(value_se_sq) && sign(value_se_sq) == -1) {
-        if (abs(value_se_sq) < sqrt(.Machine$double.eps)) {
-          value_se_sq <- 0
-        } else {
-          stop("Negative (and numerically non-zero) `value_se_sq`.")
-        }
-      }
-      value_se <- sqrt(value_se_sq)
+      value_se <- sqrt_cut0((value_se^2 -
+                               2 * mse_e / mse_y * cov_mse_e_y +
+                               (mse_e / mse_y)^2 * var_mse_y) / mse_y^2)
     }
   } else if (stat %in% c("acc", "pctcorr", "auc")) {
     y <- y_wobs_test$y

--- a/R/summary_funs.R
+++ b/R/summary_funs.R
@@ -377,7 +377,15 @@ get_stat <- function(summaries, summaries_baseline = NULL,
                               ((mu_baseline - y)^2 - mse_b)) / (n_full - 1)
       }
       if (stat != "rmse") {
-        value_se <- sqrt(value_se^2 - 2 * cov_mse_e_b + var_mse_b)
+        value_se_sq <- value_se^2 - 2 * cov_mse_e_b + var_mse_b
+        if (!is.na(value_se_sq) && sign(value_se_sq) == -1) {
+          if (abs(value_se_sq) < sqrt(.Machine$double.eps)) {
+            value_se_sq <- 0
+          } else {
+            stop("Negative (and numerically non-zero) `value_se_sq`.")
+          }
+        }
+        value_se <- sqrt(value_se_sq)
       }
     }
     if (stat == "mse") {


### PR DESCRIPTION
This should avoid issues such as the following:
```r
data("df_gaussian", package = "projpred")
dat <- data.frame(y = df_gaussian$y, df_gaussian$x)
rfit <- rstanarm::stan_glm(y ~ X1 + X2 + X3 + X4 + X5,
                           data = dat,
                           chains = 1,
                           iter = 500,
                           seed = 1140350788,
                           refresh = 0)

devtools::load_all(".")

vs <- varsel(rfit,
             nclusters = 3,
             nclusters_pred = 5,
             nterms_max = 2,
             seed = 46782345)

plot(vs, deltas = TRUE, stats = "mse")
# Warning in sqrt(value_se^2 - 2 * cov_mse_e_b + var_mse_b) :
#   NaNs produced

```

Since this is a fix-up for #496 and not a fix for a long-standing issue, I haven't added a `NEWS.md` entry.