### PR TITLE
Integer `verbose` (deprecate global options `projpred.extra_verbose` and `projpred.verbose_project`)

### DIFF
--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -13,7 +13,7 @@ divmin <- function(
     formula,
     projpred_var,
     projpred_ws_aug,
-    verbose_divmin = getOption("projpred.verbose_project", FALSE),
+    verbose_divmin,
     throw_warn_sdivmin = getOption("projpred.warn_prj_drawwise", TRUE),
     do_check_conv = getOption("projpred.check_conv", TRUE),
     ...
@@ -564,7 +564,7 @@ divmin_augdat <- function(
     weights,
     projpred_var,
     projpred_ws_aug,
-    verbose_divmin = getOption("projpred.verbose_project", FALSE),
+    verbose_divmin,
     throw_warn_sdivmin = getOption("projpred.warn_prj_drawwise", TRUE),
     do_check_conv = getOption("projpred.check_conv", TRUE),
     ...

--- a/R/misc.R
+++ b/R/misc.R
@@ -770,3 +770,64 @@ sqrt_cut0 <- function(x) {
   }
   return(sqrt(x))
 }
+
+verbose_from_deprecated_options <- function(verbose, with_cv = FALSE,
+                                            proj_only = FALSE) {
+  if (!is.logical(verbose)) {
+    return(verbose)
+  }
+  if (!is.null(getOption("projpred.extra_verbose")) &&
+      !is.null(getOption("projpred.verbose_project"))) {
+    warning(
+      "Global options `projpred.extra_verbose` and `projpred.verbose_project` ",
+      "are deprecated. Please use argument ",
+      "`verbose` instead. This argument can also be controlled via a ",
+      "corresponding global option. Now trying to find an appropriate value ",
+      "for argument `verbose`."
+    )
+    verbose <- as.logical(verbose) * (
+      proj_only * 2L +
+        (!proj_only) * (
+          (getOption("projpred.extra_verbose") ||
+             getOption("projpred.verbose_project")) *
+            (1L + with_cv + getOption("projpred.verbose_project")) +
+            1L
+        )
+    )
+  } else {
+    verbose <- verbose_from_deprecated_option(
+      verbose,
+      with_cv = with_cv,
+      proj_only = proj_only,
+      nm_option = "projpred.extra_verbose"
+    )
+    verbose <- verbose_from_deprecated_option(
+      verbose,
+      with_cv = with_cv,
+      proj_only = proj_only,
+      nm_option = "projpred.verbose_project"
+    )
+  }
+  return(verbose)
+}
+
+verbose_from_deprecated_option <- function(verbose, with_cv = FALSE,
+                                           proj_only = FALSE, nm_option) {
+  if (!is.null(getOption(nm_option))) {
+    warning(
+      "Global option `", nm_option, "` is deprecated. Please use argument ",
+      "`verbose` instead. This argument can also be controlled via a ",
+      "corresponding global option. Now trying to find an appropriate value ",
+      "for argument `verbose`."
+    )
+    verbose <- as.logical(verbose) * (
+      proj_only * 2L +
+        (!proj_only) * (
+          getOption(nm_option) *
+            (1L + with_cv + identical(nm_option, "projpred.verbose_project")) +
+            1L
+        )
+    )
+  }
+  return(verbose)
+}

--- a/R/projpred-package.R
+++ b/R/projpred-package.R
@@ -84,27 +84,8 @@
 #'
 #' # Verbosity, messages, warnings, errors
 #'
-#' Global option `projpred.verbose` may be used for specifying the value (`TRUE`
-#' or `FALSE`) passed to argument `verbose` of [varsel()] and [cv_varsel()].
-#'
-#' Setting global option `projpred.extra_verbose` to `TRUE` will print out the
-#' current fold (for [cv_varsel()] with `validate_search = TRUE`), the submodel
-#' that \pkg{projpred} is currently projecting onto, and (if `method =
-#' "forward"` and `verbose = TRUE` in [varsel()] or [cv_varsel()]) which
-#' submodel has been selected at those steps of the forward search for which a
-#' percentage (of the maximum submodel size that the search is run up to) is
-#' printed. In general, however, we cannot recommend setting this global option
-#' to `TRUE` for [cv_varsel()] with `validate_search = TRUE` (simply due to the
-#' amount of information that will be printed, but also due to the progress bar
-#' which will not work as intended anymore).
-#'
-#' Global option `projpred.verbose_project` controls argument `verbose` of
-#' [project()], but also affects the verbosity of all other projections
-#' performed by the built-in divergence minimizers (except for L1 projections),
-#' in particular during a [varsel()] or [cv_varsel()] call. Usually, setting
-#' `projpred.verbose_project` to `TRUE` only makes sense when setting global
-#' option `projpred.extra_verbose` and argument `verbose` (of [varsel()] or
-#' [cv_varsel()]) to `TRUE` as well.
+#' Global option `projpred.verbose` may be used for specifying the value passed
+#' to argument `verbose` of [project()], [varsel()], and [cv_varsel()].
 #'
 #' By default, \pkg{projpred} catches messages and warnings from the draw-wise
 #' divergence minimizers and throws their unique collection after performing all

--- a/R/search.R
+++ b/R/search.R
@@ -23,7 +23,7 @@ search_forward <- function(p_ref, refmodel, nterms_max, verbose = TRUE,
       time_bef <- Sys.time()
     }
     submodls <- lapply(full_cands, proj_to_submodl, p_ref = p_ref,
-                       refmodel = refmodel, ...)
+                       refmodel = refmodel, verbose = verbose, ...)
     if (size == 1 && est_runtime && getOption("projpred.mssg_time", TRUE)) {
       time_aft <- Sys.time()
       dtime <- difftime(time_aft, time_bef, units = "secs")
@@ -120,7 +120,7 @@ search_forward <- function(p_ref, refmodel, nterms_max, verbose = TRUE,
     ct_chosen <- count_terms_chosen(chosen)
     if (verbose && ct_chosen %in% iq) {
       vtxt <- paste(names(iq)[max(which(ct_chosen == iq))], "of terms selected")
-      if (getOption("projpred.extra_verbose", FALSE)) {
+      if (verbose >= 2L) {
         vtxt <- paste0(vtxt, ": `~ ", paste(chosen, collapse = " + "), "`")
       }
       verb_out(vtxt)

--- a/man/cv_varsel.Rd
+++ b/man/cv_varsel.Rd
@@ -32,7 +32,7 @@ cv_varsel(object, ...)
   refit_prj = !inherits(object, "datafit"),
   nterms_max = NULL,
   penalty = NULL,
-  verbose = getOption("projpred.verbose", interactive()),
+  verbose = getOption("projpred.verbose", as.integer(interactive())),
   nloo = if (cv_method == "LOO") object$nobs else NULL,
   K = if (!inherits(object, "datafit")) 5 else 10,
   cvfits = object$cvfits,
@@ -141,8 +141,13 @@ those predictors have no cost and will therefore be selected first, whereas
 \code{Inf} means those predictors will never be selected. If \code{NULL}, then \code{1} is
 used for each predictor.}
 
-\item{verbose}{A single logical value indicating whether to print out
-additional information during the computations.}
+\item{verbose}{A single integer value from the set \eqn{\{0, 1, 2, 3,
+  4\}}{{0, 1, 2, 3, 4}} (for \code{\link[=varsel]{varsel()}}, \eqn{3} and \eqn{4} have the same
+effect), indicating how much information (if any) to print out during the
+computations. Higher values indicate that more information should be
+printed, \code{0} deactivates the verbose mode. Internally, argument \code{verbose}
+is coerced to integer via \code{as.integer()}, so technically, a single logical
+value or a single numeric value work as well.}
 
 \item{search_control}{A \code{list} of "control" arguments (i.e., tuning
 parameters) for the search. In case of forward search, these arguments are

--- a/man/project.Rd
+++ b/man/project.Rd
@@ -13,7 +13,7 @@ project(
   ndraws = 400,
   nclusters = NULL,
   seed = NA,
-  verbose = getOption("projpred.verbose_project", TRUE),
+  verbose = getOption("projpred.verbose", as.integer(interactive())),
   ...
 )
 }
@@ -68,12 +68,13 @@ drawing new group-level effects when predicting from a multilevel submodel
 \code{projpred.mlvl_pred_new} set to \code{TRUE}. (Such a prediction takes place when
 calculating output elements \code{dis} and \code{ce}.)}
 
-\item{verbose}{A single logical value indicating whether to print out
-additional information during the computations. More precisely, this gets
-passed as \code{verbose_divmin} to the divergence minimizer function of the
-\code{refmodel} object. For the built-in divergence minimizers, this only has an
-effect in case of sequential computations (not in case of parallel
-projection, which is described in \link{projpred-package}).}
+\item{verbose}{A single integer value from the set \eqn{\{0, 1, 2\}}{{0, 1,
+  2}} (if \code{!is.null(predictor_terms)}, \eqn{1} and \eqn{2} have the same
+effect), indicating how much information (if any) to print out during the
+computations. Higher values indicate that more information should be
+printed, \code{0} deactivates the verbose mode. Internally, argument \code{verbose}
+is coerced to integer via \code{as.integer()}, so technically, a single logical
+value or a single numeric value work as well.}
 
 \item{...}{Arguments passed to \code{\link[=get_refmodel]{get_refmodel()}} (if \code{\link[=get_refmodel]{get_refmodel()}} is
 actually used; see argument \code{object}) as well as to the divergence

--- a/man/projpred-package.Rd
+++ b/man/projpred-package.Rd
@@ -82,26 +82,8 @@ object inherits from class \code{gam}).
 }
 
 \section{Verbosity, messages, warnings, errors}{
-Global option \code{projpred.verbose} may be used for specifying the value (\code{TRUE}
-or \code{FALSE}) passed to argument \code{verbose} of \code{\link[=varsel]{varsel()}} and \code{\link[=cv_varsel]{cv_varsel()}}.
-
-Setting global option \code{projpred.extra_verbose} to \code{TRUE} will print out the
-current fold (for \code{\link[=cv_varsel]{cv_varsel()}} with \code{validate_search = TRUE}), the submodel
-that \pkg{projpred} is currently projecting onto, and (if \code{method = "forward"} and \code{verbose = TRUE} in \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}}) which
-submodel has been selected at those steps of the forward search for which a
-percentage (of the maximum submodel size that the search is run up to) is
-printed. In general, however, we cannot recommend setting this global option
-to \code{TRUE} for \code{\link[=cv_varsel]{cv_varsel()}} with \code{validate_search = TRUE} (simply due to the
-amount of information that will be printed, but also due to the progress bar
-which will not work as intended anymore).
-
-Global option \code{projpred.verbose_project} controls argument \code{verbose} of
-\code{\link[=project]{project()}}, but also affects the verbosity of all other projections
-performed by the built-in divergence minimizers (except for L1 projections),
-in particular during a \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}} call. Usually, setting
-\code{projpred.verbose_project} to \code{TRUE} only makes sense when setting global
-option \code{projpred.extra_verbose} and argument \code{verbose} (of \code{\link[=varsel]{varsel()}} or
-\code{\link[=cv_varsel]{cv_varsel()}}) to \code{TRUE} as well.
+Global option \code{projpred.verbose} may be used for specifying the value passed
+to argument \code{verbose} of \code{\link[=project]{project()}}, \code{\link[=varsel]{varsel()}}, and \code{\link[=cv_varsel]{cv_varsel()}}.
 
 By default, \pkg{projpred} catches messages and warnings from the draw-wise
 divergence minimizers and throws their unique collection after performing all

--- a/man/varsel.Rd
+++ b/man/varsel.Rd
@@ -23,7 +23,7 @@ varsel(object, ...)
   nclusters_pred = NULL,
   refit_prj = !inherits(object, "datafit"),
   nterms_max = NULL,
-  verbose = getOption("projpred.verbose", interactive()),
+  verbose = getOption("projpred.verbose", as.integer(interactive())),
   search_control = NULL,
   lambda_min_ratio = 1e-05,
   nlambda = 150,
@@ -91,8 +91,13 @@ supplied). Note that \code{nterms_max} does not count the intercept, so use
 \code{nterms_max = 0} for the intercept-only model. (Correspondingly, \code{D} above
 does not count the intercept.)}
 
-\item{verbose}{A single logical value indicating whether to print out
-additional information during the computations.}
+\item{verbose}{A single integer value from the set \eqn{\{0, 1, 2, 3,
+  4\}}{{0, 1, 2, 3, 4}} (for \code{\link[=varsel]{varsel()}}, \eqn{3} and \eqn{4} have the same
+effect), indicating how much information (if any) to print out during the
+computations. Higher values indicate that more information should be
+printed, \code{0} deactivates the verbose mode. Internally, argument \code{verbose}
+is coerced to integer via \code{as.integer()}, so technically, a single logical
+value or a single numeric value work as well.}
 
 \item{search_control}{A \code{list} of "control" arguments (i.e., tuning
 parameters) for the search. In case of forward search, these arguments are

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -904,8 +904,8 @@ options(projpred.warn_L1_interactions = FALSE)
 # Suppress the warning thrown by proj_predict() in case of observation weights
 # that are not all equal to `1`:
 options(projpred.warn_wobs_ppd = FALSE)
-# Suppress the verbose-mode progress bar in project():
-options(projpred.verbose_project = FALSE)
+# Suppress verbose-mode output:
+options(projpred.verbose = 0L)
 # Suppress instability warnings:
 options(projpred.warn_instable_projections = FALSE)
 # Run additional checks:

--- a/tests/testthat/test_div_minimizer.R
+++ b/tests/testthat/test_div_minimizer.R
@@ -65,10 +65,12 @@ test_that("divmin() works", {
       )
     }
 
+    args_fit_i$verbose_divmin <- FALSE
+
     outdmin <- do.call(
       divmin,
       args_fit_i[intersect(c("formula", "data", "family", "weights",
-                             "projpred_var"),
+                             "projpred_var", "verbose_divmin"),
                            names(args_fit_i))]
     )
     if (fam_crr == "brnll") {
@@ -162,6 +164,8 @@ test_that("divmin_augdat() works", {
       args_fit_i <- c(args_fit_i, list(avoid.increase = TRUE))
     }
 
+    args_fit_i$verbose_divmin <- FALSE
+
     if (fam_crr == "cumul" && mod_crr %in% c("glmm", "gamm") &&
         packageVersion("ordinal") < "2022.11-16") {
       warn_expected <- paste(
@@ -185,7 +189,7 @@ test_that("divmin_augdat() works", {
         divmin_augdat,
         args_fit_i[intersect(c("formula", "data", "family", "weights",
                                "projpred_var", "projpred_ws_aug", "epsilon",
-                               "avoid.increase"),
+                               "avoid.increase", "verbose_divmin"),
                              names(args_fit_i))]
       )
     } else {
@@ -194,7 +198,7 @@ test_that("divmin_augdat() works", {
           divmin_augdat,
           args_fit_i[intersect(c("formula", "data", "family", "weights",
                                  "projpred_var", "projpred_ws_aug", "epsilon",
-                                 "avoid.increase"),
+                                 "avoid.increase", "verbose_divmin"),
                                names(args_fit_i))]
         ),
         warn_expected

--- a/vignettes/latent.Rmd
+++ b/vignettes/latent.Rmd
@@ -183,7 +183,7 @@ time_lat <- system.time(vs_lat <- varsel(
   ###
   nterms_max = 14,
   ### In interactive use, we recommend not to deactivate the verbose mode:
-  verbose = FALSE,
+  verbose = 0,
   ###
   ### For comparability with varsel() based on the traditional projection:
   seed = 95930
@@ -256,7 +256,7 @@ time_trad <- system.time(vs_trad <- varsel(
   ###
   nterms_max = 14,
   ### In interactive use, we recommend not to deactivate the verbose mode:
-  verbose = FALSE,
+  verbose = 0,
   ###
   ### For comparability with varsel() based on the latent projection:
   seed = 95930
@@ -356,7 +356,7 @@ vs_nebin <- varsel(
   ###
   nterms_max = 14,
   ### In interactive use, we recommend not to deactivate the verbose mode:
-  verbose = FALSE
+  verbose = 0
   ###
 )
 ```

--- a/vignettes/projpred.Rmd
+++ b/vignettes/projpred.Rmd
@@ -145,7 +145,7 @@ cvvs_fast <- cv_varsel(
   ###
   nterms_max = 20,
   ### In interactive use, we recommend not to deactivate the verbose mode:
-  verbose = FALSE
+  verbose = 0
   ### 
 )
 ```
@@ -170,7 +170,7 @@ cvvs_fast_refit <- cv_varsel(
   nclusters_pred = 20,
   ###
   ### In interactive use, we recommend not to deactivate the verbose mode:
-  verbose = FALSE
+  verbose = 0
   ### 
 )
 ```
@@ -218,7 +218,7 @@ cvvs <- cv_varsel(
   nterms_max = 9,
   parallel = TRUE,
   ### In interactive use, we recommend not to deactivate the verbose mode:
-  verbose = FALSE
+  verbose = 0
   ### 
 )
 # Tear down the CV parallelization setup:
@@ -337,7 +337,7 @@ prj <- project(
   refm_obj,
   predictor_terms = predictors_final,
   ### In interactive use, we recommend not to deactivate the verbose mode:
-  verbose = FALSE
+  verbose = 0
   ###
 )
 ```


### PR DESCRIPTION
This is a follow-up for PR #518: With #518 now being merged, this PR turns argument `verbose` of `project()`, `varsel()`, and `cv_varsel()` from logical to integer, which is common practice in R packages (see, e.g., argument `silent` of `brms::brm()`). This way, global options `projpred.extra_verbose` and `projpred.verbose_project` are now deprecated (which is desired, as they made it too complicated to achieve the desired verbosity).

File `NEWS.md` is unchanged here. I will update it as soon as #511 (or #508) has been merged. I would propose to add the following entry under "Major changes":
```
* Argument `verbose` of `project()`, `varsel()`, and `cv_varsel()` has been changed from logical to integer. However, logical values continue to work (since `as.integer()` is applied internally). Global options `projpred.extra_verbose` and `projpred.verbose_project` are now deprecated because additional verbosity can be achieved via higher integer values for argument `verbose`. The new global option `projpred.verbose` may be used to set argument `verbose` of `project()`, `varsel()`, and `cv_varsel()` globally. (GitHub: #519)
```
and to change the following entry:
```
* Minor enhancements concerning verbosity (e.g., the number of projected draws---resulting from clustering or thinning---is now printed out during the different steps of the computations). Also introduced global option `projpred.verbose` which may be used to set argument `verbose` of `varsel()` and `cv_varsel()` globally. (GitHub: #506)
```
(which was proposed to be changed to
```
* Several enhancements concerning verbosity (e.g., the number of projected draws---resulting from clustering or thinning---is now printed out during the different steps of the computations and verbose-mode output is redirected to `stderr()` instead of `stdout()`). Also introduced global option `projpred.verbose` which may be used to set argument `verbose` of `varsel()` and `cv_varsel()` globally. (GitHub: #506, #518)
```
in #518) to:
```
* Several enhancements concerning verbosity, e.g., the number of projected draws (resulting from clustering or thinning) is now printed out during the different steps of the computations and verbose-mode output is redirected to `stderr()` instead of `stdout()`. (GitHub: #506, #518)
```
