### PR TITLE
Remove seemingly outdated lme4 note

### DIFF
--- a/R/divergence_minimizers.R
+++ b/R/divergence_minimizers.R
@@ -1459,7 +1459,6 @@ repair_re.merMod <- function(object, newdata) {
          "to have disjoint level sets.")
   }
   re_fml <- ("lme4" %:::% "reOnly")(formula(object))
-  # Note: Calling lme4::mkNewReTrms() with `re.form = NULL` fails.
   ranefs_prep <- lme4::mkNewReTrms(object,
                                    newdata = newdata,
                                    re.form = re_fml,


### PR DESCRIPTION
This removes a note concerning `lme4::mkNewReTrms()`'s argument `re.form` whose behavior seems to have been changed (fixed) in **lme4** v1.1-38 (in that version, `re.form <- re.form %||% reOnly(formula(object))` was added at the beginning of `lme4::mkNewReTrms()`). For now, I am not changing the call to `lme4::mkNewReTrms()` which is directly underneath that note because users might have an older version of **lme4** installed and because adapting this call to the installed **lme4** version would be overkill (the current call continues to work independent of the **lme4** version because we don't rely on `re.form = NULL` but specify `re.form` explicitly).

Btw, `R CMD check` currently says:
```
checking R code for possible problems [...] NOTE
  plot.vsel: no visible global function definition for ‘packageVersion’
  plot.vsel: no visible binding for global variable ‘fontsize’
  Undefined global functions or variables:
    fontsize packageVersion
  Consider adding
    importFrom("utils", "packageVersion")
  to your NAMESPACE file.
```
which is probably due to commit 6e0682d0d3ceb88e2a44702bbefc122515992fdc (PR #556). I guess that needs to be fixed before a new CRAN release.