### PR TITLE
Fix `clust_used` in case of LOO with `validate_search = TRUE` and thinning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,10 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 * Minor enhancements concerning verbosity (e.g., the number of projected draws---resulting from clustering or thinning---is now printed out during the different steps of the computations). Also introduced global option `projpred.verbose` which may be used to set argument `verbose` of `varsel()` and `cv_varsel()` globally. (GitHub: #506)
 * For the CV parallelization (see argument `parallel` of `cv_varsel()`), a new global option `projpred.export_to_workers` may be set to a character vector of names of objects to export from the global environment to the parallel workers. (GitHub: #497, #510)
 
+## Bug fixes
+
+* Previously, in case of PSIS-LOO CV with `validate_search = TRUE` and thinned posterior draws for projection (i.e., argument(s) `ndraws` or `ndraws_pred` being used, not `nclusters` or `nclusters_pred`), `print.vselsummary()` incorrectly reported that the posterior draws had been clustered. This has now been fixed, so thinning is reported in such cases. (GitHub: #516)
+
 # projpred 2.8.0
 
 ## Major changes

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -998,18 +998,12 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
           method = method, nterms_max = nterms_max, penalty = penalty,
           verbose = verbose_search,
           verbose_txt_obs = NULL,
-          # TODO: get_p_clust() is always used here, but only for reweighting
-          # the draws according to the PSIS weights. This is a general problem,
-          # though (not only affecting verbose mode). Hence, it would be better
-          # to modify get_p_clust() in order to add an argument there which is
-          # passed as an element of `reweighting_args` and which overwrites
-          # get_p_clust()'s output element `clust_used`. Afterwards, we can use
-          # a non-`NULL` text for `verbose_txt_obs` mentioning that this is for
-          # a single fold, namely fold `i`, and also remove the possibility of
-          # `verbose_txt_obs = NULL` in .select() (and then also remove
-          # `May also be `NULL` to omit that verbose message completely.` in the
-          # corresponding internal documentation). Then also set `verbose =
-          # verbose_search` in the perf_eval() call below and rename
+          # TODO: Use a non-`NULL` text for `verbose_txt_obs` mentioning that
+          # this is for a single fold, namely fold `i`, and also remove the
+          # possibility of `verbose_txt_obs = NULL` in .select() (and then also
+          # remove `May also be `NULL` to omit that verbose message completely.`
+          # in the corresponding internal documentation). Then also set `verbose
+          # = verbose_search` in the perf_eval() call below and rename
           # `verbose_search` to something like `verbose_folds` (and don't forget
           # to update the general package documentation for global option
           # `projpred.extra_verbose`).
@@ -1329,23 +1323,22 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
 
   if (verbose) {
     # Here in kfold_varsel(), we have no get_refdist() (or get_p_clust()) output
-    # object whose elements `clust_used` and `nprjdraws` we could use, so we
-    # have to rely on a workaround:
-    verb_clust_used_sel <- !is.null(nclusters) &&
-      nclusters < length(refmodel$wdraws_ref)
-    if (verb_clust_used_sel) {
-      verb_nprjdraws_sel <- nclusters
-    } else {
-      verb_nprjdraws_sel <- ndraws
-    }
+    # available, so use clust_info() as a workaround:
+    clust_info_sel <- clust_info(
+      ndraws = ndraws,
+      nclusters = nclusters,
+      S = length(refmodel$wdraws_ref)
+    )
+    verb_clust_used_sel <- clust_info_sel[["clust_used"]]
+    verb_nprjdraws_sel <- clust_info_sel[["nprjdraws"]]
     if (refit_prj) {
-      verb_clust_used_eval <- !is.null(nclusters_pred) &&
-        nclusters_pred < length(refmodel$wdraws_ref)
-      if (verb_clust_used_eval) {
-        verb_nprjdraws_eval <- nclusters_pred
-      } else {
-        verb_nprjdraws_eval <- ndraws_pred
-      }
+      clust_info_eval <- clust_info(
+        ndraws = ndraws_pred,
+        nclusters = nclusters_pred,
+        S = length(refmodel$wdraws_ref)
+      )
+      verb_clust_used_eval <- clust_info_eval[["clust_used"]]
+      verb_nprjdraws_eval <- clust_info_eval[["nprjdraws"]]
     } else {
       # NOTE: `!refit_prj` cannot occur in combination with
       # `!search_out_rks_was_null || !validate_search`, so it is correct and

--- a/R/misc.R
+++ b/R/misc.R
@@ -305,7 +305,8 @@ get_standard_y <- function(y, weights, fam) {
 #   have been kept as general as possible and `wdraws_orig` is more general than
 #   `wdraws_ref`.
 #   * `clust_used`: A single logical value indicating whether clustering (i.e.,
-#   get_p_clust()) has been used.
+#   get_p_clust(), with the possibility that its output element `clust_used` is
+#   overwritten by its argument `clust_used_forced`) has been used.
 get_refdist <- function(refmodel, ndraws = NULL, nclusters = NULL,
                         thinning = TRUE,
                         throw_mssg_ndraws = getOption("projpred.mssg_ndraws",
@@ -454,6 +455,22 @@ draws_subsample <- function(S, ndraws) {
   # calling stack at the beginning of which a seed is set.
 
   return(sample.int(S, size = ndraws))
+}
+
+# If no get_refdist() (or get_p_clust()) output is available to infer elements
+# `clust_used` (a single logical value indicating whether the given combination
+# of `ndraws` and `nclusters` will lead to clustered projected draws or not) and
+# `nprjdraws` (a single numeric value giving the number of (possibly clustered)
+# projected draws resulting from the given combination of `ndraws` and
+# `nclusters`), the following function can be used as a workaround (argument `S`
+# denotes the number of posterior draws in the reference model object):
+clust_info <- function(ndraws, nclusters, S) {
+  clust_used_out <- !is.null(nclusters) && nclusters < S
+  nprjdraws_out <- if (clust_used_out) nclusters else ndraws
+  return(list(
+    clust_used = clust_used_out,
+    nprjdraws = nprjdraws_out
+  ))
 }
 
 is_proj_list <- function(proj) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -376,7 +376,8 @@ get_refdist <- function(refmodel, ndraws = NULL, nclusters = NULL,
 # Function for clustering the parameter draws:
 get_p_clust <- function(family, eta, mu, mu_offs, dis, nclusters = 10,
                         wobs = rep(1, dim(mu)[1]),
-                        wdraws = rep(1, dim(mu)[2]), cl = NULL) {
+                        wdraws = rep(1, dim(mu)[2]), cl = NULL,
+                        clust_used_forced = NULL) {
   # cluster the draws in the latent space if no clustering provided
   if (is.null(cl)) {
     # Note: A seed is not set here because this function is not exported and has
@@ -444,7 +445,7 @@ get_p_clust <- function(family, eta, mu, mu_offs, dis, nclusters = 10,
     nprjdraws = nclusters,
     cl = cl,
     wdraws_orig = wdraws,
-    clust_used = TRUE
+    clust_used = clust_used_forced %||% TRUE
   ))
 }
 

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -85,7 +85,12 @@ perf_eval <- function(search_path,
       p_ref <- get_p_clust(
         family = refmodel$family, eta = refmodel$eta, mu = refmodel$mu,
         mu_offs = refmodel$mu_offs, dis = refmodel$dis,
-        wdraws = reweighting_args$wdraws_ref, cl = reweighting_args$cl_ref
+        wdraws = reweighting_args$wdraws_ref, cl = reweighting_args$cl_ref,
+        clust_used_forced = clust_info(
+          ndraws = ndraws,
+          nclusters = nclusters,
+          S = length(refmodel$wdraws_ref)
+        )[["clust_used"]]
       )
     }
     fetch_submodl <- function(size_j, ...) {

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -531,7 +531,12 @@ varsel.refmodel <- function(
     p_sel <- get_p_clust(
       family = refmodel$family, eta = refmodel$eta, mu = refmodel$mu,
       mu_offs = refmodel$mu_offs, dis = refmodel$dis,
-      wdraws = reweighting_args$wdraws_ref, cl = reweighting_args$cl_ref
+      wdraws = reweighting_args$wdraws_ref, cl = reweighting_args$cl_ref,
+      clust_used_forced = clust_info(
+        ndraws = ndraws,
+        nclusters = nclusters,
+        S = length(refmodel$wdraws_ref)
+      )[["clust_used"]]
     )
   }
 


### PR DESCRIPTION
So far, in `get_p_clust()`, we have fixed output element `clust_used` to `TRUE`, but when reweighting draws according to PSIS-LOO weights via `get_p_clust()`, this is not necessarily correct. Illustration:
```r
data("df_gaussian", package = "projpred")
dat <- data.frame(y = df_gaussian$y, df_gaussian$x)
rfit <- rstanarm::stan_glm(y ~ X1 + X2 + X3 + X4 + X5,
                           data = dat,
                           chains = 1,
                           iter = 500,
                           seed = 1140350788,
                           refresh = 0)
library(projpred)
cvvs <- cv_varsel(rfit,
                  nclusters = 2,
                  ndraws_pred = 25,
                  nterms_max = 1,
                  seed = 46782345)
print(summary(cvvs))
```
On branch `master`, the summary from the last line says
```
Number of projected draws in the performance evaluation: 25 (from clustered projection)
```
while on this PR branch, that summary correctly says
```
Number of projected draws in the performance evaluation: 25
```
and hence omits the `(from clustered projection)` part.

I discovered this while working on projpred's verbose-mode messages (PR #506), but then realized that this is a general problem (not only affecting verbose mode). Hence, this PR adds an argument `clust_used_forced` to `get_p_clust()` which overwrites output element `clust_used`. We then make use of this argument when calling `get_p_clust()` from `.select()` and `perf_eval()`.