### PR TITLE
use relative fontsize for model size numbers

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -1105,9 +1105,15 @@ plot.vsel <- function(
       x_color_txt <- "black"
     }
     pp <- pp +
-      geom_text(aes(y = -Inf, label = .data[["size_chr"]],
-                    size = from_theme(fontsize * 0.7)),
-                vjust = -0.5, color = x_color_txt)
+      if (packageVersion("ggplot2") < "4.0.0") {
+        geom_text(aes(y = -Inf, label = .data[["size_chr"]]), vjust = -0.5,
+                        color = x_color_txt)
+      } else {
+        geom_text(aes(y = -Inf, label = .data[["size_chr"]],
+                      size = from_theme(fontsize * 0.7)),
+                  vjust = -0.5, color = x_color_txt)
+
+      }
   }
   # Miscellaneous stuff (axes, theming, faceting, etc.):
   if (!is.na(ranking_nterms_max) && ranking_colored &&


### PR DESCRIPTION
Fixes #555 

This would add requirement that ggplot2 version needs to be at least 4.*