### PR TITLE
Docs: Fix links to `summary()` generic

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -1211,15 +1211,15 @@ plot.vsel <- function(
 
 #' Summary of a [varsel()] or [cv_varsel()] run
 #'
-#' This is the [summary()] method for `vsel` objects (returned by [varsel()] or
-#' [cv_varsel()]). Apart from some general information about the [varsel()] or
-#' [cv_varsel()] run, it shows the full-data predictor ranking, basic
-#' information about the (CV) variability in the ranking of the predictors (if
-#' available; inferred from [cv_proportions()]), and estimates for
-#' user-specified predictive performance statistics. For a graphical
-#' representation, see [plot.vsel()]. For extracting the predictive performance
-#' results printed at the bottom of the output created by this [summary()]
-#' method, see [performances()].
+#' This is the [`summary()`][base::summary()] method for `vsel` objects
+#' (returned by [varsel()] or [cv_varsel()]). Apart from some general
+#' information about the [varsel()] or [cv_varsel()] run, it shows the full-data
+#' predictor ranking, basic information about the (CV) variability in the
+#' ranking of the predictors (if available; inferred from [cv_proportions()]),
+#' and estimates for user-specified predictive performance statistics. For a
+#' graphical representation, see [plot.vsel()]. For extracting the predictive
+#' performance results printed at the bottom of the output created by this
+#' [`summary()`][base::summary()] method, see [performances()].
 #'
 #' @param object An object of class `vsel` (returned by [varsel()] or
 #'   [cv_varsel()]).

--- a/man/summary.vsel.Rd
+++ b/man/summary.vsel.Rd
@@ -131,15 +131,15 @@ meant to be accessed directly but instead via helper functions
 (\code{\link[=print.vselsummary]{print.vselsummary()}} and \code{\link[=performances.vselsummary]{performances.vselsummary()}}).
 }
 \description{
-This is the \code{\link[=summary]{summary()}} method for \code{vsel} objects (returned by \code{\link[=varsel]{varsel()}} or
-\code{\link[=cv_varsel]{cv_varsel()}}). Apart from some general information about the \code{\link[=varsel]{varsel()}} or
-\code{\link[=cv_varsel]{cv_varsel()}} run, it shows the full-data predictor ranking, basic
-information about the (CV) variability in the ranking of the predictors (if
-available; inferred from \code{\link[=cv_proportions]{cv_proportions()}}), and estimates for
-user-specified predictive performance statistics. For a graphical
-representation, see \code{\link[=plot.vsel]{plot.vsel()}}. For extracting the predictive performance
-results printed at the bottom of the output created by this \code{\link[=summary]{summary()}}
-method, see \code{\link[=performances]{performances()}}.
+This is the \code{\link[base:summary]{summary()}} method for \code{vsel} objects
+(returned by \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}}). Apart from some general
+information about the \code{\link[=varsel]{varsel()}} or \code{\link[=cv_varsel]{cv_varsel()}} run, it shows the full-data
+predictor ranking, basic information about the (CV) variability in the
+ranking of the predictors (if available; inferred from \code{\link[=cv_proportions]{cv_proportions()}}),
+and estimates for user-specified predictive performance statistics. For a
+graphical representation, see \code{\link[=plot.vsel]{plot.vsel()}}. For extracting the predictive
+performance results printed at the bottom of the output created by this
+\code{\link[base:summary]{summary()}} method, see \code{\link[=performances]{performances()}}.
 }
 \details{
 The \code{stats} options \code{"mse"}, \code{"rmse"}, and \code{"R2"} are only available


### PR DESCRIPTION
`devtools::check()` complained about an ambiguity for the `summary()` link in the documentation (because of `cmdstanr::summary()` and `base::summary()`). This PR fixes this.