### PR TITLE
Fix typo in `latent_ppd_oscale` docs

### DIFF
--- a/R/extend_family.R
+++ b/R/extend_family.R
@@ -185,9 +185,9 @@
 #' * `ilpreds_resamp` accepts the return value from `latent_ilink`, but possibly
 #' with resampled (clustered) draws (see argument `nresample_clusters` of
 #' [proj_predict()]).
-#' * `dis_resamp` accepts a vector of length \eqn{\texttt{dim(ilpreds)[1]}}
-#' containing dispersion parameter draws, possibly resampled (in the same way as
-#' the draws in `ilpreds_resamp`, see also argument `idxs_prjdraws`).
+#' * `dis_resamp` accepts a vector of length `dim(ilpreds_resamp)[1]` containing
+#' dispersion parameter draws, possibly resampled (in the same way as the draws
+#' in `ilpreds_resamp`, see also argument `idxs_prjdraws`).
 #' * `wobs` accepts a numeric vector of length \eqn{N} containing observation
 #' weights.
 #' * `cl_ref` accepts the same input as argument `cl_ref` of `latent_ilink`.

--- a/man/extend_family.Rd
+++ b/man/extend_family.Rd
@@ -227,9 +227,9 @@ where:
 \item \code{ilpreds_resamp} accepts the return value from \code{latent_ilink}, but possibly
 with resampled (clustered) draws (see argument \code{nresample_clusters} of
 \code{\link[=proj_predict]{proj_predict()}}).
-\item \code{dis_resamp} accepts a vector of length \eqn{\texttt{dim(ilpreds)[1]}}
-containing dispersion parameter draws, possibly resampled (in the same way as
-the draws in \code{ilpreds_resamp}, see also argument \code{idxs_prjdraws}).
+\item \code{dis_resamp} accepts a vector of length \code{dim(ilpreds_resamp)[1]} containing
+dispersion parameter draws, possibly resampled (in the same way as the draws
+in \code{ilpreds_resamp}, see also argument \code{idxs_prjdraws}).
 \item \code{wobs} accepts a numeric vector of length \eqn{N} containing observation
 weights.
 \item \code{cl_ref} accepts the same input as argument \code{cl_ref} of \code{latent_ilink}.


### PR DESCRIPTION
This fixes a typo in the docs for the `latent_ppd_oscale` function.