### PR TITLE
Verbosity enhancements

### DIFF
--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -1007,9 +1007,9 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
           refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
           reweighting_args = list(cl_ref = cl_sel, wdraws_ref = exp(lw[, i])),
           method = method, nterms_max = nterms_max, penalty = penalty,
-          verbose = verbose_obs, verbose_txt_obs = vtxt_obs_i,
-          search_control = search_control, search_terms = search_terms,
-          est_runtime = FALSE, ...
+          verbose = verbose_obs, verbose_line_length = 3,
+          verbose_txt_obs = vtxt_obs_i, search_control = search_control,
+          search_terms = search_terms, est_runtime = FALSE, ...
         )
       }
 
@@ -1019,8 +1019,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
         search_path = search_path, refmodel = refmodel, refit_prj = refit_prj,
         ndraws = ndraws_pred, nclusters = nclusters_pred,
         reweighting_args = list(cl_ref = cl_pred, wdraws_ref = exp(lw[, i])),
-        indices_test = i, verbose = verbose_obs, verbose_txt_obs = vtxt_obs_i,
-        ...
+        indices_test = i, verbose = verbose_obs, verbose_line_length = 3,
+        verbose_txt_obs = vtxt_obs_i, ...
       )
 
       return(nlist(predictor_ranking = search_path[["predictor_ranking"]],
@@ -1381,9 +1381,9 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
       search_path <- .select(
         refmodel = fold$refmodel, ndraws = ndraws, nclusters = nclusters,
         method = method, nterms_max = nterms_max, penalty = penalty,
-        verbose = verbose_fold, verbose_txt_obs = vtxt_fold_k,
-        search_control = search_control, search_terms = search_terms,
-        est_runtime = FALSE, ...
+        verbose = verbose_fold, verbose_line_length = 3,
+        verbose_txt_obs = vtxt_fold_k, search_control = search_control,
+        search_terms = search_terms, est_runtime = FALSE, ...
       )
     }
 
@@ -1393,7 +1393,8 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
       search_path = search_path, refmodel = fold$refmodel,
       refit_prj = refit_prj, ndraws = ndraws_pred, nclusters = nclusters_pred,
       refmodel_fulldata = refmodel, indices_test = fold$omitted,
-      verbose = verbose_fold, verbose_txt_obs = vtxt_fold_k, ...
+      verbose = verbose_fold, verbose_line_length = 3,
+      verbose_txt_obs = vtxt_fold_k, ...
     )
 
     # Performance evaluation for the reference model of the current fold:

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -354,7 +354,7 @@ cv_varsel.refmodel <- function(
       # NOTE: If `!validate_search`, this is still a full-data search, but in
       # that case, there are no fold-wise searches, so declaring this as a
       # full-data search could be confusing:
-      verbose_txt_obs = if (validate_search) "using the full dataset " else "",
+      verbose_txt_add = if (validate_search) "using the full dataset " else "",
       search_control = search_control, search_terms = search_terms,
       search_terms_was_null = search_terms_was_null, ...
     )
@@ -400,7 +400,7 @@ cv_varsel.refmodel <- function(
         refmodel = refmodel, method = method, nterms_max = nterms_max,
         ndraws = ndraws, nclusters = nclusters, ndraws_pred = ndraws_pred,
         nclusters_pred = nclusters_pred, refit_prj = refit_prj, penalty = penalty,
-        verbose = verbose, verbose_txt_obs = "using the full dataset ",
+        verbose = verbose, verbose_txt_add = "using the full dataset ",
         search_control = search_control,
         nloo = refmodel$nobs,    # fast LOO-CV (using all observations)
         validate_search = FALSE, # fast LOO-CV (using all observations)
@@ -1009,7 +1009,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
           reweighting_args = list(cl_ref = cl_sel, wdraws_ref = exp(lw[, i])),
           method = method, nterms_max = nterms_max, penalty = penalty,
           verbose = verbose_obs, verbose_line_length = 3,
-          verbose_txt_obs = vtxt_obs_i, search_control = search_control,
+          verbose_txt_add = vtxt_obs_i, search_control = search_control,
           search_terms = search_terms, est_runtime = FALSE, ...
         )
       }
@@ -1021,7 +1021,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
         ndraws = ndraws_pred, nclusters = nclusters_pred,
         reweighting_args = list(cl_ref = cl_pred, wdraws_ref = exp(lw[, i])),
         indices_test = i, verbose = verbose_obs, verbose_line_length = 3,
-        verbose_txt_obs = vtxt_obs_i, ...
+        verbose_txt_add = vtxt_obs_i, ...
       )
 
       return(nlist(predictor_ranking = search_path[["predictor_ranking"]],
@@ -1383,7 +1383,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
         refmodel = fold$refmodel, ndraws = ndraws, nclusters = nclusters,
         method = method, nterms_max = nterms_max, penalty = penalty,
         verbose = verbose_fold, verbose_line_length = 3,
-        verbose_txt_obs = vtxt_fold_k, search_control = search_control,
+        verbose_txt_add = vtxt_fold_k, search_control = search_control,
         search_terms = search_terms, est_runtime = FALSE, ...
       )
     }
@@ -1395,7 +1395,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
       refit_prj = refit_prj, ndraws = ndraws_pred, nclusters = nclusters_pred,
       refmodel_fulldata = refmodel, indices_test = fold$omitted,
       verbose = verbose_fold, verbose_line_length = 3,
-      verbose_txt_obs = vtxt_fold_k, ...
+      verbose_txt_add = vtxt_fold_k, ...
     )
 
     # Performance evaluation for the reference model of the current fold:

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -400,7 +400,8 @@ cv_varsel.refmodel <- function(
         refmodel = refmodel, method = method, nterms_max = nterms_max,
         ndraws = ndraws, nclusters = nclusters, ndraws_pred = ndraws_pred,
         nclusters_pred = nclusters_pred, refit_prj = refit_prj, penalty = penalty,
-        verbose = verbose, search_control = search_control,
+        verbose = verbose, verbose_txt_obs = "using the full dataset ",
+        search_control = search_control,
         nloo = refmodel$nobs,    # fast LOO-CV (using all observations)
         validate_search = FALSE, # fast LOO-CV (using all observations)
         search_path_fulldata = search_path_fulldata,

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -1036,7 +1036,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
       # 'foreach' and 'doRNG' would have to be moved from `Suggests:` to
       # `Imports:`).
       if (verbose) {
-        pb <- utils::txtProgressBar(min = 0, max = nloo, style = 3, initial = 0)
+        pb <- utils::txtProgressBar(min = 0, max = nloo, style = 3, initial = 0,
+                                    file = stderr())
       }
       res_cv <- lapply(seq_along(inds), function(run_index) {
         if (verbose) {
@@ -1425,7 +1426,8 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
     # would require adding more "hard" dependencies (because packages 'foreach'
     # and 'doRNG' would have to be moved from `Suggests:` to `Imports:`).
     if (verbose) {
-      pb <- utils::txtProgressBar(min = 0, max = K, style = 3, initial = 0)
+      pb <- utils::txtProgressBar(min = 0, max = K, style = 3, initial = 0,
+                                  file = stderr())
     }
     res_cv <- lapply(seq_len(K), function(k) {
       if (verbose) {

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -955,14 +955,14 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
 
     if (verbose) {
       if (refit_prj) {
-        verb_clust_used_eval <- refdist_pred[["clust_used"]]
-        verb_nprjdraws_eval <- refdist_pred[["nprjdraws"]]
+        vtxt_clust_used_eval <- refdist_pred[["clust_used"]]
+        vtxt_nprjdraws_eval <- refdist_pred[["nprjdraws"]]
       } else {
         # NOTE: `!refit_prj` cannot occur in combination with
         # `!search_out_rks_was_null`, so it is correct and safe to use
         # `refdist_sel` here.
-        verb_clust_used_eval <- refdist_sel[["clust_used"]]
-        verb_nprjdraws_eval <- refdist_sel[["nprjdraws"]]
+        vtxt_clust_used_eval <- refdist_sel[["clust_used"]]
+        vtxt_nprjdraws_eval <- refdist_sel[["nprjdraws"]]
       }
       verb_out("-----\nRunning ",
                if (!search_out_rks_was_null) {
@@ -974,16 +974,27 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
                         " and ")
                },
                "the performance evaluation with ",
-               txt_clust_draws(verb_clust_used_eval, verb_nprjdraws_eval),
+               txt_clust_draws(vtxt_clust_used_eval, vtxt_nprjdraws_eval),
                " (`refit_prj = ", refit_prj, "`) for each of the `nloo = ",
                nloo, "` LOO-CV folds separately ...")
     }
     one_obs <- function(run_index,
-                        verbose_search = verbose &&
+                        verbose_obs = verbose &&
                           getOption("projpred.extra_verbose", FALSE),
                         ...) {
       # Observation index:
       i <- inds[run_index]
+
+      # For (extra-)verbose mode:
+      vtxt_obs_i <- paste0(
+        "for LOO-CV fold ", run_index, " out of `nloo = ", nloo, "` ",
+        "(", round(100 * run_index / nloo), " %) ",
+        if (nloo < n) {
+          paste0("(this is observation ", i, ") ")
+        } else {
+          ""
+        }
+      )
 
       # Run the search with the reweighted clusters (or thinned draws) (so the
       # *reweighted* fitted response values from the reference model act as
@@ -996,19 +1007,9 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
           refmodel = refmodel, ndraws = ndraws, nclusters = nclusters,
           reweighting_args = list(cl_ref = cl_sel, wdraws_ref = exp(lw[, i])),
           method = method, nterms_max = nterms_max, penalty = penalty,
-          verbose = verbose_search,
-          verbose_txt_obs = NULL,
-          # TODO: Use a non-`NULL` text for `verbose_txt_obs` mentioning that
-          # this is for a single fold, namely fold `i`, and also remove the
-          # possibility of `verbose_txt_obs = NULL` in .select() (and then also
-          # remove `May also be `NULL` to omit that verbose message completely.`
-          # in the corresponding internal documentation). Then also set `verbose
-          # = verbose_search` in the perf_eval() call below and rename
-          # `verbose_search` to something like `verbose_folds` (and don't forget
-          # to update the general package documentation for global option
-          # `projpred.extra_verbose`).
-          search_control = search_control,
-          search_terms = search_terms, est_runtime = FALSE, ...
+          verbose = verbose_obs, verbose_txt_obs = vtxt_obs_i,
+          search_control = search_control, search_terms = search_terms,
+          est_runtime = FALSE, ...
         )
       }
 
@@ -1018,7 +1019,8 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
         search_path = search_path, refmodel = refmodel, refit_prj = refit_prj,
         ndraws = ndraws_pred, nclusters = nclusters_pred,
         reweighting_args = list(cl_ref = cl_pred, wdraws_ref = exp(lw[, i])),
-        indices_test = i, ...
+        indices_test = i, verbose = verbose_obs, verbose_txt_obs = vtxt_obs_i,
+        ...
       )
 
       return(nlist(predictor_ranking = search_path[["predictor_ranking"]],
@@ -1069,7 +1071,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
                       "loo_sub_oscale", "mu_sub_oscale")
       ) %do_projpred% {
         out_one_obs <- do.call(one_obs, c(list(run_index = run_index,
-                                               verbose_search = FALSE),
+                                               verbose_obs = FALSE),
                                           dot_args))
         if (!is.null(progressor_obj)) progressor_obj()
         return(out_one_obs)
@@ -1293,6 +1295,7 @@ warn_pareto <- function(n07, n, khat_threshold = 0.7, warn_txt) {
 if (getRversion() >= package_version("2.15.1")) {
   utils::globalVariables("list_cv_k")
   utils::globalVariables("search_out_rks_k")
+  utils::globalVariables("ks_k")
 }
 
 kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
@@ -1329,41 +1332,46 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
       nclusters = nclusters,
       S = length(refmodel$wdraws_ref)
     )
-    verb_clust_used_sel <- clust_info_sel[["clust_used"]]
-    verb_nprjdraws_sel <- clust_info_sel[["nprjdraws"]]
+    vtxt_clust_used_sel <- clust_info_sel[["clust_used"]]
+    vtxt_nprjdraws_sel <- clust_info_sel[["nprjdraws"]]
     if (refit_prj) {
       clust_info_eval <- clust_info(
         ndraws = ndraws_pred,
         nclusters = nclusters_pred,
         S = length(refmodel$wdraws_ref)
       )
-      verb_clust_used_eval <- clust_info_eval[["clust_used"]]
-      verb_nprjdraws_eval <- clust_info_eval[["nprjdraws"]]
+      vtxt_clust_used_eval <- clust_info_eval[["clust_used"]]
+      vtxt_nprjdraws_eval <- clust_info_eval[["nprjdraws"]]
     } else {
       # NOTE: `!refit_prj` cannot occur in combination with
       # `!search_out_rks_was_null || !validate_search`, so it is correct and
-      # safe to use `verb_clust_used_sel` and `verb_nprjdraws_sel` here.
-      verb_clust_used_eval <- verb_clust_used_sel
-      verb_nprjdraws_eval <- verb_nprjdraws_sel
+      # safe to use `vtxt_clust_used_sel` and `vtxt_nprjdraws_sel` here.
+      vtxt_clust_used_eval <- vtxt_clust_used_sel
+      vtxt_nprjdraws_eval <- vtxt_nprjdraws_sel
     }
     verb_out("-----\nRunning ",
              if (!search_out_rks_was_null || !validate_search) {
                ""
              } else {
                paste0(method, " search with ",
-                      txt_clust_draws(verb_clust_used_sel, verb_nprjdraws_sel),
+                      txt_clust_draws(vtxt_clust_used_sel, vtxt_nprjdraws_sel),
                       " and ")
              },
              "the performance evaluation with ",
-             txt_clust_draws(verb_clust_used_eval, verb_nprjdraws_eval),
+             txt_clust_draws(vtxt_clust_used_eval, vtxt_nprjdraws_eval),
              " (`refit_prj = ", refit_prj, "`) for each of the K = ", K,
              " CV folds separately ...")
   }
   one_fold <- function(fold,
                        rk,
-                       verbose_search = verbose &&
+                       k,
+                       verbose_fold = verbose &&
                          getOption("projpred.extra_verbose", FALSE),
                        ...) {
+    # For (extra-)verbose mode:
+    vtxt_fold_k <- paste0("for CV fold ", k, " out of K = ", K, " (",
+                          round(100 * k / K), " %) ")
+
     # Run the search for the current fold:
     if (!validate_search) {
       search_path <- search_path_fulldata
@@ -1373,16 +1381,9 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
       search_path <- .select(
         refmodel = fold$refmodel, ndraws = ndraws, nclusters = nclusters,
         method = method, nterms_max = nterms_max, penalty = penalty,
-        verbose = verbose_search,
-        verbose_txt_obs = NULL,
-        # TODO: When using a non-`NULL` text for `verbose_txt_obs` in one_obs(),
-        # also do this here in one_fold(). Then also set `verbose =
-        # verbose_search` in the perf_eval() call below and rename
-        # `verbose_search` to something like `verbose_folds` (and don't forget
-        # to update the general package documentation for global option
-        # `projpred.extra_verbose`).
-        search_control = search_control,
-        search_terms = search_terms, est_runtime = FALSE, ...
+        verbose = verbose_fold, verbose_txt_obs = vtxt_fold_k,
+        search_control = search_control, search_terms = search_terms,
+        est_runtime = FALSE, ...
       )
     }
 
@@ -1391,7 +1392,8 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
     perf_eval_out <- perf_eval(
       search_path = search_path, refmodel = fold$refmodel,
       refit_prj = refit_prj, ndraws = ndraws_pred, nclusters = nclusters_pred,
-      refmodel_fulldata = refmodel, indices_test = fold$omitted, ...
+      refmodel_fulldata = refmodel, indices_test = fold$omitted,
+      verbose = verbose_fold, verbose_txt_obs = vtxt_fold_k, ...
     )
 
     # Performance evaluation for the reference model of the current fold:
@@ -1423,11 +1425,11 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
     if (verbose) {
       pb <- utils::txtProgressBar(min = 0, max = K, style = 3, initial = 0)
     }
-    res_cv <- lapply(seq_along(list_cv), function(k) {
+    res_cv <- lapply(seq_len(K), function(k) {
       if (verbose) {
         on.exit(utils::setTxtProgressBar(pb, k))
       }
-      one_fold(fold = list_cv[[k]], rk = search_out_rks[[k]], ...)
+      one_fold(fold = list_cv[[k]], rk = search_out_rks[[k]], k = k, ...)
     })
     if (verbose) {
       close(pb)
@@ -1441,7 +1443,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
       stop("Please install the 'doRNG' package.")
     }
     if (verbose && use_progressr()) {
-      progressor_obj <- progressr::progressor(length(list_cv))
+      progressor_obj <- progressr::progressor(K)
     } else {
       progressor_obj <- NULL
     }
@@ -1450,6 +1452,7 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
     res_cv <- foreach::foreach(
       list_cv_k = list_cv,
       search_out_rks_k = search_out_rks,
+      ks_k = seq_len(K),
       .packages = c("projpred"),
       .export = c("one_fold", "dot_args", "progressor_obj",
                   getOption("projpred.export_to_workers", character())),
@@ -1457,7 +1460,8 @@ kfold_varsel <- function(refmodel, method, nterms_max, ndraws, nclusters,
     ) %do_projpred% {
       out_one_fold <- do_call(one_fold, c(list(fold = list_cv_k,
                                                rk = search_out_rks_k,
-                                               verbose_search = FALSE),
+                                               k = ks_k,
+                                               verbose_fold = FALSE),
                                           dot_args))
       if (!is.null(progressor_obj)) progressor_obj()
       return(out_one_fold)

--- a/R/cv_varsel.R
+++ b/R/cv_varsel.R
@@ -828,7 +828,7 @@ loo_varsel <- function(refmodel, method, nterms_max, ndraws,
         if (getOption("projpred.warn_psis", TRUE)) {
           message(
             "Using standard importance sampling (SIS) due to a small number of ",
-            if (clust_used_eval) "clusters" else "draws (from thinning)", "."
+            if (clust_used_eval) "clusters" else "draws", "."
           )
         }
         # Use loo::sis().

--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -65,7 +65,7 @@ divmin <- function(
     # and 'iterators' would have to be moved from `Suggests:` to `Imports:`).
     if (verbose_divmin) {
       pb <- utils::txtProgressBar(min = 0, max = length(formulas), style = 3,
-                                  initial = 0)
+                                  initial = 0, file = stderr())
       on.exit(close(pb))
     }
     outdmin <- lapply(seq_along(formulas), function(s) {
@@ -628,7 +628,7 @@ divmin_augdat <- function(
     # and 'iterators' would have to be moved from `Suggests:` to `Imports:`).
     if (verbose_divmin) {
       pb <- utils::txtProgressBar(min = 0, max = ncol(projpred_ws_aug),
-                                  style = 3, initial = 0)
+                                  style = 3, initial = 0, file = stderr())
       on.exit(close(pb))
     }
     outdmin <- lapply(seq_len(ncol(projpred_ws_aug)), function(s) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -636,10 +636,10 @@ cat_cls <- function(x) {
       paste(cls, collapse = ", "), "\n\n", sep = "")
 }
 
-# Print out text via cat() if `verbose = TRUE`:
+# Print out text via message() if `verbose = TRUE`:
 verb_out <- function(..., verbose = TRUE) {
   if (verbose) {
-    cat(..., "\n", sep = "")
+    message(...)
   }
 }
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -654,9 +654,6 @@ txt_clust_draws <- function(clust_used, nprjdraws) {
   if (nprjdraws > 1) {
     out <- paste0(out, "s")
   }
-  if (!clust_used) {
-    out <- paste0(out, " (from thinning)")
-  }
   return(out)
 }
 

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -23,7 +23,7 @@ proj_to_submodl <- function(predictor_terms, p_ref, refmodel,
       rhs_chr <- paste("<EXCEPTION: Unexpected length of the character-coerced",
                        "formula passed to the divergence minimizer.>")
     }
-    verb_out("  Projecting onto ", utils::tail(rhs_chr, 1))
+    verb_out("  Projecting onto `~ ", utils::tail(rhs_chr, 1), "`")
   }
 
   args_divmin <- list(formula = fml_divmin,

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -61,7 +61,7 @@ perf_eval <- function(search_path,
                       y_test = refmodel_fulldata$y[indices_test],
                       y_oscale_test = refmodel_fulldata$y_oscale[indices_test],
                       verbose = FALSE, verbose_line_length = 5,
-                      verbose_txt_obs = "", ...) {
+                      verbose_txt_add = "", ...) {
   if (!refit_prj) {
     p_ref <- search_path$p_sel
     # In this case, simply fetch the already computed projections, so don't
@@ -108,7 +108,7 @@ perf_eval <- function(search_path,
     verbose <- FALSE
   }
   verb_out(rep("-", verbose_line_length), "\nRunning the performance evaluation ",
-           verbose_txt_obs, "with ",
+           verbose_txt_add, "with ",
            txt_clust_draws(p_ref[["clust_used"]], p_ref[["nprjdraws"]]),
            " (`refit_prj = ", refit_prj, "`) ...", verbose = verbose)
   out_by_size <- lapply(nterms, function(size_j) {

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -60,8 +60,8 @@ perf_eval <- function(search_path,
                       wobs_test = refmodel_fulldata$wobs[indices_test],
                       y_test = refmodel_fulldata$y[indices_test],
                       y_oscale_test = refmodel_fulldata$y_oscale[indices_test],
-                      verbose = FALSE, verbose_txt_obs = "",
-                      ...) {
+                      verbose = FALSE, verbose_line_length = 5,
+                      verbose_txt_obs = "", ...) {
   if (!refit_prj) {
     p_ref <- search_path$p_sel
     # In this case, simply fetch the already computed projections, so don't
@@ -107,7 +107,8 @@ perf_eval <- function(search_path,
     # project()).
     verbose <- FALSE
   }
-  verb_out("-----\nRunning the performance evaluation ", verbose_txt_obs, "with ",
+  verb_out(rep("-", verbose_line_length), "\nRunning the performance evaluation ",
+           verbose_txt_obs, "with ",
            txt_clust_draws(p_ref[["clust_used"]], p_ref[["nprjdraws"]]),
            " (`refit_prj = ", refit_prj, "`) ...", verbose = verbose)
   out_by_size <- lapply(nterms, function(size_j) {
@@ -152,7 +153,7 @@ perf_eval <- function(search_path,
     }
     return(out_j)
   })
-  verb_out("-----", verbose = verbose)
+  verb_out(rep("-", verbose_line_length), verbose = verbose)
   if (return_submodls) {
     # Currently only called in project().
     return(out_by_size)

--- a/R/projfun.R
+++ b/R/projfun.R
@@ -60,7 +60,7 @@ perf_eval <- function(search_path,
                       wobs_test = refmodel_fulldata$wobs[indices_test],
                       y_test = refmodel_fulldata$y[indices_test],
                       y_oscale_test = refmodel_fulldata$y_oscale[indices_test],
-                      verbose = FALSE,
+                      verbose = FALSE, verbose_txt_obs = "",
                       ...) {
   if (!refit_prj) {
     p_ref <- search_path$p_sel
@@ -107,7 +107,7 @@ perf_eval <- function(search_path,
     # project()).
     verbose <- FALSE
   }
-  verb_out("-----\nRunning the performance evaluation with ",
+  verb_out("-----\nRunning the performance evaluation ", verbose_txt_obs, "with ",
            txt_clust_draws(p_ref[["clust_used"]], p_ref[["nprjdraws"]]),
            " (`refit_prj = ", refit_prj, "`) ...", verbose = verbose)
   out_by_size <- lapply(nterms, function(size_j) {

--- a/R/projpred-package.R
+++ b/R/projpred-package.R
@@ -87,8 +87,9 @@
 #' Global option `projpred.verbose` may be used for specifying the value (`TRUE`
 #' or `FALSE`) passed to argument `verbose` of [varsel()] and [cv_varsel()].
 #'
-#' Setting global option `projpred.extra_verbose` to `TRUE` will print out which
-#' submodel \pkg{projpred} is currently projecting onto as well as (if `method =
+#' Setting global option `projpred.extra_verbose` to `TRUE` will print out the
+#' current fold (for [cv_varsel()] with `validate_search = TRUE`), the submodel
+#' that \pkg{projpred} is currently projecting onto, and (if `method =
 #' "forward"` and `verbose = TRUE` in [varsel()] or [cv_varsel()]) which
 #' submodel has been selected at those steps of the forward search for which a
 #' percentage (of the maximum submodel size that the search is run up to) is
@@ -96,6 +97,14 @@
 #' to `TRUE` for [cv_varsel()] with `validate_search = TRUE` (simply due to the
 #' amount of information that will be printed, but also due to the progress bar
 #' which will not work as intended anymore).
+#'
+#' Global option `projpred.verbose_project` controls argument `verbose` of
+#' [project()], but also affects the verbosity of all other projections
+#' performed by the built-in divergence minimizers (except for L1 projections),
+#' in particular during a [varsel()] or [cv_varsel()] call. Usually, setting
+#' `projpred.verbose_project` to `TRUE` only makes sense when setting global
+#' option `projpred.extra_verbose` and argument `verbose` (of [varsel()] or
+#' [cv_varsel()]) to `TRUE` as well.
 #'
 #' By default, \pkg{projpred} catches messages and warnings from the draw-wise
 #' divergence minimizers and throws their unique collection after performing all

--- a/R/search.R
+++ b/R/search.R
@@ -121,7 +121,7 @@ search_forward <- function(p_ref, refmodel, nterms_max, verbose = TRUE,
     if (verbose && ct_chosen %in% iq) {
       vtxt <- paste(names(iq)[max(which(ct_chosen == iq))], "of terms selected")
       if (getOption("projpred.extra_verbose", FALSE)) {
-        vtxt <- paste0(vtxt, ": ", paste(chosen, collapse = " + "))
+        vtxt <- paste0(vtxt, ": `~ ", paste(chosen, collapse = " + "), "`")
       }
       verb_out(vtxt)
     }

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -513,7 +513,6 @@ varsel.refmodel <- function(
 #   weighted_summary_means().
 # @param verbose_txt_obs Passed to `...` of verb_out(), so character string(s)
 #   to be included in the verbose message indicating the start of the search.
-#   May also be `NULL` to omit that verbose message completely.
 # For all other arguments, see the documentation of varsel().
 #
 # @return A list with elements `predictor_ranking` (the predictor ranking
@@ -540,11 +539,9 @@ varsel.refmodel <- function(
     )
   }
 
-  if (!is.null(verbose_txt_obs)) {
-    verb_out("-----\nRunning ", method, " search ", verbose_txt_obs, "with ",
-             txt_clust_draws(p_sel[["clust_used"]], p_sel[["nprjdraws"]]),
-             " ...", verbose = verbose)
-  }
+  verb_out("-----\nRunning ", method, " search ", verbose_txt_obs, "with ",
+           txt_clust_draws(p_sel[["clust_used"]], p_sel[["nprjdraws"]]),
+           " ...", verbose = verbose)
   if (method == "L1") {
     search_path <- search_L1(
       p_ref = p_sel, refmodel = refmodel, nterms_max = nterms_max,
@@ -556,9 +553,7 @@ varsel.refmodel <- function(
       verbose = verbose, search_control = search_control, ...
     )
   }
-  if (!is.null(verbose_txt_obs)) {
-    verb_out("-----", verbose = verbose)
-  }
+  verb_out("-----", verbose = verbose)
 
   search_path$p_sel <- p_sel
   return(search_path)

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -511,7 +511,7 @@ varsel.refmodel <- function(
 #   weights), then this needs to be a `list` with elements `wdraws_ref` and
 #   `cl_ref`. For these two elements, see the (internal) documentation of
 #   weighted_summary_means().
-# @param verbose_txt_obs Passed to `...` of verb_out(), so character string(s)
+# @param verbose_txt_add Passed to `...` of verb_out(), so character string(s)
 #   to be included in the verbose message indicating the start of the search.
 # For all other arguments, see the documentation of varsel().
 #
@@ -522,7 +522,7 @@ varsel.refmodel <- function(
 #   `p_sel` (the output from get_refdist() for the search).
 .select <- function(refmodel, ndraws, nclusters, reweighting_args = NULL,
                     method, nterms_max, penalty, verbose,
-                    verbose_line_length = 5, verbose_txt_obs = "",
+                    verbose_line_length = 5, verbose_txt_add = "",
                     search_control, ...) {
   if (is.null(reweighting_args)) {
     p_sel <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)
@@ -541,7 +541,7 @@ varsel.refmodel <- function(
   }
 
   verb_out(rep("-", verbose_line_length), "\nRunning ", method, " search ",
-           verbose_txt_obs, "with ",
+           verbose_txt_add, "with ",
            txt_clust_draws(p_sel[["clust_used"]], p_sel[["nprjdraws"]]),
            " ...", verbose = verbose)
   if (method == "L1") {

--- a/R/varsel.R
+++ b/R/varsel.R
@@ -521,7 +521,8 @@ varsel.refmodel <- function(
 #   of fits per model size being equal to the number of projected draws), and
 #   `p_sel` (the output from get_refdist() for the search).
 .select <- function(refmodel, ndraws, nclusters, reweighting_args = NULL,
-                    method, nterms_max, penalty, verbose, verbose_txt_obs = "",
+                    method, nterms_max, penalty, verbose,
+                    verbose_line_length = 5, verbose_txt_obs = "",
                     search_control, ...) {
   if (is.null(reweighting_args)) {
     p_sel <- get_refdist(refmodel, ndraws = ndraws, nclusters = nclusters)
@@ -539,7 +540,8 @@ varsel.refmodel <- function(
     )
   }
 
-  verb_out("-----\nRunning ", method, " search ", verbose_txt_obs, "with ",
+  verb_out(rep("-", verbose_line_length), "\nRunning ", method, " search ",
+           verbose_txt_obs, "with ",
            txt_clust_draws(p_sel[["clust_used"]], p_sel[["nprjdraws"]]),
            " ...", verbose = verbose)
   if (method == "L1") {
@@ -553,7 +555,7 @@ varsel.refmodel <- function(
       verbose = verbose, search_control = search_control, ...
     )
   }
-  verb_out("-----", verbose = verbose)
+  verb_out(rep("-", verbose_line_length), verbose = verbose)
 
   search_path$p_sel <- p_sel
   return(search_path)

--- a/man/projpred-package.Rd
+++ b/man/projpred-package.Rd
@@ -85,14 +85,23 @@ object inherits from class \code{gam}).
 Global option \code{projpred.verbose} may be used for specifying the value (\code{TRUE}
 or \code{FALSE}) passed to argument \code{verbose} of \code{\link[=varsel]{varsel()}} and \code{\link[=cv_varsel]{cv_varsel()}}.
 
-Setting global option \code{projpred.extra_verbose} to \code{TRUE} will print out which
-submodel \pkg{projpred} is currently projecting onto as well as (if \code{method = "forward"} and \code{verbose = TRUE} in \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}}) which
+Setting global option \code{projpred.extra_verbose} to \code{TRUE} will print out the
+current fold (for \code{\link[=cv_varsel]{cv_varsel()}} with \code{validate_search = TRUE}), the submodel
+that \pkg{projpred} is currently projecting onto, and (if \code{method = "forward"} and \code{verbose = TRUE} in \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}}) which
 submodel has been selected at those steps of the forward search for which a
 percentage (of the maximum submodel size that the search is run up to) is
 printed. In general, however, we cannot recommend setting this global option
 to \code{TRUE} for \code{\link[=cv_varsel]{cv_varsel()}} with \code{validate_search = TRUE} (simply due to the
 amount of information that will be printed, but also due to the progress bar
 which will not work as intended anymore).
+
+Global option \code{projpred.verbose_project} controls argument \code{verbose} of
+\code{\link[=project]{project()}}, but also affects the verbosity of all other projections
+performed by the built-in divergence minimizers (except for L1 projections),
+in particular during a \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}} call. Usually, setting
+\code{projpred.verbose_project} to \code{TRUE} only makes sense when setting global
+option \code{projpred.extra_verbose} and argument \code{verbose} (of \code{\link[=varsel]{varsel()}} or
+\code{\link[=cv_varsel]{cv_varsel()}}) to \code{TRUE} as well.
 
 By default, \pkg{projpred} catches messages and warnings from the draw-wise
 divergence minimizers and throws their unique collection after performing all

--- a/tests/testthat/test_as_matrix.R
+++ b/tests/testthat/test_as_matrix.R
@@ -224,7 +224,7 @@ test_that("as.matrix.projection() works", {
       width_orig <- options(width = 145)
       expect_snapshot({
         print(tstsetup)
-        print(rlang::hash(m)) # cat(m)
+        print(rlang::hash(m)) # message(m)
       })
       options(width_orig)
       if (testthat_ed_max2) local_edition(2)
@@ -340,7 +340,7 @@ if (run_snaps) {
         expect_snapshot({
           print(tstsetup)
           print(prjs_vs_i$predictor_terms)
-          print(rlang::hash(m)) # cat(m)
+          print(rlang::hash(m)) # message(m)
         })
         return(invisible(TRUE))
       })
@@ -379,7 +379,7 @@ if (run_snaps) {
         expect_snapshot({
           print(tstsetup)
           print(prjs_cvvs_i$predictor_terms)
-          print(rlang::hash(m)) # cat(m)
+          print(rlang::hash(m)) # message(m)
         })
         return(invisible(TRUE))
       })

--- a/tests/testthat/test_datafit.R
+++ b/tests/testthat/test_datafit.R
@@ -355,7 +355,7 @@ test_that(paste(
       #   m <- as.matrix(prjs_vs_datafit[[tstsetup]])
       #   expect_snapshot({
       #     print(tstsetup)
-      #     print(rlang::hash(m)) # cat(m)
+      #     print(rlang::hash(m)) # message(m)
       #   })
       #   if (testthat_ed_max2) local_edition(2)
       # }
@@ -382,7 +382,7 @@ test_that(paste(
       #     expect_snapshot({
       #       print(tstsetup)
       #       print(prjs_vs_i$predictor_terms)
-      #       print(rlang::hash(m)) # cat(m)
+      #       print(rlang::hash(m)) # message(m)
       #     })
       #     return(invisible(TRUE))
       #   })

--- a/tests/testthat/test_varsel.R
+++ b/tests/testthat/test_varsel.R
@@ -1659,9 +1659,9 @@ test_that(paste(
                                             cores = 1)),
                      silent = TRUE)
     if (inherits(kfold_obj, "try-error")) {
-      cat("Could not test `tstsetup = \"", tstsetup, "\"` in the rstanarm ",
-          "`cvfits` test. Error message: \"",
-          attr(kfold_obj, "condition")$message, "\"\n", sep = "")
+      message("Could not test `tstsetup = \"", tstsetup, "\"` in the rstanarm ",
+              "`cvfits` test. Error message: \"",
+              attr(kfold_obj, "condition")$message, "\"")
       next
     }
     kfold_obj <- structure(kfold_obj$fits[, "fit"], folds = folds_vec)
@@ -1786,9 +1786,9 @@ test_that(paste(
       silent = TRUE
     )
     if (inherits(cvvs_cvfits, "try-error")) {
-      cat("Failure for `tstsetup = \"", tstsetup, "\"` in the brms ",
-          "`cvfits` test. Error message: \"",
-          attr(cvvs_cvfits, "condition")$message, "\"\n", sep = "")
+      message("Failure for `tstsetup = \"", tstsetup, "\"` in the brms ",
+              "`cvfits` test. Error message: \"",
+              attr(cvvs_cvfits, "condition")$message, "\"")
       # Check that this is a "pwrssUpdate" failure in lme4, so for solving this,
       # we would either need to tweak the lme4 tuning parameters manually (via
       # `...`) or change the data-generating mechanism here in the tests (to
@@ -2334,9 +2334,9 @@ test_that(paste(
       silent = TRUE
     )
     if (inherits(cvvs_eval, "try-error")) {
-      cat("Failure for `tstsetup = \"", tstsetup, "\"` in a cv_varsel.vsel() ",
-          "test. Error message: \"",
-          attr(cvvs_eval, "condition")$message, "\"\n", sep = "")
+      message("Failure for `tstsetup = \"", tstsetup, "\"` in a cv_varsel.vsel() ",
+              "test. Error message: \"",
+              attr(cvvs_eval, "condition")$message, "\"")
       # Check that this is a "pwrssUpdate" failure in lme4, so for solving this,
       # we would either need to tweak the lme4 tuning parameters manually (via
       # `...`) or change the data-generating mechanism here in the tests (to
@@ -2412,9 +2412,9 @@ test_that(paste(
       silent = TRUE
     )
     if (inherits(cvvs_eval, "try-error")) {
-      cat("Failure for `tstsetup = \"", tstsetup, "\"` in a cv_varsel.vsel() ",
-          "test. Error message: \"",
-          attr(cvvs_eval, "condition")$message, "\"\n", sep = "")
+      message("Failure for `tstsetup = \"", tstsetup, "\"` in a cv_varsel.vsel() ",
+              "test. Error message: \"",
+              attr(cvvs_eval, "condition")$message, "\"")
       # Check that this is a "pwrssUpdate" failure in lme4, so for solving this,
       # we would either need to tweak the lme4 tuning parameters manually (via
       # `...`) or change the data-generating mechanism here in the tests (to
@@ -2490,9 +2490,9 @@ test_that(paste(
       )
     }
     if (inherits(cvvs_eval, "try-error")) {
-      cat("Failure for `tstsetup = \"", tstsetup, "\"` in a cv_varsel.vsel() ",
-          "test. Error message: \"",
-          attr(cvvs_eval, "condition")$message, "\"\n", sep = "")
+      message("Failure for `tstsetup = \"", tstsetup, "\"` in a cv_varsel.vsel() ",
+              "test. Error message: \"",
+              attr(cvvs_eval, "condition")$message, "\"")
       # Check that this is a "pwrssUpdate" failure in lme4, so for solving this,
       # we would either need to tweak the lme4 tuning parameters manually (via
       # `...`) or change the data-generating mechanism here in the tests (to
@@ -2594,9 +2594,9 @@ test_that(paste(
       )
     }
     if (inherits(cvvs_eval, "try-error")) {
-      cat("Failure for `tstsetup = \"", tstsetup, "\"` in a cv_varsel.vsel() ",
-          "test. Error message: \"",
-          attr(cvvs_eval, "condition")$message, "\"\n", sep = "")
+      message("Failure for `tstsetup = \"", tstsetup, "\"` in a cv_varsel.vsel() ",
+              "test. Error message: \"",
+              attr(cvvs_eval, "condition")$message, "\"")
       # Check that this is a "pwrssUpdate" failure in lme4, so for solving this,
       # we would either need to tweak the lme4 tuning parameters manually (via
       # `...`) or change the data-generating mechanism here in the tests (to


### PR DESCRIPTION
This is a follow-up for PR #516: Thanks to #516, the PR presented here can add "extra" verbosity (i.e., when global option `projpred.extra_verbose` is set to `TRUE`) about the current fold when running `cv_varsel()` with `validate_search = TRUE` or K-fold CV with `validate_search = FALSE`. There are some other minor enhancements to verbosity which are explained in the commit messages.

File `NEWS.md` is unchanged here. I will update it as soon as #511 (or #508) has been merged. I would propose to change the following entry:
```
* Minor enhancements concerning verbosity (e.g., the number of projected draws---resulting from clustering or thinning---is now printed out during the different steps of the computations). Also introduced global option `projpred.verbose` which may be used to set argument `verbose` of `varsel()` and `cv_varsel()` globally. (GitHub: #506)
```
to:
```
* Several enhancements concerning verbosity (e.g., the number of projected draws---resulting from clustering or thinning---is now printed out during the different steps of the computations and verbose-mode output is redirected to `stderr()` instead of `stdout()`). Also introduced global option `projpred.verbose` which may be used to set argument `verbose` of `varsel()` and `cv_varsel()` globally. (GitHub: #506, #518)
```
