### PR TITLE
Modify tests to unblock reverse dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: projpred
 Encoding: UTF-8
 Title: Projection Predictive Feature Selection
-Version: 2.9.0.9000
+Version: 2.9.1
 Date: 2025-07-09
 Authors@R: c(person("Juho", "Piironen", role = c("aut"),
                     email = "juho.t.piironen@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 If you read this from a place other than <https://mc-stan.org/projpred/news/index.html>, please consider switching to that website since it features better formatting and cross-linking.
 
-# projpred 2.9.0.9000
+# projpred 2.9.1
 
 ## Major changes
 
@@ -12,6 +12,7 @@ If you read this from a place other than <https://mc-stan.org/projpred/news/inde
 
 * Fixed a bug that caused forward search not to place lower-order terms of a 3-way or higher-order interaction term before that interaction term. (GitHub: #531, #532)
 * Fixed a bug that caused `project()` to construct an incorrect internal table of predictor terms (from which argument `predictor_terms` can select one or several terms from) in case of a group-level term that does not contain a group-level intercept. (GitHub: #533, #534)
+* Relaxed test to prevent spurious failures and unblock reverse dependencies. No functional changes.
 
 # projpred 2.9.0
 

--- a/tests/testthat/test_proj_predfun.R
+++ b/tests/testthat/test_proj_predfun.R
@@ -637,7 +637,7 @@ test_that(paste(
                                  function(x) x[i, ])))
     }))
   dmnms <- list(NULL, dimnames(lpreds_man)[[2]])
-  expect_equal(lpreds, structure(lpreds_man, dimnames = dmnms),
+  expect_equal(as.numeric(lpreds), as.numeric(lpreds_man),
                tolerance = 1e-14)
 })
 
@@ -650,14 +650,6 @@ test_that(paste(
   skip_if_not(packageVersion("mclogit") >= "0.9")
 
   ### Fit with mclogit::mblogit() -------------------------------------------
-
-  warn_expected <- if (packageVersion("mclogit") <= "0.8.7.3") {
-    "variable 'prior' is absent, its contrast will be ignored"
-  } else if (packageVersion("mclogit") >= "0.9.6") {
-    "Inner iterations did not coverge"
-  } else {
-    NA
-  }
   expect_warning(
     out_capt <- capture.output(
       mfit <- mclogit::mblogit(
@@ -669,7 +661,6 @@ test_that(paste(
         y = FALSE
       )
     ),
-    warn_expected
   )
   expect_identical(tail(out_capt, 1), "converged")
 
@@ -923,7 +914,7 @@ test_that(paste(
                                  function(x) x[i, ])))
     }))
   dmnms <- list(NULL, dimnames(lpreds_man)[[2]])
-  expect_equal(lpreds, structure(lpreds_man, dimnames = dmnms),
+  expect_equal(as.numeric(lpreds), as.numeric(lpreds_man),
                tolerance = 1e-14)
 })
 


### PR DESCRIPTION
The main goal of the PR (and release) is to unlock the publication of the package `mclogit` that our tests are currently blocking.