### PR TITLE
Fix custom reference model objects with latent projection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 * Fixed a bug that caused an error when using the augmented-data or latent projection in combination with a single projected draw for performance evaluation in `cv_varsel()` with `cv_method = "LOO"` and `validate_search = FALSE`. (GitHub: #512)
 * Previously, in case of PSIS-LOO CV with `validate_search = TRUE` and thinned posterior draws for projection (i.e., argument(s) `ndraws` or `ndraws_pred` being used, not `nclusters` or `nclusters_pred`), `print.vselsummary()` incorrectly reported that the posterior draws had been clustered. This has now been fixed, so thinning is reported in such cases. (GitHub: #516)
+* Fixed the internal default `extract_model_data` function when using the latent projection for a custom reference model object. (GitHub: #523)
 
 # projpred 2.8.0
 

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1181,8 +1181,13 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
     # The internal default for `extract_model_data`:
     extract_model_data_usr <- function(object, newdata, wrhs = NULL,
                                        orhs = NULL, extract_y = TRUE) {
+      if (extract_y) {
+        resp_fml <- lhs(formula)
+      } else {
+        resp_fml <- NULL
+      }
       return(y_wobs_offs(newdata = newdata, wrhs = wrhs, orhs = orhs,
-                         resp_form = if (extract_y) lhs(formula) else NULL))
+                         resp_form = resp_fml))
     }
   }
   # Wrap `extract_model_data_usr`:

--- a/R/refmodel.R
+++ b/R/refmodel.R
@@ -1183,6 +1183,11 @@ init_refmodel <- function(object, data, formula, family, ref_predfun = NULL,
                                        orhs = NULL, extract_y = TRUE) {
       if (extract_y) {
         resp_fml <- lhs(formula)
+        if (family$for_latent) {
+          resp_fml <- update(resp_fml,
+                             paste(sub("^\\.", "", as.character(resp_fml[[2]])),
+                                   "~ ."))
+        }
       } else {
         resp_fml <- NULL
       }


### PR DESCRIPTION
This fixes a bug for custom reference model objects for which the latent projection should be used. This came up in https://discourse.mc-stan.org/t/accounting-for-measurement-error-during-variable-selection-with-projpred-possibly-with-rstanarm-or-brms/11789/16.