### PR TITLE
Fix #531

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 # projpred 2.9.0.9000
 
+## Major changes
+
+* Fixed a major bug in forward search with 3-way or higher-order interactions. See "Bug fixes" below for details.
+
+## Bug fixes
+
+* Fixed a bug that caused forward search not to place lower-order terms of a 3-way or higher-order interaction term before that interaction term. (GitHub: #531, #532)
 
 # projpred 2.9.0
 

--- a/R/project.R
+++ b/R/project.R
@@ -232,7 +232,7 @@ project <- function(
       vars <- object$predictor_ranking
     } else {
       vars <- split_formula(refmodel$formula, data = refmodel$fetch_data(),
-                            add_main_effects = FALSE)
+                            add_lower_terms = FALSE)
       vars <- setdiff(vars, "1")
     }
 


### PR DESCRIPTION
Fixes #531. The problem was in `split_interaction_term()`: Before, only main-effect terms were added. Now all lower-order terms (including main-effect terms) are added.

At first, I thought it would make sense to add only lower-order terms which also occur in the full formula, but then I realized that analogously to the intercept which is always included in the submodels (https://github.com/stan-dev/projpred/issues/96#issuecomment-1018361615), all lower-order terms should be added, even those which do not occur in the full formula. The reason is that even if the true coefficient for some lower-order term in the reference model were zero, this would only hold for the reference model and would not have to hold for a submodel.

As explained in the message of commit c11bac4145ea4700bf54e774463834f6f90ed76d, argument `return_group_terms` is removed here because it was unused (always at its default of `TRUE`) and because it was easier to deal without separate `return_group_terms` cases.

Apart from #531, there might be another issue (an inconsistency in how `split_group_term()` behaves in case of `add_lower_terms = FALSE`), but I'll open a new issue for that.

Again, I requested a review from @avehtari because I could not request it from @aloctavodia. Tell me if I should request it from someone else.